### PR TITLE
Increased the allowed size of DAPHNE fragments in readout_type_scan y…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(daqsystemtest VERSION 2.3.6)
+project(daqsystemtest VERSION 2.3.7)
 
 find_package(daq-cmake REQUIRED)
 

--- a/integtest/readout_type_scan.py
+++ b/integtest/readout_type_scan.py
@@ -62,7 +62,7 @@ pds_frag_params={"fragment_type_description": "PDS",
                  "fragment_type": "DAPHNE",
                  "hdf5_source_subsystem": "Detector_Readout",
                  "expected_fragment_count": number_of_data_producers,
-                 "min_size_bytes": 72, "max_size_bytes": 18000}
+                 "min_size_bytes": 72, "max_size_bytes": 30000}
 triggercandidate_frag_params={"fragment_type_description": "Trigger Candidate",
                               "fragment_type": "Trigger_Candidate",
                               "hdf5_source_subsystem": "Trigger",


### PR DESCRIPTION
…et again, allowing for 5 self-triggered data packets instead of 3, to support fluctuations in what is produced in the emulated-data test.