### PR TITLE
Increased the configured number of DFO/TRB trigger-record slots

### DIFF
--- a/integtest/3ru_1df_multirun_test.py
+++ b/integtest/3ru_1df_multirun_test.py
@@ -121,7 +121,7 @@ swtpg_conf["readout"]["tpg_algorithm"] = "SimpleThreshold"
 swtpg_conf["readout"]["default_data_file"] = "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798" # WIBEth All Zeros
 swtpg_conf["trigger"]["trigger_activity_config"] = {"prescale": 25}
 swtpg_conf["trigger"]["mlt_merge_overlapping_tcs"] = False
-swtpg_conf["dataflow"]["token_count"] = max(10, 3*number_of_data_producers*number_of_readout_apps)
+swtpg_conf["dataflow"]["token_count"] = max(10, 6*number_of_data_producers*number_of_readout_apps)
 
 dqm_conf = copy.deepcopy(conf_dict)
 dqm_conf["dqm"]["enable_dqm"] = True

--- a/integtest/3ru_3df_multirun_test.py
+++ b/integtest/3ru_3df_multirun_test.py
@@ -101,7 +101,7 @@ swtpg_conf["readout"]["tpg_algorithm"] = "SimpleThreshold"
 swtpg_conf["readout"]["default_data_file"] = "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798" # WIBEth All Zeros
 swtpg_conf["trigger"]["trigger_activity_config"] = {"prescale": 25}
 swtpg_conf["trigger"]["mlt_merge_overlapping_tcs"] = False
-swtpg_conf["dataflow"]["token_count"] = int(math.ceil(max(10, 3*number_of_data_producers*number_of_readout_apps)/number_of_dataflow_apps))
+swtpg_conf["dataflow"]["token_count"] = int(math.ceil(max(10, 6*number_of_data_producers*number_of_readout_apps)/number_of_dataflow_apps))
 
 dqm_conf = copy.deepcopy(conf_dict)
 dqm_conf["dqm"]["enable_dqm"] = True

--- a/integtest/tpstream_writing_test.py
+++ b/integtest/tpstream_writing_test.py
@@ -117,7 +117,7 @@ conf_dict["readout"]["tpg_algorithm"] = "SimpleThreshold"
 conf_dict["readout"]["default_data_file"] = "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798" # WIBEth All Zeros
 conf_dict["trigger"]["trigger_activity_config"] = {"prescale": 25}
 
-conf_dict["dataflow"]["token_count"] = int(math.ceil(max(10, 3*number_of_data_producers*number_of_readout_apps)/number_of_dataflow_apps))
+conf_dict["dataflow"]["token_count"] = int(math.ceil(max(10, 6*number_of_data_producers*number_of_readout_apps)/number_of_dataflow_apps))
 conf_dict["dataflow"]["apps"] = [] # Remove preconfigured dataflow0 app
 for df_app in range(number_of_dataflow_apps):
     dfapp_conf = {}


### PR DESCRIPTION
…in several integtests to avoid startup issues when occasional slowness in creating DataRequest Senders happens.

With the existing number of tokens, I occasionally see Trigger Inhibits in the 3ru_3df integtest.