### PR TITLE
Updated integtests to use the new TTCM readout window configuration parameters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(daqsystemtest VERSION 2.2.0)
+project(daqsystemtest VERSION 2.3.0)
 
 find_package(daq-cmake REQUIRED)
 

--- a/integtest/3ru_1df_multirun_test.py
+++ b/integtest/3ru_1df_multirun_test.py
@@ -76,7 +76,8 @@ hsi_frag_params ={"fragment_type_description": "HSI",
                              "expected_fragment_count": 1,
                              "min_size_bytes": 72, "max_size_bytes": 100}
 ignored_logfile_problems={"trigger": ["zipped_tpset_q: Unable to push within timeout period"],
-                         }
+                          "rulocalhost": ["Encountered new error, name=\"MISSING_FRAMES\"",
+                                          "Encountered new error, name=\"SEQUENCE_ID_JUMP\""]}
 
 # Determine if this computer is powerful enough for these tests
 sufficient_resources_on_this_computer=True
@@ -108,6 +109,8 @@ conf_dict["readout"]["default_data_file"] = "asset://?checksum=e96fd6efd3f98a9a3
 conf_dict["detector"]["clock_speed_hz"] = 62500000 # DuneWIB/WIBEth
 conf_dict["readout"]["use_fake_cards"] = True
 conf_dict["hsi"]["random_trigger_rate_hz"] = trigger_rate
+conf_dict["trigger"]["ttcm_input_map"] = [{'signal': 1, 'tc_type_name': 'kTiming',
+                                           'time_before': 1000, 'time_after': 1000}]
 
 swtpg_conf = copy.deepcopy(conf_dict)
 swtpg_conf["readout"]["generate_periodic_adc_pattern"] = True

--- a/integtest/3ru_3df_multirun_test.py
+++ b/integtest/3ru_3df_multirun_test.py
@@ -63,7 +63,8 @@ hsi_frag_params ={"fragment_type_description": "HSI",
                              "hdf5_source_subsystem": "HW_Signals_Interface",
                              "expected_fragment_count": 1,
                              "min_size_bytes": 72, "max_size_bytes": 100}
-ignored_logfile_problems={}
+ignored_logfile_problems={"rulocalhost": ["Encountered new error, name=\"MISSING_FRAMES\"",
+                                          "Encountered new error, name=\"SEQUENCE_ID_JUMP\""]}
 
 # The next three variable declarations *must* be present as globals in the test
 # file. They're read by the "fixtures" in conftest.py to determine how
@@ -83,8 +84,8 @@ conf_dict["readout"]["default_data_file"] = "asset://?checksum=e96fd6efd3f98a9a3
 conf_dict["detector"]["clock_speed_hz"] = 62500000 # DuneWIB/WIBEth
 conf_dict["readout"]["use_fake_cards"] = True
 conf_dict["hsi"]["random_trigger_rate_hz"] = trigger_rate
-conf_dict["trigger"]["trigger_window_before_ticks"] = 1000
-conf_dict["trigger"]["trigger_window_after_ticks"] = 1000
+conf_dict["trigger"]["ttcm_input_map"] = [{'signal': 1, 'tc_type_name': 'kTiming',
+                                           'time_before': 1000, 'time_after': 1000}]
 
 conf_dict["dataflow"]["apps"] = [] # Remove preconfigured dataflow0 app
 for df_app in range(number_of_dataflow_apps):

--- a/integtest/fake_data_producer_test.py
+++ b/integtest/fake_data_producer_test.py
@@ -61,12 +61,12 @@ conf_dict["daq_common"]["data_rate_slowdown_factor"] = data_rate_slowdown_factor
 conf_dict["readout"]["use_fake_data_producers"] = True
 #conf_dict["readout"]["clock_speed_hz"] = 50000000 # ProtoWIB
 conf_dict["detector"]["clock_speed_hz"] = 62500000 # DuneWIB/WIBEth
-conf_dict["trigger"]["trigger_window_before_ticks"] = 1000
-conf_dict["trigger"]["trigger_window_after_ticks"] = 1001
+ttcm_conf = [{'signal': 1, 'tc_type_name': 'kTiming', 'time_before': 1000, 'time_after': 1001}]
+conf_dict["trigger"]["ttcm_input_map"] = ttcm_conf
 
 doublewindow_conf = copy.deepcopy(conf_dict)
-doublewindow_conf["trigger"]["trigger_window_before_ticks"] = 2000
-doublewindow_conf["trigger"]["trigger_window_after_ticks"] = 2001
+ttcm_conf2 = [{'signal': 1, 'tc_type_name': 'kTiming', 'time_before': 2000, 'time_after': 2001}]
+doublewindow_conf["trigger"]["ttcm_input_map"] = ttcm_conf2
 
 confgen_arguments={"Baseline_Window_Size": conf_dict,
                    "Double_Window_Size": doublewindow_conf,
@@ -109,7 +109,7 @@ def test_data_files(run_nanorc):
     #frag_params=wib1_frag_hsi_trig_params # ProtoWIB
     #frag_params=wib2_frag_params # DuneWIB
     frag_params=wibeth_frag_params
-    if run_nanorc.confgen_config["trigger"]["trigger_window_before_ticks"] == 2000:
+    if run_nanorc.confgen_config["trigger"]["ttcm_input_map"][0]["time_before"] == 2000:
         #frag_params["min_size_bytes"]=72+(464*161) # 161 frames of 464 bytes each with 72-byte Fragment header # ProtoWIB
         #frag_params["max_size_bytes"]=72+(464*161)
         #frag_params["min_size_bytes"]=72+(472*math.ceil(4001/32)) # 126 frames of 472 bytes each with 72-byte Fragment header # DuneWIB

--- a/integtest/long_window_readout_test.py
+++ b/integtest/long_window_readout_test.py
@@ -101,8 +101,9 @@ conf_dict["detector"]["clock_speed_hz"] = 62500000 # DuneWIB/WIBEth
 conf_dict["readout"]["use_fake_cards"] = True
 conf_dict["readout"]["emulated_data_times_start_with_now"] = True
 conf_dict["hsi"]["random_trigger_rate_hz"] = trigger_rate
-conf_dict["trigger"]["trigger_window_before_ticks"] = readout_window_time_before
-conf_dict["trigger"]["trigger_window_after_ticks"] = readout_window_time_after
+conf_dict["trigger"]["ttcm_input_map"] = [{'signal': 1, 'tc_type_name': 'kTiming',
+                                           'time_before': readout_window_time_before,
+                                           'time_after': readout_window_time_after}]
 
 conf_dict["dataflow"]["token_count"] = token_count
 conf_dict["dataflow"]["apps"] = [] # Remove preconfigured dataflow0 app

--- a/integtest/minimal_system_quick_test.py
+++ b/integtest/minimal_system_quick_test.py
@@ -61,8 +61,9 @@ conf_dict["detector"]["op_env"] = "integtest"
 conf_dict["daq_common"]["data_rate_slowdown_factor"] = data_rate_slowdown_factor
 conf_dict["detector"]["clock_speed_hz"] = 62500000 # DuneWIB/WIBEth
 conf_dict["readout"]["use_fake_cards"] = True
-conf_dict["trigger"]["trigger_window_before_ticks"] = readout_window_time_before
-conf_dict["trigger"]["trigger_window_after_ticks"] = readout_window_time_after
+conf_dict["trigger"]["ttcm_input_map"] = [{'signal': 1, 'tc_type_name': 'kTiming',
+                                           'time_before': readout_window_time_before,
+                                           'time_after': readout_window_time_after}]
 
 conf_dict["readout"]["data_files"] = []
 datafile_conf = {}

--- a/integtest/readout_type_scan.py
+++ b/integtest/readout_type_scan.py
@@ -73,8 +73,9 @@ triggertp_frag_params={"fragment_type_description": "Trigger with TPs",
                        "expected_fragment_count": number_of_data_producers,
                        "min_size_bytes": 72, "max_size_bytes": 16000}
 ignored_logfile_problems={"trigger": ["zipped_tpset_q: Unable to push within timeout period"],
-                          "rulocalhost": ["Configuration Error: Binary file contains more data than expected"],
-                         }
+                          "rulocalhost": ["Configuration Error: Binary file contains more data than expected",
+                                          "Encountered new error, name=\"MISSING_FRAMES\"",
+                                          "Encountered new error, name=\"SEQUENCE_ID_JUMP\""]}
 
 # The next three variable declarations *must* be present as globals in the test
 # file. They're read by the "fixtures" in conftest.py to determine how
@@ -91,8 +92,8 @@ conf_dict["readout"]["dro_map"] = dro_map_contents
 conf_dict["daq_common"]["data_rate_slowdown_factor"] = data_rate_slowdown_factor
 conf_dict["readout"]["default_data_file"] = "asset://?label=ProtoWIB&subsystem=readout"
 conf_dict["readout"]["use_fake_cards"] = True
-conf_dict["trigger"]["trigger_window_before_ticks"] = 1000
-conf_dict["trigger"]["trigger_window_after_ticks"] = 1000
+conf_dict["trigger"]["ttcm_input_map"] = [{'signal': 1, 'tc_type_name': 'kTiming',
+                                           'time_before': 1000, 'time_after': 1000}]
 
 swtpg_conf = copy.deepcopy(conf_dict)
 swtpg_conf["readout"]["generate_periodic_adc_pattern"] = True
@@ -130,14 +131,14 @@ tde_conf["readout"]["default_data_file"] = "asset://?checksum=759e5351436bead208
 pds_stream_conf = copy.deepcopy(conf_dict)
 pds_stream_conf["readout"]["dro_map"] = dro_map_gen.generate_dromap_contents(n_streams=number_of_data_producers, n_apps=1, det_id=2, app_type='flx', flx_mode='fix_rate', flx_protocol='half') # det_id = 2 for HD_PDS
 pds_stream_conf["readout"]["default_data_file"] = "asset://?label=DAPHNEStream&subsystem=readout"
-pds_stream_conf["trigger"]["trigger_window_before_ticks"] = 62000
-pds_stream_conf["trigger"]["trigger_window_after_ticks"] = 500
+pds_stream_conf["trigger"]["ttcm_input_map"] = [{'signal': 1, 'tc_type_name': 'kTiming',
+                                                 'time_before': 62000, 'time_after': 500}]
 
 pds_conf = copy.deepcopy(conf_dict)
 pds_conf["readout"]["dro_map"] = dro_map_gen.generate_dromap_contents(n_streams=number_of_data_producers, n_apps=1, det_id=2, app_type='flx', flx_mode='var_rate', flx_protocol='half') # det_id = 2 for HD_PDS
 pds_conf["readout"]["default_data_file"] = "asset://?label=DAPHNE&subsystem=readout"
-pds_conf["trigger"]["trigger_window_before_ticks"] = 62000
-pds_conf["trigger"]["trigger_window_after_ticks"] = 500
+pds_conf["trigger"]["ttcm_input_map"] = [{'signal': 1, 'tc_type_name': 'kTiming',
+                                          'time_before': 62000, 'time_after': 500}]
 
 #pacman_conf = copy.deepcopy(conf_dict)
 #pacman_conf["readout"]["dro_map"] = dro_map_gen.generate_dromap_contents(number_of_data_producers, 1, 32) # det_id = 32 for NDLAr_TPC

--- a/integtest/small_footprint_quick_test.py
+++ b/integtest/small_footprint_quick_test.py
@@ -62,8 +62,9 @@ conf_dict["daq_common"]["data_rate_slowdown_factor"] = data_rate_slowdown_factor
 conf_dict["detector"]["clock_speed_hz"] = 62500000 # DuneWIB/WIBEth
 conf_dict["readout"]["use_fake_cards"] = True
 conf_dict["readout"]["latency_buffer_size"] = 50000
-conf_dict["trigger"]["trigger_window_before_ticks"] = readout_window_time_before
-conf_dict["trigger"]["trigger_window_after_ticks"] = readout_window_time_after
+conf_dict["trigger"]["ttcm_input_map"] = [{'signal': 1, 'tc_type_name': 'kTiming',
+                                           'time_before': readout_window_time_before,
+                                           'time_after': readout_window_time_after}]
 
 conf_dict["readout"]["data_files"] = []
 datafile_conf = {}

--- a/integtest/tpstream_writing_test.py
+++ b/integtest/tpstream_writing_test.py
@@ -88,7 +88,8 @@ hsi_frag_params ={"fragment_type_description": "HSI",
                              "hdf5_source_subsystem": "HW_Signals_Interface",
                              "expected_fragment_count": 1,
                              "min_size_bytes": 72, "max_size_bytes": 100}
-ignored_logfile_problems={}
+ignored_logfile_problems={"rulocalhost": ["Encountered new error, name=\"MISSING_FRAMES\"",
+                                          "Encountered new error, name=\"SEQUENCE_ID_JUMP\""]}
 
 # The next three variable declarations *must* be present as globals in the test
 # file. They're read by the "fixtures" in conftest.py to determine how
@@ -120,6 +121,8 @@ conf_dict["trigger"]["trigger_activity_plugin"] = ["TriggerActivityMakerPrescale
 conf_dict["trigger"]["trigger_activity_config"] = [ {"prescale": 25} ]
 conf_dict["trigger"]["trigger_candidate_plugin"] = ["TriggerCandidateMakerPrescalePlugin"]
 conf_dict["trigger"]["trigger_candidate_config"] = [ {"prescale": 100} ]
+conf_dict["trigger"]["ttcm_input_map"] = [{'signal': 1, 'tc_type_name': 'kTiming',
+                                           'time_before': 1000, 'time_after': 1000}]
 
 conf_dict["dataflow"]["token_count"] = int(math.ceil(max(10, 6*number_of_data_producers*number_of_readout_apps)/number_of_dataflow_apps))
 conf_dict["dataflow"]["apps"] = [] # Remove preconfigured dataflow0 app


### PR DESCRIPTION
Also, added some ignored warning messages for RUs so that these integtests fairly reliably run successfully (need to circle back and understand why those are appearing more often now).

The TTCM readout window config param changes are simply the result of keeping up with recent changes in the trigger.

