### PR TITLE
Added warnings to the bundle script to alert users to the presence of a `numad` daemon

### DIFF
--- a/scripts/daqsystemtest_integtest_bundle.sh
+++ b/scripts/daqsystemtest_integtest_bundle.sh
@@ -146,6 +146,6 @@ if [[ "${numad_grep_output}" != "" ]]; then
    echo "*** This daemon can adversely affect the running of these tests, especially ones" | tee -a ${ITGRUNNER_LOG_FILE}
    echo "*** that are resource intensive in the Readout Apps. This is because numad moves" | tee -a ${ITGRUNNER_LOG_FILE}
    echo "*** processes (threads?) to different cores/numa nodes periodically, and that"    | tee -a ${ITGRUNNER_LOG_FILE}
-   echo "*** context switch is bad for the stable running of the DAQ processes."           | tee -a ${ITGRUNNER_LOG_FILE}
+   echo "*** context switch can disrupt the stable running of the DAQ processes."          | tee -a ${ITGRUNNER_LOG_FILE}
    echo "********************************************************************************" | tee -a ${ITGRUNNER_LOG_FILE}
 fi

--- a/scripts/daqsystemtest_integtest_bundle.sh
+++ b/scripts/daqsystemtest_integtest_bundle.sh
@@ -74,6 +74,16 @@ while true; do
     esac
 done
 
+# check if the numad daemon is running
+numad_grep_output=`ps -ef | grep numad | grep -v grep`
+if [[ "${numad_grep_output}" != "" ]]; then
+   echo "*******************************************************"
+   echo "*** DANGER, DANGER, numad is running on this computer!"
+   echo "*** <ctrl-c> now if you want to abort this testing."
+   echo "*******************************************************"
+   sleep 3
+fi
+
 # other setup
 TIMESTAMP=`date '+%Y%m%d%H%M%S'`
 mkdir -p /tmp/pytest-of-${USER}
@@ -126,3 +136,16 @@ date                                                      | tee -a ${ITGRUNNER_L
 echo "Log file is: ${ITGRUNNER_LOG_FILE}"                 | tee -a ${ITGRUNNER_LOG_FILE}
 echo ""                                                   | tee -a ${ITGRUNNER_LOG_FILE}
 grep '=====' ${ITGRUNNER_LOG_FILE} | egrep ' in |Running' | tee -a ${ITGRUNNER_LOG_FILE}
+
+# check again if the numad daemon is running
+numad_grep_output=`ps -ef | grep numad | grep -v grep`
+if [[ "${numad_grep_output}" != "" ]]; then
+   echo ""                                                                                 | tee -a ${ITGRUNNER_LOG_FILE}
+   echo "********************************************************************************" | tee -a ${ITGRUNNER_LOG_FILE}
+   echo "*** WARNING: numad is running on this computer!"                                  | tee -a ${ITGRUNNER_LOG_FILE}
+   echo "*** This daemon can adversely affect the running of these tests, especially ones" | tee -a ${ITGRUNNER_LOG_FILE}
+   echo "*** that are resource intensive in the Readout Apps. This is because numad moves" | tee -a ${ITGRUNNER_LOG_FILE}
+   echo "*** processes (threads?) to different cores/numa nodes periodically, and that"    | tee -a ${ITGRUNNER_LOG_FILE}
+   echo "*** context switch is bad for the stable running of the DAQ processes."           | tee -a ${ITGRUNNER_LOG_FILE}
+   echo "********************************************************************************" | tee -a ${ITGRUNNER_LOG_FILE}
+fi

--- a/scripts/daqsystemtest_integtest_bundle.sh
+++ b/scripts/daqsystemtest_integtest_bundle.sh
@@ -77,10 +77,11 @@ done
 # check if the numad daemon is running
 numad_grep_output=`ps -ef | grep numad | grep -v grep`
 if [[ "${numad_grep_output}" != "" ]]; then
-   echo "*******************************************************"
-   echo "*** DANGER, DANGER, numad is running on this computer!"
+   echo "*********************************************************************"
+   echo "*** DANGER, DANGER, 'numad' appears to be running on this computer!"
+   echo "*** 'ps' output:  ${numad_grep_output}"
    echo "*** <ctrl-c> now if you want to abort this testing."
-   echo "*******************************************************"
+   echo "*********************************************************************"
    sleep 3
 fi
 
@@ -142,7 +143,8 @@ numad_grep_output=`ps -ef | grep numad | grep -v grep`
 if [[ "${numad_grep_output}" != "" ]]; then
    echo ""                                                                                 | tee -a ${ITGRUNNER_LOG_FILE}
    echo "********************************************************************************" | tee -a ${ITGRUNNER_LOG_FILE}
-   echo "*** WARNING: numad is running on this computer!"                                  | tee -a ${ITGRUNNER_LOG_FILE}
+   echo "*** WARNING: 'numad' appears to be running on this computer!"                     | tee -a ${ITGRUNNER_LOG_FILE}
+   echo "*** 'ps' output:  ${numad_grep_output}"                                           | tee -a ${ITGRUNNER_LOG_FILE}
    echo "*** This daemon can adversely affect the running of these tests, especially ones" | tee -a ${ITGRUNNER_LOG_FILE}
    echo "*** that are resource intensive in the Readout Apps. This is because numad moves" | tee -a ${ITGRUNNER_LOG_FILE}
    echo "*** processes (threads?) to different cores/numa nodes periodically, and that"    | tee -a ${ITGRUNNER_LOG_FILE}


### PR DESCRIPTION
`numad` can adversely affect the running of integtests by moving ReadoutApps between cores/numa nodes.  The context switch when this happens can disrupt the smooth flow of data inside a Readout App, and this disruption can cause an integtest to fail.  One type of disruption is for a ReadoutApp to stop processing data for ~1 second and then it is always running behind afterward.