### PR TITLE
TPG Threshold By Plane

### DIFF
--- a/config/default_system/default_system_with_tpg.json
+++ b/config/default_system/default_system_with_tpg.json
@@ -12,7 +12,7 @@
     "use_fake_cards": true,
     "default_data_file": "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798",
     "emulator_mode": true,
-    "tpg_threshold": 500,
+    "tpg_threshold_default": 500,
     "tpg_algorithm": "SimpleThreshold"
   },
   "dataflow": {

--- a/config/k8s_tests/apps/readout_028_029_notpg.json
+++ b/config/k8s_tests/apps/readout_028_029_notpg.json
@@ -2,7 +2,7 @@
     "emulator_mode": false,
     "latency_buffer_size": 499968,
     "enable_tpg": false,
-    "tpg_threshold": 250,
+    "tpg_threshold_default": 250,
     "tpg_algorithm": "SimpleThreshold",
     "tpg_channel_mask": [],
     "enable_raw_recording": false,

--- a/config/k8s_tests/apps/readout_028_029_tpg.json
+++ b/config/k8s_tests/apps/readout_028_029_tpg.json
@@ -2,7 +2,7 @@
     "emulator_mode": false,
     "latency_buffer_size": 499968,
     "enable_tpg": true,
-    "tpg_threshold": 250,
+    "tpg_threshold_default": 250,
     "tpg_algorithm": "SimpleThreshold",
     "tpg_channel_mask": [],
     "enable_raw_recording": false,

--- a/config/k8s_tests/np04_daq.json
+++ b/config/k8s_tests/np04_daq.json
@@ -79,7 +79,7 @@
         "clock_speed_hz": 62500000,
         "latency_buffer_size": 499968,
         "enable_tpg": false,
-        "tpg_threshold": 250,
+        "tpg_threshold_default": 250,
         "tpg_algorithm": "SimpleThreshold",
         "tpg_channel_mask": [],
         "enable_raw_recording": false,

--- a/integtest/3ru_1df_multirun_test.py
+++ b/integtest/3ru_1df_multirun_test.py
@@ -116,7 +116,7 @@ swtpg_conf = copy.deepcopy(conf_dict)
 swtpg_conf["readout"]["generate_periodic_adc_pattern"] = True
 swtpg_conf["readout"]["emulated_TP_rate_per_ch"] = 1
 swtpg_conf["readout"]["enable_tpg"] = True
-swtpg_conf["readout"]["tpg_threshold"] = 500
+swtpg_conf["readout"]["tpg_threshold_default"] = 500
 swtpg_conf["readout"]["tpg_algorithm"] = "SimpleThreshold"
 swtpg_conf["readout"]["default_data_file"] = "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798" # WIBEth All Zeros
 swtpg_conf["readout"]["tpset_min_latency_ticks"] = 9375000

--- a/integtest/3ru_3df_multirun_test.py
+++ b/integtest/3ru_3df_multirun_test.py
@@ -97,7 +97,7 @@ swtpg_conf = copy.deepcopy(conf_dict)
 swtpg_conf["readout"]["generate_periodic_adc_pattern"] = True
 swtpg_conf["readout"]["emulated_TP_rate_per_ch"] = 1
 swtpg_conf["readout"]["enable_tpg"] = True
-swtpg_conf["readout"]["tpg_threshold"] = 500
+swtpg_conf["readout"]["tpg_threshold_default"] = 500
 swtpg_conf["readout"]["tpg_algorithm"] = "SimpleThreshold"
 swtpg_conf["readout"]["default_data_file"] = "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798" # WIBEth All Zeros
 swtpg_conf["readout"]["tpset_min_latency_ticks"] = 9375000

--- a/integtest/readout_type_scan.py
+++ b/integtest/readout_type_scan.py
@@ -99,7 +99,7 @@ swtpg_conf = copy.deepcopy(conf_dict)
 swtpg_conf["readout"]["generate_periodic_adc_pattern"] = True
 swtpg_conf["readout"]["emulated_TP_rate_per_ch"] = 4
 swtpg_conf["readout"]["enable_tpg"] = True
-swtpg_conf["readout"]["tpg_threshold"] = 500
+swtpg_conf["readout"]["tpg_threshold_default"] = 500
 swtpg_conf["readout"]["tpg_algorithm"] = "SimpleThreshold"
 swtpg_conf["readout"]["default_data_file"] = "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798" # WIBEth All Zeros
 swtpg_conf["trigger"]["trigger_activity_plugin"] = ["TriggerActivityMakerPrescalePlugin"]

--- a/integtest/tpstream_writing_test.py
+++ b/integtest/tpstream_writing_test.py
@@ -113,7 +113,7 @@ conf_dict["dataflow"]["tpset_output_path"] = output_dir
 conf_dict["readout"]["generate_periodic_adc_pattern"] = True
 conf_dict["readout"]["emulated_TP_rate_per_ch"] = 1
 conf_dict["readout"]["enable_tpg"] = True
-conf_dict["readout"]["tpg_threshold"] = 500
+conf_dict["readout"]["tpg_threshold_default"] = 500
 conf_dict["readout"]["tpg_algorithm"] = "SimpleThreshold"
 conf_dict["readout"]["default_data_file"] = "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798" # WIBEth All Zeros
 conf_dict["readout"]["tpset_min_latency_ticks"] = 9375000


### PR DESCRIPTION
Propagating configuration changes made from https://github.com/DUNE-DAQ/fdreadoutlibs/pull/177. I ran `pytest` on all the relevant integration tests. All completed without error.

I am unfamiliar with what the `config/*` changes are controlling, so I could not test those.

Repos needed to build and recreate tests (assumes in a `sourcecode`):
```bash
git clone git@github.com:DUNE-DAQ/appfwk.git
git clone git@github.com:DUNE-DAQ/daqconf.git -b aeo/tpg-threshold-by-plane
git clone git@github.com:DUNE-DAQ/daqsystemtest.git -b aeo/tpg-threshold-by-plane
git clone git@github.com:DUNE-DAQ/daqconf.git -b aeo/tpg-threshold-by-plane
git clone git@github.com:DUNE-DAQ/dfmodules.git -b aeo/tpg-threshold-by-plane
git clone git@github.com:DUNE-DAQ/fddaqconf.git -b aeo/tpg-threshold-by-plane
git clone git@github.com:DUNE-DAQ/fdreadoutlibs.git -b aeo/threshold_by_plane
git clone git@github.com:DUNE-DAQ/fdreadoutmodules.git
git clone git@github.com:DUNE-DAQ/readoutlibs.git -b aeo/tpg-threshold-by-plane
git clone git@github.com:DUNE-DAQ/readoutmodules.git
git clone git@github.com:DUNE-DAQ/tpgtools.git -b aeo/threshold-by-plane
```