### PR TITLE
Fixes for integtests on the v4 development line

### DIFF
--- a/integtest/3ru_1df_multirun_test.py
+++ b/integtest/3ru_1df_multirun_test.py
@@ -136,9 +136,9 @@ confgen_arguments={"WIBEth_System": conf_dict,
 # The commands to run in nanorc, as a list
 if sufficient_resources_on_this_computer:
     nanorc_command_list="integtest-partition boot conf".split()
-    nanorc_command_list+="start_run --wait 1 101 wait ".split() + [str(run_duration)] + "stop_run          wait 2".split()
-    nanorc_command_list+="start_run --wait 2 102 wait ".split() + [str(run_duration)] + "stop_run --wait 1 wait 2".split()
-    nanorc_command_list+="start_run          103 wait ".split() + [str(run_duration)] + "stop_run --wait 2 wait 2".split()
+    nanorc_command_list+="start_run --wait 2 101 wait ".split() + [str(run_duration)] + "stop_run          wait 2".split()
+    nanorc_command_list+="start_run --wait 5 102 wait ".split() + [str(run_duration)] + "stop_run --wait 1 wait 2".split()
+    nanorc_command_list+="start_run --wait 2 103 wait ".split() + [str(run_duration)] + "stop_run --wait 2 wait 2".split()
     nanorc_command_list+="scrap terminate".split()
 else:
     nanorc_command_list=["integtest-partition", "boot", "terminate"]

--- a/integtest/3ru_3df_multirun_test.py
+++ b/integtest/3ru_3df_multirun_test.py
@@ -116,9 +116,9 @@ confgen_arguments={"WIBEth_System": conf_dict,
                   }
 # The commands to run in nanorc, as a list
 nanorc_command_list="integtest-partition boot conf".split()
-nanorc_command_list+="start 101 enable_triggers wait ".split() + [str(run_duration)] + "stop_run wait 2".split()
-nanorc_command_list+="start 102 wait 1 enable_triggers wait ".split() + [str(run_duration)] + "disable_triggers wait 1 stop_run".split()
-nanorc_command_list+="start_run 103 wait ".split() + [str(run_duration)] + "disable_triggers wait 1 drain_dataflow wait 1 stop_trigger_sources wait 1 stop wait 2".split()
+nanorc_command_list+="start 101 wait 2 enable_triggers wait ".split() + [str(run_duration)] + "stop_run wait 2".split()
+nanorc_command_list+="start 102 wait 5 enable_triggers wait ".split() + [str(run_duration)] + "disable_triggers wait 1 stop_run".split()
+nanorc_command_list+="start_run --wait 2 103 wait ".split() + [str(run_duration)] + "disable_triggers wait 1 drain_dataflow wait 1 stop_trigger_sources wait 1 stop wait 2".split()
 nanorc_command_list+="shutdown".split()
 
 # The tests themselves

--- a/integtest/readout_type_scan.py
+++ b/integtest/readout_type_scan.py
@@ -57,12 +57,12 @@ pds_stream_frag_params={"fragment_type_description": "PDSStream",
                         "fragment_type": "DAPHNEStream",
                         "hdf5_source_subsystem": "Detector_Readout",
                         "expected_fragment_count": number_of_data_producers,
-                        "min_size_bytes": 1936, "max_size_bytes": 93272}
+                        "min_size_bytes": 461216, "max_size_bytes": 461688}
 pds_frag_params={"fragment_type_description": "PDS",
                  "fragment_type": "DAPHNE",
                  "hdf5_source_subsystem": "Detector_Readout",
                  "expected_fragment_count": number_of_data_producers,
-                 "min_size_bytes": 134280, "max_size_bytes": 268488}  # 6 x 12 x 1864; 12 x 12 x 1864 (+72)
+                 "min_size_bytes": 72, "max_size_bytes": 16000}
 triggercandidate_frag_params={"fragment_type_description": "Trigger Candidate",
                               "fragment_type": "Trigger_Candidate",
                               "hdf5_source_subsystem": "Trigger",

--- a/integtest/readout_type_scan.py
+++ b/integtest/readout_type_scan.py
@@ -57,12 +57,12 @@ pds_stream_frag_params={"fragment_type_description": "PDSStream",
                         "fragment_type": "DAPHNEStream",
                         "hdf5_source_subsystem": "Detector_Readout",
                         "expected_fragment_count": number_of_data_producers,
-                        "min_size_bytes": 108632, "max_size_bytes": 297432}  # 230 x 472; 630 * 472 (+72)
+                        "min_size_bytes": 1936, "max_size_bytes": 93272}
 pds_frag_params={"fragment_type_description": "PDS",
                  "fragment_type": "DAPHNE",
                  "hdf5_source_subsystem": "Detector_Readout",
                  "expected_fragment_count": number_of_data_producers,
-                 "min_size_bytes": 447432, "max_size_bytes": 1163208}  # 20 x 12 x 1864; 52 x 12 x 1864 (+72)
+                 "min_size_bytes": 134280, "max_size_bytes": 268488}  # 6 x 12 x 1864; 12 x 12 x 1864 (+72)
 triggercandidate_frag_params={"fragment_type_description": "Trigger Candidate",
                               "fragment_type": "Trigger_Candidate",
                               "hdf5_source_subsystem": "Trigger",


### PR DESCRIPTION
Two categories of changes:

- updates to the expected PDS fragment sizes in the readout_type_scan.  This may need to change again after we discuss what the correct time-tick value should be used in emulated-data tests.  (The changes in the DAPHNE emulated data were triggered when the number of frames per superchunk was changed from 12 to 1.)
- the addition of a small wait time at the start of a run before enabling triggers when TPG is enabled.  This is to allow TPs to appear in all of the relevant latency buffers now that we have 3 times as many TP DataLinkHandlers (now one per plane).