### PR TITLE
Minor changes to tpstream_writing_test to get it working again after …

### DIFF
--- a/integtest/tpstream_writing_test.py
+++ b/integtest/tpstream_writing_test.py
@@ -66,7 +66,7 @@ wibeth_frag_multi_trig_params={"fragment_type_description": "WIBEth",
 wibeth_tpset_params={"fragment_type_description": "TP Stream", 
                    "fragment_type": "Trigger_Primitive",
                    "hdf5_source_subsystem": "Trigger",
-                   "expected_fragment_count": number_of_readout_apps,
+                   "expected_fragment_count": (3*number_of_readout_apps),
                    "min_size_bytes": 72, "max_size_bytes": 3291080}
 triggercandidate_frag_params={"fragment_type_description": "Trigger Candidate", 
                               "fragment_type": "Trigger_Candidate",
@@ -76,12 +76,12 @@ triggercandidate_frag_params={"fragment_type_description": "Trigger Candidate",
 triggeractivity_frag_params={"fragment_type_description": "Trigger Activity",
                               "fragment_type": "Trigger_Activity",
                               "hdf5_source_subsystem": "Trigger",
-                              "expected_fragment_count": number_of_readout_apps,
+                              "expected_fragment_count": (3*number_of_readout_apps),
                               "min_size_bytes": 72, "max_size_bytes": 216}
 triggertp_frag_params={"fragment_type_description": "Trigger with TPs",
                        "fragment_type": "Trigger_Primitive",
                        "hdf5_source_subsystem": "Trigger",
-                       "expected_fragment_count": (number_of_data_producers*number_of_readout_apps),
+                       "expected_fragment_count": (3*number_of_readout_apps),
                        "min_size_bytes": 72, "max_size_bytes": 16000}
 hsi_frag_params ={"fragment_type_description": "HSI",
                              "fragment_type": "Hardware_Signal",
@@ -137,8 +137,8 @@ confgen_arguments={"Software_TPG_System": conf_dict}
 
 # The commands to run in nanorc, as a list
 nanorc_command_list="integtest-partition boot conf".split()
-nanorc_command_list+="start_run --wait 2 101 wait ".split() + [str(run_duration)] + "stop_run          wait 2".split()
-nanorc_command_list+="start_run          102 wait ".split() + [str(run_duration)] + "stop_run --wait 2 wait 2".split()
+nanorc_command_list+="start_run --wait 4 101 wait ".split() + [str(run_duration)] + "stop_run          wait 2".split()
+nanorc_command_list+="start_run --wait 2 102 wait ".split() + [str(run_duration)] + "stop_run --wait 2 wait 2".split()
 nanorc_command_list+="scrap terminate".split()
 
 # The tests themselves

--- a/integtest/tpstream_writing_test.py
+++ b/integtest/tpstream_writing_test.py
@@ -12,6 +12,7 @@ import integrationtest.dro_map_gen as dro_map_gen
 # Values that help determine the running conditions
 number_of_data_producers=2
 number_of_readout_apps=2
+number_pf_tpc_wire_planes_per_readout_app=3
 number_of_dataflow_apps=2
 pulser_trigger_rate=1.0 # Hz
 run_duration=30  # seconds
@@ -66,7 +67,7 @@ wibeth_frag_multi_trig_params={"fragment_type_description": "WIBEth",
 wibeth_tpset_params={"fragment_type_description": "TP Stream", 
                    "fragment_type": "Trigger_Primitive",
                    "hdf5_source_subsystem": "Trigger",
-                   "expected_fragment_count": (3*number_of_readout_apps),
+                   "expected_fragment_count": (number_pf_tpc_wire_planes_per_readout_app*number_of_readout_apps),
                    "min_size_bytes": 72, "max_size_bytes": 3291080}
 triggercandidate_frag_params={"fragment_type_description": "Trigger Candidate", 
                               "fragment_type": "Trigger_Candidate",
@@ -76,12 +77,12 @@ triggercandidate_frag_params={"fragment_type_description": "Trigger Candidate",
 triggeractivity_frag_params={"fragment_type_description": "Trigger Activity",
                               "fragment_type": "Trigger_Activity",
                               "hdf5_source_subsystem": "Trigger",
-                              "expected_fragment_count": (3*number_of_readout_apps),
+                              "expected_fragment_count": (number_pf_tpc_wire_planes_per_readout_app*number_of_readout_apps),
                               "min_size_bytes": 72, "max_size_bytes": 216}
 triggertp_frag_params={"fragment_type_description": "Trigger with TPs",
                        "fragment_type": "Trigger_Primitive",
                        "hdf5_source_subsystem": "Trigger",
-                       "expected_fragment_count": (3*number_of_readout_apps),
+                       "expected_fragment_count": (number_pf_tpc_wire_planes_per_readout_app*number_of_readout_apps),
                        "min_size_bytes": 72, "max_size_bytes": 16000}
 hsi_frag_params ={"fragment_type_description": "HSI",
                              "fragment_type": "Hardware_Signal",

--- a/integtest/tpstream_writing_test.py
+++ b/integtest/tpstream_writing_test.py
@@ -12,7 +12,7 @@ import integrationtest.dro_map_gen as dro_map_gen
 # Values that help determine the running conditions
 number_of_data_producers=2
 number_of_readout_apps=2
-number_pf_tpc_wire_planes_per_readout_app=3
+number_of_tpc_wire_planes_per_readout_app=3
 number_of_dataflow_apps=2
 pulser_trigger_rate=1.0 # Hz
 run_duration=30  # seconds
@@ -67,7 +67,7 @@ wibeth_frag_multi_trig_params={"fragment_type_description": "WIBEth",
 wibeth_tpset_params={"fragment_type_description": "TP Stream", 
                    "fragment_type": "Trigger_Primitive",
                    "hdf5_source_subsystem": "Trigger",
-                   "expected_fragment_count": (number_pf_tpc_wire_planes_per_readout_app*number_of_readout_apps),
+                   "expected_fragment_count": (number_of_tpc_wire_planes_per_readout_app*number_of_readout_apps),
                    "min_size_bytes": 72, "max_size_bytes": 3291080}
 triggercandidate_frag_params={"fragment_type_description": "Trigger Candidate", 
                               "fragment_type": "Trigger_Candidate",
@@ -77,12 +77,12 @@ triggercandidate_frag_params={"fragment_type_description": "Trigger Candidate",
 triggeractivity_frag_params={"fragment_type_description": "Trigger Activity",
                               "fragment_type": "Trigger_Activity",
                               "hdf5_source_subsystem": "Trigger",
-                              "expected_fragment_count": (number_pf_tpc_wire_planes_per_readout_app*number_of_readout_apps),
+                              "expected_fragment_count": (number_of_tpc_wire_planes_per_readout_app*number_of_readout_apps),
                               "min_size_bytes": 72, "max_size_bytes": 216}
 triggertp_frag_params={"fragment_type_description": "Trigger with TPs",
                        "fragment_type": "Trigger_Primitive",
                        "hdf5_source_subsystem": "Trigger",
-                       "expected_fragment_count": (number_pf_tpc_wire_planes_per_readout_app*number_of_readout_apps),
+                       "expected_fragment_count": (number_of_tpc_wire_planes_per_readout_app*number_of_readout_apps),
                        "min_size_bytes": 72, "max_size_bytes": 16000}
 hsi_frag_params ={"fragment_type_description": "HSI",
                              "fragment_type": "Hardware_Signal",


### PR DESCRIPTION
…the switch to TP handling per detector plane and the dropping of TP buffers from the Trigger App

To test this, one can run
```
daqsystemtest_integtest_bundle.sh -s 2 -f 6
```

both before and after including these changes in a software area.  There will be errors printed out before including these changes and hopefully none printed out after these changes.

Here are instructions for setting up a software area and run the tests both without and with the changes:
```
DATE_PREFIX=`date '+%d%b'`
TIME_SUFFIX=`date '+%H%M'`

source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
setup_dbt fddaq-v4.4.2
dbt-create fddaq-v4.4.2-a9 ${DATE_PREFIX}FDv4.4.3Testing${TIME_SUFFIX}
cd ${DATE_PREFIX}FDv4.4.3Testing${TIME_SUFFIX}/sourcecode

git clone https://github.com/DUNE-DAQ/daqsystemtest.git -b patch/fddaq-v4.4.x
cd ..

dbt-workarea-env
dbt-build -j 20
dbt-workarea-env

daqsystemtest_integtest_bundle.sh -s 2 -f 6

cd sourcecode/daqsystemtest
git checkout kbiery/tpstream_integtest_fix
cd ../..

dbt-build -j 20
dbt-workarea-env

daqsystemtest_integtest_bundle.sh -s 2 -f 6

```