### PR TITLE
 Updated the readout_type_scan integtest to take into account the new DAPHNE frame size

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(daqsystemtest VERSION 2.3.0)
+project(daqsystemtest VERSION 2.3.1)
 
 find_package(daq-cmake REQUIRED)
 

--- a/integtest/readout_type_scan.py
+++ b/integtest/readout_type_scan.py
@@ -61,7 +61,7 @@ pds_frag_params={"fragment_type_description": "PDS",
                  "fragment_type": "DAPHNE",
                  "hdf5_source_subsystem": "Detector_Readout",
                  "expected_fragment_count": number_of_data_producers,
-                 "min_size_bytes": 435912, "max_size_bytes": 1133256}  # 20 x 21792; 52 x 21792 (+72)
+                 "min_size_bytes": 447432, "max_size_bytes": 1163208}  # 20 x 12 x 1864; 52 x 12 x 1864 (+72)
 triggercandidate_frag_params={"fragment_type_description": "Trigger Candidate",
                               "fragment_type": "Trigger_Candidate",
                               "hdf5_source_subsystem": "Trigger",

--- a/integtest/tpstream_writing_test.py
+++ b/integtest/tpstream_writing_test.py
@@ -121,6 +121,7 @@ conf_dict["trigger"]["trigger_activity_plugin"] = ["TriggerActivityMakerPrescale
 conf_dict["trigger"]["trigger_activity_config"] = [ {"prescale": 25} ]
 conf_dict["trigger"]["trigger_candidate_plugin"] = ["TriggerCandidateMakerPrescalePlugin"]
 conf_dict["trigger"]["trigger_candidate_config"] = [ {"prescale": 100} ]
+conf_dict["trigger"]["mlt_merge_overlapping_tcs"] = False
 conf_dict["trigger"]["ttcm_input_map"] = [{'signal': 1, 'tc_type_name': 'kTiming',
                                            'time_before': 1000, 'time_after': 1000}]
 
@@ -132,7 +133,7 @@ for df_app in range(number_of_dataflow_apps):
     dfapp_conf["output_path"] = output_dir
     conf_dict["dataflow"]["apps"].append(dfapp_conf)
 
-confgen_arguments={"Software_TPG_System": conf_dict                  }
+confgen_arguments={"Software_TPG_System": conf_dict}
 
 # The commands to run in nanorc, as a list
 nanorc_command_list="integtest-partition boot conf".split()


### PR DESCRIPTION
plus a minor change in the `tpstream_writer` integtest, and an update to the package version number.

With these changes, I'm seeing all of the integtests in the `daqsystemtest` package completing successfully.