### PR TITLE
Changed the number of handler_threads from 0 to 1 in the hsi-requesth…

### DIFF
--- a/config/daqsystemtest/integrationtest-objects.data.xml
+++ b/config/daqsystemtest/integrationtest-objects.data.xml
@@ -128,7 +128,7 @@
 </obj>
 
 <obj class="RequestHandler" id="hsi-requesthandler-generic">
- <attr name="handler_threads" type="u16" val="0"/>
+ <attr name="handler_threads" type="u16" val="1"/>
  <attr name="request_timeout" type="u32" val="0"/>
  <attr name="pop_limit_pct" type="float" val="0.8"/>
  <attr name="pop_size_pct" type="float" val="0.1"/>


### PR DESCRIPTION
…andler-generic declaration in integrationtest-objects.data.xml.  This is to get the small_footprint_quick_test (and any other integtests that use the FakeHSI) to work.  And, it seems reasonable to have at least one data handler thread as a default.