### PR TITLE
Increased the expected number of TimeSlices in tpstream_writing_test.py

### DIFF
--- a/integtest/tpstream_writing_test.py
+++ b/integtest/tpstream_writing_test.py
@@ -192,7 +192,7 @@ def test_data_files(run_nanorc):
 
 def test_tpstream_files(run_nanorc):
     tpstream_files = run_nanorc.tpset_files
-    local_expected_event_count=run_duration # TPStreamWriter is currently configured to write at 1 Hz
+    local_expected_event_count=run_duration+2 # TPStreamWriter is currently configured to write at 1 Hz
     local_event_count_tolerance = local_expected_event_count / 10
     #fragment_check_list=[wib1_tpset_params] # ProtoWIB
     #fragment_check_list=[wib2_tpset_params] # DuneWIB


### PR DESCRIPTION
…now that we flush pending ones at end-run.

One of the fixes in [dfmodules PR 336](https://github.com/DUNE-DAQ/dfmodules/pull/336) is to write out pending TimeSlices at the end of the run.  This slightly increases the expected number of TimeSlices in each run, and this change is simply a reaction to that.

This PR is also correlated with [daqconf PR 440](https://github.com/DUNE-DAQ/daqconf/pull/440).
