### PR TITLE
Tweaked the default_system_with_tpg.json configuration a bit to help …

### DIFF
--- a/config/default_system/default_system_with_tpg.json
+++ b/config/default_system/default_system_with_tpg.json
@@ -7,12 +7,20 @@
     "enable_tpg": true,
     "detector_readout_map_file": "default_system_eth_DetReadoutMap.json",
     "use_fake_cards": true,
-    "default_data_file": "asset://?label=WIBEth&subsystem=readout"
+    "default_data_file": "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798",
+    "emulator_mode": true,
+    "tpg_threshold": 500,
+    "tpg_algorithm": "SimpleThreshold"
+
   },
   "dataflow": {
       "enable_tpset_writing" : true
   },
   "daq_common" : {
-    "data_rate_slowdown_factor" : 10 
+    "data_rate_slowdown_factor" : 1
+  },
+  "trigger": {
+    "trigger_activity_config": {"prescale": 25},
+    "mlt_merge_overlapping_tcs": false
   }
 }


### PR DESCRIPTION
…reduce the many error messages in the logfiles.

The changes include:

- switching to the wibeth playback-data file that has all zeroes and enabling the emulator mode that generates occasional pattern ADC data
- setting the slowdown factor to 1, since that is what we feel is appropriate for WIBEth data
- setting the TriggerActivity prescale to 25 so that a reasonable amount of TAs are produced from the TPs
- allowing the MLT to generate triggers with overlapping readout windows
