### PR TITLE
DAQ conf split

### DIFF
--- a/config/emulated_systems/README.md
+++ b/config/emulated_systems/README.md
@@ -13,7 +13,7 @@ The ones that have been demonstrated to work are the following:
 <!--
 Here are sample commands for using them
 * make any necessary edits to `long_window_readout.json`
-* `daqconf_multiru_gen -c ./long_window_readout.json --hardware-map-file ./long_window_readout_DetReadoutMap.json lwr_config`
+* `fddaqconf_gen -c ./long_window_readout.json --hardware-map-file ./long_window_readout_DetReadoutMap.json lwr_config`
 * `wget https://www.dropbox.com/s/9b1xtkjbkfyakij/frames_wib2.bin`  # if needed
 * `nanorc lwr_config ${USER}-test boot conf start_run 101 wait 35 stop_run scrap terminate`
 * `rm -i /tmp/dunedaq/swtest*.hdf5`

--- a/config/hd_coldbox_tests/README.md
+++ b/config/hd_coldbox_tests/README.md
@@ -1,6 +1,6 @@
 # Horizontal Drift Coldbox, Generation Commands
 
-* `daqconf_multiru_gen --hardware-map-file ./hd_coldbox_DetReadoutMap.json -c daq_hd_coldbox.json hd_coldbox_daq`
+* `fddaqconf_gen --hardware-map-file ./hd_coldbox_DetReadoutMap.json -c daq_hd_coldbox.json hd_coldbox_daq`
 * `felixcardcontrollerconf_gen.py -c flx_card_hd_coldbox.json  --hardware-map-file hd_coldbox_DetReadoutMap.json hd_coldbox_cardctrl`
 * `wibconf_gen -c wib_hd_coldbox.json hd_coldbox_wib`
 

--- a/config/long_window_readout/README.md
+++ b/config/long_window_readout/README.md
@@ -11,7 +11,7 @@ Independent of that, the existing parameter values in the `daqconf` file specify
 Here are the steps that I used in my tests:
 
 * make any necessary edits to `long_window_readout.json`
-* `daqconf_multiru_gen -c ./long_window_readout.json --detector-readout-map-file ./long_window_readout_DetReadoutMap.json lwr_config`
+* `fddaqconf_gen -c ./long_window_readout.json --detector-readout-map-file ./long_window_readout_DetReadoutMap.json lwr_config`
 * `nanorc lwr_config ${USER}-test boot conf start_run 101 wait 35 stop_run scrap terminate`
 * `rm -i /tmp/dunedaq/swtest*.hdf5`
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 This repository contains configurations for system-level DAQ tests. Currently, there are two subdirectories:
 * `integtest/`: `pytest`-based integration tests
-* `config/`: JSON configurations for the `daqconf` package's `daqconf_multiru_gen` (and the `timinglibs` package's `daqconf_timing_gen`)
+* `config/`: JSON configurations for the `fddaqconf` package's `fddaqconf_gen` (and the `timinglibs` package's `daqconf_timing_gen`)
 
 These tests are meant to be run as part of the release testing procedure to ensure that all of the functionality needed by DUNE-DAQ is present. An example of this would be the [`dunedaq-v3.2.0` release test spreadsheet](https://docs.google.com/spreadsheets/d/1VCIrNpCJmxFIntKK-6MynWt0kQ-v7wrTS46KjMe0_EY) from October 2022. 
 
@@ -16,6 +16,6 @@ For more on emulated systems tests (`config/emulated_systems`), click [here](con
 
 # Test-specific notes
 
-* The tests in [`config/timing_systems`](https://github.com/DUNE-DAQ/daq-systemtest/tree/develop/config/timing_systems) consist of a `*_daq.json` file which should be run through `daqconf_multiru_gen` and a `*_timing.json` file which should be run through `daqconf_timing_gen`
+* The tests in [`config/timing_systems`](https://github.com/DUNE-DAQ/daq-systemtest/tree/develop/config/timing_systems) consist of a `*_daq.json` file which should be run through `fddaqconf_gen` and a `*_timing.json` file which should be run through `daqconf_timing_gen`
 * [`detector_configurations/wib_hd_coldbox.json`](https://raw.githubusercontent.com/DUNE-DAQ/daq-systemtest/develop/config/detector_configurations/wib_hd_coldbox.json) is a configuration for `wibconf_gen`
 

--- a/integtest/3ru_1df_multirun_test.py
+++ b/integtest/3ru_1df_multirun_test.py
@@ -97,7 +97,7 @@ if cpu_count < minimum_cpu_count or free_mem < minimum_free_memory_gb:
 # to run the config generation and nanorc
 
 # The name of the python module for the config generation
-confgen_name="daqconf_multiru_gen"
+confgen_name="fddaqconf__gen"
 
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)

--- a/integtest/3ru_1df_multirun_test.py
+++ b/integtest/3ru_1df_multirun_test.py
@@ -97,7 +97,7 @@ if cpu_count < minimum_cpu_count or free_mem < minimum_free_memory_gb:
 # to run the config generation and nanorc
 
 # The name of the python module for the config generation
-confgen_name="fddaqconf__gen"
+confgen_name="fddaqconf_gen"
 
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)

--- a/integtest/3ru_3df_multirun_test.py
+++ b/integtest/3ru_3df_multirun_test.py
@@ -70,7 +70,7 @@ ignored_logfile_problems={"dqm": ["client will not be able to connect to Kafka c
 # to run the config generation and nanorc
 
 # The name of the python module for the config generation
-confgen_name="daqconf_multiru_gen"
+confgen_name="fddaqconf_gen"
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)
 dro_map_contents = dro_map_gen.generate_dromap_contents(number_of_data_producers, number_of_readout_apps)

--- a/integtest/fake_data_producer_test.py
+++ b/integtest/fake_data_producer_test.py
@@ -51,7 +51,7 @@ ignored_logfile_problems={}
 # to run the config generation and nanorc
 
 # The name of the python module for the config generation
-confgen_name="daqconf_multiru_gen"
+confgen_name="fddaqconf_gen"
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)
 dro_map_contents = dro_map_gen.generate_dromap_contents(number_of_data_producers)

--- a/integtest/long_window_readout_test.py
+++ b/integtest/long_window_readout_test.py
@@ -87,7 +87,7 @@ if cpu_count < minimum_cpu_count or free_mem < minimum_free_memory_gb:
 # to run the config generation and nanorc
 
 # The name of the python module for the config generation
-confgen_name="daqconf_multiru_gen"
+confgen_name="fddaqconf_gen"
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)
 dro_map_contents = dro_map_gen.generate_dromap_contents(number_of_data_producers, number_of_readout_apps)

--- a/integtest/minimal_system_quick_test.py
+++ b/integtest/minimal_system_quick_test.py
@@ -50,7 +50,7 @@ ignored_logfile_problems={"connectionservice": ["Searching for connections match
 # to run the config generation and nanorc
 
 # The name of the python module for the config generation
-confgen_name="daqconf_multiru_gen"
+confgen_name="fddaqconf_gen"
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)
 

--- a/integtest/readout_type_scan.py
+++ b/integtest/readout_type_scan.py
@@ -83,7 +83,7 @@ ignored_logfile_problems={"dqm": ["client will not be able to connect to Kafka c
 # to run the config generation and nanorc
 
 # The name of the python module for the config generation
-confgen_name="daqconf_multiru_gen"
+confgen_name="fddaqconf_gen"
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)
 dro_map_contents = dro_map_gen.generate_dromap_contents(n_streams=number_of_data_producers, det_id = 3) # default HD_TPC

--- a/integtest/tpstream_writing_test.py
+++ b/integtest/tpstream_writing_test.py
@@ -95,7 +95,7 @@ ignored_logfile_problems={}
 # to run the config generation and nanorc
 
 # The name of the python module for the config generation
-confgen_name="daqconf_multiru_gen"
+confgen_name="fddaqconf_gen"
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)
 dro_map_contents = dro_map_gen.generate_dromap_contents(number_of_data_producers, number_of_readout_apps)

--- a/test/test_default_system.py
+++ b/test/test_default_system.py
@@ -10,14 +10,14 @@ script_path = pathlib.Path(__file__).parent
 cfg_dir = script_path.parent / "config" / "default_system"
 
 commands = [
-    f"daqconf_multiru_gen -n --detector-readout-map-file {cfg_dir}/default_system_eth_DetReadoutMap.json -c {cfg_dir}/default_system_eth.json test",
-    f"daqconf_multiru_gen -n --detector-readout-map-file {cfg_dir}/default_system_eth_DetReadoutMap.json -c {cfg_dir}/default_system_eth.json --force-pm k8s test",
-    f"daqconf_multiru_gen -n --detector-readout-map-file {cfg_dir}/default_system_eth_DetReadoutMap.json -c {cfg_dir}/default_system_fake.json test",
-    f"daqconf_multiru_gen -n --detector-readout-map-file {cfg_dir}/default_system_eth_DetReadoutMap.json -c {cfg_dir}/default_system_fake.json --force-pm k8s test",
-    f"daqconf_multiru_gen -n --detector-readout-map-file {cfg_dir}/default_system_eth_DetReadoutMap.json -c {cfg_dir}/default_system_with_tpg.json test",
-    f"daqconf_multiru_gen -n --detector-readout-map-file {cfg_dir}/default_system_eth_DetReadoutMap.json -c {cfg_dir}/default_system_with_tpg.json --force-pm k8s test",
-    f"daqconf_multiru_gen -n --detector-readout-map-file {cfg_dir}/default_system_flx_DetReadoutMap.json -c {cfg_dir}/default_system_flx.json test",
-    f"daqconf_multiru_gen -n --detector-readout-map-file {cfg_dir}/default_system_flx_DetReadoutMap.json -c {cfg_dir}/default_system_flx.json --force-pm k8s test",
+    f"fddaqconf_gen -n --detector-readout-map-file {cfg_dir}/default_system_eth_DetReadoutMap.json -c {cfg_dir}/default_system_eth.json test",
+    f"fddaqconf_gen -n --detector-readout-map-file {cfg_dir}/default_system_eth_DetReadoutMap.json -c {cfg_dir}/default_system_eth.json --force-pm k8s test",
+    f"fddaqconf_gen -n --detector-readout-map-file {cfg_dir}/default_system_eth_DetReadoutMap.json -c {cfg_dir}/default_system_fake.json test",
+    f"fddaqconf_gen -n --detector-readout-map-file {cfg_dir}/default_system_eth_DetReadoutMap.json -c {cfg_dir}/default_system_fake.json --force-pm k8s test",
+    f"fddaqconf_gen -n --detector-readout-map-file {cfg_dir}/default_system_eth_DetReadoutMap.json -c {cfg_dir}/default_system_with_tpg.json test",
+    f"fddaqconf_gen -n --detector-readout-map-file {cfg_dir}/default_system_eth_DetReadoutMap.json -c {cfg_dir}/default_system_with_tpg.json --force-pm k8s test",
+    f"fddaqconf_gen -n --detector-readout-map-file {cfg_dir}/default_system_flx_DetReadoutMap.json -c {cfg_dir}/default_system_flx.json test",
+    f"fddaqconf_gen -n --detector-readout-map-file {cfg_dir}/default_system_flx_DetReadoutMap.json -c {cfg_dir}/default_system_flx.json --force-pm k8s test",
 ]
 
 failed = {}

--- a/test/test_emulated_systems.py
+++ b/test/test_emulated_systems.py
@@ -13,20 +13,20 @@ commands = [
     # Daphne
     f"flx_ctrl_gen.py -n --detector-readout-map-file {cfg_dir}/emulated_daphne_system_DetReadoutMap.json -c {cfg_dir}/emulated_daphne_system_flx_ctrl.json test",
     f"flx_ctrl_gen -n --detector-readout-map-file {cfg_dir}/emulated_daphne_system_DetReadoutMap.json -c {cfg_dir}/emulated_daphne_system_flx_ctrl.json --force-pm k8s test",
-    f"daqconf_multiru_gen -n --detector-readout-map-file {cfg_dir}/emulated_daphne_system_DetReadoutMap.json -c {cfg_dir}/emulated_daphne_system.json test",
-    f"daqconf_multiru_gen -n --detector-readout-map-file {cfg_dir}/emulated_daphne_system_DetReadoutMap.json -c {cfg_dir}/emulated_daphne_system.json --force-pm k8s test",
+    f"fddaqconf_gen -n --detector-readout-map-file {cfg_dir}/emulated_daphne_system_DetReadoutMap.json -c {cfg_dir}/emulated_daphne_system.json test",
+    f"fddaqconf_gen -n --detector-readout-map-file {cfg_dir}/emulated_daphne_system_DetReadoutMap.json -c {cfg_dir}/emulated_daphne_system.json --force-pm k8s test",
     # Pacman
-    f"daqconf_multiru_gen -n --detector-readout-map-file {cfg_dir}/emulated_pacman_system_DetReadoutMap.json -c {cfg_dir}/emulated_pacman_system.json test",
-    f"daqconf_multiru_gen -n --detector-readout-map-file {cfg_dir}/emulated_pacman_system_DetReadoutMap.json -c {cfg_dir}/emulated_pacman_system.json --force-pm k8s test",
+    f"fddaqconf_gen -n --detector-readout-map-file {cfg_dir}/emulated_pacman_system_DetReadoutMap.json -c {cfg_dir}/emulated_pacman_system.json test",
+    f"fddaqconf_gen -n --detector-readout-map-file {cfg_dir}/emulated_pacman_system_DetReadoutMap.json -c {cfg_dir}/emulated_pacman_system.json --force-pm k8s test",
     # TDE
-    f"daqconf_multiru_gen -n --detector-readout-map-file {cfg_dir}/emulated_tde_system_DetReadoutMap.json -c {cfg_dir}/emulated_tde_system.json test",
-    f"daqconf_multiru_gen -n --detector-readout-map-file {cfg_dir}/emulated_tde_system_DetReadoutMap.json -c {cfg_dir}/emulated_tde_system.json --force-pm k8s test",
+    f"fddaqconf_gen -n --detector-readout-map-file {cfg_dir}/emulated_tde_system_DetReadoutMap.json -c {cfg_dir}/emulated_tde_system.json test",
+    f"fddaqconf_gen -n --detector-readout-map-file {cfg_dir}/emulated_tde_system_DetReadoutMap.json -c {cfg_dir}/emulated_tde_system.json --force-pm k8s test",
     # WIB2
-    f"daqconf_multiru_gen -n --detector-readout-map-file {cfg_dir}/emulated_wib2_system_DetReadoutMap.json -c {cfg_dir}/emulated_wib2_system.json test",
-    f"daqconf_multiru_gen -n --detector-readout-map-file {cfg_dir}/emulated_wib2_system_DetReadoutMap.json -c {cfg_dir}/emulated_wib2_system.json --force-pm k8s test",
+    f"fddaqconf_gen -n --detector-readout-map-file {cfg_dir}/emulated_wib2_system_DetReadoutMap.json -c {cfg_dir}/emulated_wib2_system.json test",
+    f"fddaqconf_gen -n --detector-readout-map-file {cfg_dir}/emulated_wib2_system_DetReadoutMap.json -c {cfg_dir}/emulated_wib2_system.json --force-pm k8s test",
     # WIBEth
-    f"daqconf_multiru_gen -n --detector-readout-map-file {cfg_dir}/emulated_wibeth_system_DetReadoutMap.json -c {cfg_dir}/emulated_wibeth_system.json test",
-    f"daqconf_multiru_gen -n --detector-readout-map-file {cfg_dir}/emulated_wibeth_system_DetReadoutMap.json -c {cfg_dir}/emulated_wibeth_system.json --force-pm k8s test",
+    f"fddaqconf_gen -n --detector-readout-map-file {cfg_dir}/emulated_wibeth_system_DetReadoutMap.json -c {cfg_dir}/emulated_wibeth_system.json test",
+    f"fddaqconf_gen -n --detector-readout-map-file {cfg_dir}/emulated_wibeth_system_DetReadoutMap.json -c {cfg_dir}/emulated_wibeth_system.json --force-pm k8s test",
 ]
 
 failed = {}

--- a/test/test_hardware_tests.py
+++ b/test/test_hardware_tests.py
@@ -11,8 +11,8 @@ cfg_dir = script_path.parent / "config" / "hardware_tests"
 
 commands = [
     # WIB2
-    f"daqconf_multiru_gen -n --detector-readout-map-file {cfg_dir}/wib2_system_DetReadoutMap.json -c {cfg_dir}/wib2_system.json test",
-    f"daqconf_multiru_gen -n --detector-readout-map-file {cfg_dir}/wib2_system_DetReadoutMap.json -c {cfg_dir}/wib2_system.json --force-pm k8s test",
+    f"fddaqconf_gen -n --detector-readout-map-file {cfg_dir}/wib2_system_DetReadoutMap.json -c {cfg_dir}/wib2_system.json test",
+    f"fddaqconf_gen -n --detector-readout-map-file {cfg_dir}/wib2_system_DetReadoutMap.json -c {cfg_dir}/wib2_system.json --force-pm k8s test",
 ]
 
 failed = {}

--- a/test/test_hd_coldbox_tests.py
+++ b/test/test_hd_coldbox_tests.py
@@ -13,7 +13,7 @@ commands = [
     f"fddaqconf_gen -n --detector-readout-map-file {cfg_dir}/hd_coldbox_DetReadoutMap.json -c {cfg_dir}/daq_hd_coldbox.json test",
     f"felixcardcontrollerconf_gen.py -n --detector-readout-map-file {cfg_dir}/hd_coldbox_DetReadoutMap.json -c {cfg_dir}/flx_card_hd_coldbox.json test",
     f"wibconf_gen -c {cfg_dir}/wib_hd_coldbox.json hd_coldbox_wib"
-    f"daqconf_multiru_gen -n --detector-readout-map-file {cfg_dir}/hd_coldbox_DetReadoutMap.json -c {cfg_dir}/daq_hd_coldbox.json --force-pm k8s test",
+    f"fddaqconf_gen -n --detector-readout-map-file {cfg_dir}/hd_coldbox_DetReadoutMap.json -c {cfg_dir}/daq_hd_coldbox.json --force-pm k8s test",
     f"felixcardcontrollerconf_gen.py -n --detector-readout-map-file {cfg_dir}/hd_coldbox_DetReadoutMap.json -c {cfg_dir}/flx_card_hd_coldbox.json --force-pm k8s test",
     f"wibconf_gen -c {cfg_dir}/wib_hd_coldbox.json --force-pm k8s hd_coldbox_wib"
 ]

--- a/test/test_hd_coldbox_tests.py
+++ b/test/test_hd_coldbox_tests.py
@@ -10,7 +10,7 @@ script_path = pathlib.Path(__file__).parent
 cfg_dir = script_path.parent / "config" / "hd_coldbox_tests"
 
 commands = [
-    f"daqconf_multiru_gen -n --detector-readout-map-file {cfg_dir}/hd_coldbox_DetReadoutMap.json -c {cfg_dir}/daq_hd_coldbox.json test",
+    f"fddaqconf_gen -n --detector-readout-map-file {cfg_dir}/hd_coldbox_DetReadoutMap.json -c {cfg_dir}/daq_hd_coldbox.json test",
     f"felixcardcontrollerconf_gen.py -n --detector-readout-map-file {cfg_dir}/hd_coldbox_DetReadoutMap.json -c {cfg_dir}/flx_card_hd_coldbox.json test",
     f"wibconf_gen -c {cfg_dir}/wib_hd_coldbox.json hd_coldbox_wib"
     f"daqconf_multiru_gen -n --detector-readout-map-file {cfg_dir}/hd_coldbox_DetReadoutMap.json -c {cfg_dir}/daq_hd_coldbox.json --force-pm k8s test",

--- a/test/test_k8s_tests.py
+++ b/test/test_k8s_tests.py
@@ -31,8 +31,8 @@ flx_commands = [
 ]
 
 daq_commands = [
-    f"daqconf_multiru_gen {' '.join(common_flags)} --force-pm k8s -c {cfg_dir}/np04_daq_tpg_slim.json -m {cfg_dir}/np04_APA1_DetReadoutMap.json --debug daq_APA1_k8s",
-    f"daqconf_multiru_gen {' '.join(common_flags)} --force-pm ssh -c {cfg_dir}/np04_daq_tpg_slim.json -m {cfg_dir}/np04_APA1_DetReadoutMap.json --debug daq_APA1_ssh",
+    f"fddaqconf_gen {' '.join(common_flags)} --force-pm k8s -c {cfg_dir}/np04_daq_tpg_slim.json -m {cfg_dir}/np04_APA1_DetReadoutMap.json --debug daq_APA1_k8s",
+    f"fddaqconf_gen {' '.join(common_flags)} --force-pm ssh -c {cfg_dir}/np04_daq_tpg_slim.json -m {cfg_dir}/np04_APA1_DetReadoutMap.json --debug daq_APA1_ssh",
 ]
 
 hermes_commands = [

--- a/test/test_long_window_readout.py
+++ b/test/test_long_window_readout.py
@@ -10,8 +10,8 @@ script_path = pathlib.Path(__file__).parent
 cfg_dir = script_path.parent / "config" / "long_window_readout"
 
 commands = [
-    f"daqconf_multiru_gen -n --detector-readout-map-file {cfg_dir}/long_window_readout_DetReadoutMap.json -c {cfg_dir}/long_window_readout.json test",
-    f"daqconf_multiru_gen -n --detector-readout-map-file {cfg_dir}/long_window_readout_DetReadoutMap.json -c {cfg_dir}/long_window_readout.json --force-pm k8s test",
+    f"fddaqconf_gen -n --detector-readout-map-file {cfg_dir}/long_window_readout_DetReadoutMap.json -c {cfg_dir}/long_window_readout.json test",
+    f"fddaqconf_gen -n --detector-readout-map-file {cfg_dir}/long_window_readout_DetReadoutMap.json -c {cfg_dir}/long_window_readout.json --force-pm k8s test",
 ]
 
 failed = {}

--- a/test/test_scale_tests.py
+++ b/test/test_scale_tests.py
@@ -10,10 +10,10 @@ script_path = pathlib.Path(__file__).parent
 cfg_dir = script_path.parent / "config" / "scale_tests"
 
 commands = [
-    f"daqconf_multiru_gen -n --detector-readout-map-file {cfg_dir}/large_scale_system_DetReadoutMap.json -c {cfg_dir}/large_scale_system.json test",
-    f"daqconf_multiru_gen -n --force-pm k8s --detector-readout-map-file {cfg_dir}/large_scale_system_DetReadoutMap.json -c {cfg_dir}/large_scale_system.json test",
-    f"daqconf_multiru_gen -n --detector-readout-map-file {cfg_dir}/medium_scale_system_DetReadoutMap.json -c {cfg_dir}/large_scale_system.json test",
-    f"daqconf_multiru_gen -n --force-pm k8s --detector-readout-map-file {cfg_dir}/medium_scale_system_DetReadoutMap.json -c {cfg_dir}/large_scale_system.json test",
+    f"fddaqconf_gen -n --detector-readout-map-file {cfg_dir}/large_scale_system_DetReadoutMap.json -c {cfg_dir}/large_scale_system.json test",
+    f"fddaqconf_gen -n --force-pm k8s --detector-readout-map-file {cfg_dir}/large_scale_system_DetReadoutMap.json -c {cfg_dir}/large_scale_system.json test",
+    f"fddaqconf_gen -n --detector-readout-map-file {cfg_dir}/medium_scale_system_DetReadoutMap.json -c {cfg_dir}/large_scale_system.json test",
+    f"fddaqconf_gen -n --force-pm k8s --detector-readout-map-file {cfg_dir}/medium_scale_system_DetReadoutMap.json -c {cfg_dir}/large_scale_system.json test",
 ]
 
 failed = {}

--- a/test/test_timing.py
+++ b/test/test_timing.py
@@ -10,16 +10,16 @@ script_path = pathlib.Path(__file__).parent
 cfg_dir = script_path.parent / "config" / "timing_systems"
 
 commands = [
-    f"daqconf_multiru_gen -n --detector-readout-map-file {cfg_dir}/timing_system_local_DetReadoutMap.json -c {cfg_dir}/timing_system_bristol_daq.json test",
-    f"daqconf_multiru_gen -n --detector-readout-map-file {cfg_dir}/timing_system_local_DetReadoutMap.json -c {cfg_dir}/timing_system_bristol_ouroboros_daq.json test",
-    f"daqconf_multiru_gen -n --detector-readout-map-file {cfg_dir}/timing_system_local_DetReadoutMap.json -c {cfg_dir}/timing_system_bristol_daq.json --force-pm k8s test",
-    f"daqconf_multiru_gen -n --detector-readout-map-file {cfg_dir}/timing_system_local_DetReadoutMap.json -c {cfg_dir}/timing_system_bristol_ouroboros_daq.json --force-pm k8s test",
+    f"fddaqconf_gen -n --detector-readout-map-file {cfg_dir}/timing_system_local_DetReadoutMap.json -c {cfg_dir}/timing_system_bristol_daq.json test",
+    f"fddaqconf_gen -n --detector-readout-map-file {cfg_dir}/timing_system_local_DetReadoutMap.json -c {cfg_dir}/timing_system_bristol_ouroboros_daq.json test",
+    f"fddaqconf_gen -n --detector-readout-map-file {cfg_dir}/timing_system_local_DetReadoutMap.json -c {cfg_dir}/timing_system_bristol_daq.json --force-pm k8s test",
+    f"fddaqconf_gen -n --detector-readout-map-file {cfg_dir}/timing_system_local_DetReadoutMap.json -c {cfg_dir}/timing_system_bristol_ouroboros_daq.json --force-pm k8s test",
     f"daqconf_timing_gen  -n -c {cfg_dir}/timing_system_bristol_ouroboros_timing.json test",
-    f"daqconf_multiru_gen -n --detector-readout-map-file {cfg_dir}/timing_system_cern_DetReadoutMap.json  -c {cfg_dir}/timing_system_cern_daq.json test",
-    f"daqconf_multiru_gen -n --detector-readout-map-file {cfg_dir}/timing_system_cern_DetReadoutMap.json  -c {cfg_dir}/timing_system_cern_daq.json --force-pm k8s test",
+    f"fddaqconf_gen -n --detector-readout-map-file {cfg_dir}/timing_system_cern_DetReadoutMap.json  -c {cfg_dir}/timing_system_cern_daq.json test",
+    f"fddaqconf_gen -n --detector-readout-map-file {cfg_dir}/timing_system_cern_DetReadoutMap.json  -c {cfg_dir}/timing_system_cern_daq.json --force-pm k8s test",
     f"daqconf_timing_gen  -n -c {cfg_dir}/timing_system_cern_timing.json test",
-    f"daqconf_multiru_gen -n --detector-readout-map-file {cfg_dir}/timing_system_local_DetReadoutMap.json -c {cfg_dir}/timing_system_iceberg_daq.json test",
-    f"daqconf_multiru_gen -n --detector-readout-map-file {cfg_dir}/timing_system_local_DetReadoutMap.json -c {cfg_dir}/timing_system_iceberg_daq.json --force-pm k8s test",
+    f"fddaqconf_gen -n --detector-readout-map-file {cfg_dir}/timing_system_local_DetReadoutMap.json -c {cfg_dir}/timing_system_iceberg_daq.json test",
+    f"fddaqconf_gen -n --detector-readout-map-file {cfg_dir}/timing_system_local_DetReadoutMap.json -c {cfg_dir}/timing_system_iceberg_daq.json --force-pm k8s test",
     f"daqconf_timing_gen  -n -c {cfg_dir}/timing_system_iceberg_timing.json test",
 ] ## only k8s for daq
 


### PR DESCRIPTION
This pull request addresses the need to have a daqconf for fd and nd separately. This pull request is associated to a number of pull requests: 
- daqconf: https://github.com/DUNE-DAQ/daqconf/pull/386
- nddaqconf: https://github.com/DUNE-DAQ/nddaqconf/pull/3
- fddaqconf: https://github.com/DUNE-DAQ/fddaqconf/pull/1
- lbrulibs: https://github.com/DUNE-DAQ/lbrulibs/pull/62
- daq-systemtest: https://github.com/DUNE-DAQ/daq-systemtest/pull/64
- dfmodules: https://github.com/DUNE-DAQ/dfmodules/pull/313
- ndreadoutmodules: https://github.com/DUNE-DAQ/ndreadoutmodules/pull/5

You can find the associated issue in https://github.com/DUNE-DAQ/daq-deliverables/issues/119
and the deliverable documentation https://github.com/DUNE-DAQ/daq-deliverables/blob/feature/fddaq_v4.2.0_dev/docs/fddaq-v4.2.0/daqconfSplitForNDFD.md