### PR TITLE
Extended tpset min latency in integtests and added an option to stop the bundle script on a failure

### DIFF
--- a/integtest/3ru_1df_multirun_test.py
+++ b/integtest/3ru_1df_multirun_test.py
@@ -116,7 +116,7 @@ swtpg_conf["readout"]["enable_tpg"] = True
 swtpg_conf["readout"]["tpg_threshold"] = 500
 swtpg_conf["readout"]["tpg_algorithm"] = "SimpleThreshold"
 swtpg_conf["readout"]["default_data_file"] = "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798" # WIBEth All Zeros
-swtpg_conf["readout"]["tpset_min_latency_ticks"] = 6250000
+swtpg_conf["readout"]["tpset_min_latency_ticks"] = 9375000
 swtpg_conf["trigger"]["trigger_activity_plugin"] = ["TriggerActivityMakerPrescalePlugin"]
 swtpg_conf["trigger"]["trigger_activity_config"] = [ {"prescale": 25} ]
 swtpg_conf["trigger"]["trigger_candidate_plugin"] = ["TriggerCandidateMakerPrescalePlugin"]

--- a/integtest/3ru_1df_multirun_test.py
+++ b/integtest/3ru_1df_multirun_test.py
@@ -116,6 +116,7 @@ swtpg_conf["readout"]["enable_tpg"] = True
 swtpg_conf["readout"]["tpg_threshold"] = 500
 swtpg_conf["readout"]["tpg_algorithm"] = "SimpleThreshold"
 swtpg_conf["readout"]["default_data_file"] = "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798" # WIBEth All Zeros
+swtpg_conf["readout"]["tpset_min_latency_ticks"] = 6250000
 swtpg_conf["trigger"]["trigger_activity_plugin"] = ["TriggerActivityMakerPrescalePlugin"]
 swtpg_conf["trigger"]["trigger_activity_config"] = [ {"prescale": 25} ]
 swtpg_conf["trigger"]["trigger_candidate_plugin"] = ["TriggerCandidateMakerPrescalePlugin"]

--- a/integtest/3ru_3df_multirun_test.py
+++ b/integtest/3ru_3df_multirun_test.py
@@ -99,7 +99,7 @@ swtpg_conf["readout"]["enable_tpg"] = True
 swtpg_conf["readout"]["tpg_threshold"] = 500
 swtpg_conf["readout"]["tpg_algorithm"] = "SimpleThreshold"
 swtpg_conf["readout"]["default_data_file"] = "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798" # WIBEth All Zeros
-swtpg_conf["readout"]["tpset_min_latency_ticks"] = 6250000
+swtpg_conf["readout"]["tpset_min_latency_ticks"] = 9375000
 swtpg_conf["trigger"]["trigger_activity_plugin"] = ["TriggerActivityMakerPrescalePlugin"]
 swtpg_conf["trigger"]["trigger_activity_config"] = [ {"prescale": 25} ]
 swtpg_conf["trigger"]["trigger_candidate_plugin"] = ["TriggerCandidateMakerPrescalePlugin"]

--- a/integtest/3ru_3df_multirun_test.py
+++ b/integtest/3ru_3df_multirun_test.py
@@ -99,6 +99,7 @@ swtpg_conf["readout"]["enable_tpg"] = True
 swtpg_conf["readout"]["tpg_threshold"] = 500
 swtpg_conf["readout"]["tpg_algorithm"] = "SimpleThreshold"
 swtpg_conf["readout"]["default_data_file"] = "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798" # WIBEth All Zeros
+swtpg_conf["readout"]["tpset_min_latency_ticks"] = 6250000
 swtpg_conf["trigger"]["trigger_activity_plugin"] = ["TriggerActivityMakerPrescalePlugin"]
 swtpg_conf["trigger"]["trigger_activity_config"] = [ {"prescale": 25} ]
 swtpg_conf["trigger"]["trigger_candidate_plugin"] = ["TriggerCandidateMakerPrescalePlugin"]

--- a/integtest/readout_type_scan.py
+++ b/integtest/readout_type_scan.py
@@ -101,7 +101,6 @@ swtpg_conf["readout"]["enable_tpg"] = True
 swtpg_conf["readout"]["tpg_threshold"] = 500
 swtpg_conf["readout"]["tpg_algorithm"] = "SimpleThreshold"
 swtpg_conf["readout"]["default_data_file"] = "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798" # WIBEth All Zeros
-swtpg_conf["readout"]["tpset_min_latency_ticks"] = 6250000
 swtpg_conf["trigger"]["trigger_activity_plugin"] = ["TriggerActivityMakerPrescalePlugin"]
 swtpg_conf["trigger"]["trigger_activity_config"] = [ {"prescale": 10} ]
 swtpg_conf["trigger"]["trigger_candidate_plugin"] = ["TriggerCandidateMakerPrescalePlugin"]

--- a/integtest/readout_type_scan.py
+++ b/integtest/readout_type_scan.py
@@ -101,6 +101,7 @@ swtpg_conf["readout"]["enable_tpg"] = True
 swtpg_conf["readout"]["tpg_threshold"] = 500
 swtpg_conf["readout"]["tpg_algorithm"] = "SimpleThreshold"
 swtpg_conf["readout"]["default_data_file"] = "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798" # WIBEth All Zeros
+swtpg_conf["readout"]["tpset_min_latency_ticks"] = 6250000
 swtpg_conf["trigger"]["trigger_activity_plugin"] = ["TriggerActivityMakerPrescalePlugin"]
 swtpg_conf["trigger"]["trigger_activity_config"] = [ {"prescale": 10} ]
 swtpg_conf["trigger"]["trigger_candidate_plugin"] = ["TriggerCandidateMakerPrescalePlugin"]

--- a/integtest/tpstream_writing_test.py
+++ b/integtest/tpstream_writing_test.py
@@ -115,6 +115,7 @@ conf_dict["readout"]["enable_tpg"] = True
 conf_dict["readout"]["tpg_threshold"] = 500
 conf_dict["readout"]["tpg_algorithm"] = "SimpleThreshold"
 conf_dict["readout"]["default_data_file"] = "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798" # WIBEth All Zeros
+conf_dict["readout"]["tpset_min_latency_ticks"] = 6250000
 conf_dict["trigger"]["trigger_activity_plugin"] = ["TriggerActivityMakerPrescalePlugin"]
 conf_dict["trigger"]["trigger_activity_config"] = [ {"prescale": 25} ]
 conf_dict["trigger"]["trigger_candidate_plugin"] = ["TriggerCandidateMakerPrescalePlugin"]

--- a/integtest/tpstream_writing_test.py
+++ b/integtest/tpstream_writing_test.py
@@ -115,7 +115,7 @@ conf_dict["readout"]["enable_tpg"] = True
 conf_dict["readout"]["tpg_threshold"] = 500
 conf_dict["readout"]["tpg_algorithm"] = "SimpleThreshold"
 conf_dict["readout"]["default_data_file"] = "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798" # WIBEth All Zeros
-conf_dict["readout"]["tpset_min_latency_ticks"] = 6250000
+conf_dict["readout"]["tpset_min_latency_ticks"] = 9375000
 conf_dict["trigger"]["trigger_activity_plugin"] = ["TriggerActivityMakerPrescalePlugin"]
 conf_dict["trigger"]["trigger_activity_config"] = [ {"prescale": 25} ]
 conf_dict["trigger"]["trigger_candidate_plugin"] = ["TriggerCandidateMakerPrescalePlugin"]


### PR DESCRIPTION
The changes in this PR specify a longer-than-default value for the tpset_min_latency_ticks configuration parameter in several integtests to try to allow those tests to run without errors.

There is also a change to the script that runs multiple integtests (the "bundle" script) to support an option to stop running individual tests when a failure occurs.
