### PR TITLE
Renamed the kSW_TriggerPrimitive/SW_Trigger_Primitive fragment type

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains configurations for system-level DAQ tests. Currently, t
 
 These tests are meant to be run as part of the release testing procedure to ensure that all of the functionality needed by DUNE-DAQ is present.
 
-Version v1.0.1
+Version v1.0.2
 
 # Test-specific notes
 

--- a/integtest/readout_type_scan.py
+++ b/integtest/readout_type_scan.py
@@ -44,7 +44,7 @@ triggercandidate_frag_params={"fragment_type_description": "Trigger Candidate",
                               "expected_fragment_count": 1,
                               "min_size_bytes": 120, "max_size_bytes": 150}
 triggertp_frag_params={"fragment_type_description": "Trigger with TPs",
-                       "fragment_type": "SW_Trigger_Primitive",
+                       "fragment_type": "Trigger_Primitive",
                        "hdf5_source_subsystem": "Trigger",
                        "expected_fragment_count": number_of_data_producers,
                        "min_size_bytes": 72, "max_size_bytes": 16000}


### PR DESCRIPTION
…to just kTriggerPrimitive/Trigger_Primitive.

These changes are correlated with changes in other repositories, and they need to be tested and merged together. I will add a comment with the full list of repos in a little while.