### PR TITLE
Removed the session number from the daqsystemtest_integtest_bundle.sh script…

### DIFF
--- a/scripts/daqsystemtest_integtest_bundle.sh
+++ b/scripts/daqsystemtest_integtest_bundle.sh
@@ -11,7 +11,6 @@ Usage:
 
 Options:
     -h, --help : prints out usage information
-    -s <DAQ session number (formerly known as partition number), default=1)>
     -f <zero-based index of the first test to be run, default=0>
     -l <zero-based index of the last test to be run, default=999>
     -n <number of times to run each individual test, default=1>
@@ -30,7 +29,6 @@ Options:
 TEMP=`getopt -o hs:f:l:n:N: --long help,stop-on-failure -- "$@"`
 eval set -- "$TEMP"
 
-let session_number=1
 let first_test_index=0
 let last_test_index=999
 let individual_run_count=1
@@ -42,10 +40,6 @@ while true; do
         -h|--help)
             usage
             exit 0
-            ;;
-        -s)
-            let session_number=$2
-            shift 2
             ;;
         -f)
             let first_test_index=$2
@@ -102,11 +96,11 @@ while [[ ${overall_loop_count} -lt ${overall_run_count} ]]; do
       while [[ ${individual_loop_count} -lt ${individual_run_count} ]]; do
         echo "===== Running ${TEST_NAME}" >> ${ITGRUNNER_LOG_FILE}
         if [[ -e "./${TEST_NAME}" ]]; then
-          pytest -s ./${TEST_NAME} --nanorc-option partition-number ${session_number} | tee -a ${ITGRUNNER_LOG_FILE}
+          pytest -s ./${TEST_NAME} | tee -a ${ITGRUNNER_LOG_FILE}
         elif [[ -e "${DBT_AREA_ROOT}/sourcecode/daqsystemtest/integtest/${TEST_NAME}" ]]; then
-          pytest -s ${DBT_AREA_ROOT}/sourcecode/daqsystemtest/integtest/${TEST_NAME} --nanorc-option partition-number ${session_number} | tee -a ${ITGRUNNER_LOG_FILE}
+          pytest -s ${DBT_AREA_ROOT}/sourcecode/daqsystemtest/integtest/${TEST_NAME} | tee -a ${ITGRUNNER_LOG_FILE}
         else
-          pytest -s ${DAQSYSTEMTEST_SHARE}/integtest/${TEST_NAME} --nanorc-option partition-number ${session_number} | tee -a ${ITGRUNNER_LOG_FILE}
+          pytest -s ${DAQSYSTEMTEST_SHARE}/integtest/${TEST_NAME} | tee -a ${ITGRUNNER_LOG_FILE}
         fi
         let pytest_return_code=${PIPESTATUS[0]}
 


### PR DESCRIPTION
… now that we are using drunc for integtests, and we get errors when we try to pass --nanorc-options to integtests.