### PR TITLE
Increased the expected number of TimeSlices in the tpstream_writing_test…

### DIFF
--- a/integtest/tpstream_writing_test.py
+++ b/integtest/tpstream_writing_test.py
@@ -233,7 +233,7 @@ def test_data_files(run_nanorc):
 def test_tpstream_files(run_nanorc):
     tpstream_files = run_nanorc.tpset_files
     local_expected_event_count = (
-        run_duration + 6
+        run_duration + 8
     )  # TPStreamWriterModule is currently configured to write at 1 Hz, addl TimeSlices expected because of wait times in drunc command list
     local_event_count_tolerance = local_expected_event_count / 10
     # fragment_check_list=[wib1_tpset_params] # ProtoWIB


### PR DESCRIPTION
…to account for the better handling of edge TimeSlices that has been ported from v4 to v5.

These changes are dependent on ones in [dfmodules](https://github.com/DUNE-DAQ/dfmodules/pull/386) and [appmodel](https://github.com/DUNE-DAQ/daqsystemtest/pull/131).
