### PR TITLE
Since drunc PR #266 has been merged, we can remove a number of log-file

### DIFF
--- a/integtest/3ru_1df_multirun_test.py
+++ b/integtest/3ru_1df_multirun_test.py
@@ -78,10 +78,6 @@ hsi_frag_params = {
 }
 ignored_logfile_problems = {
     "-controller": [
-        "Propagating take_control to children",
-        "Propagating describe to children",
-        "There is no broadcasting service",
-        "Could not understand the BroadcastHandler technology you want to use",
         "Worker with pid \\d+ was terminated due to signal 1",
         "Connection '.*' not found on the application registry",
     ],

--- a/integtest/3ru_3df_multirun_test.py
+++ b/integtest/3ru_3df_multirun_test.py
@@ -76,10 +76,6 @@ hsi_frag_params = {
 }
 ignored_logfile_problems = {
     "-controller": [
-        "Propagating take_control to children",
-        "Propagating describe to children",
-        "There is no broadcasting service",
-        "Could not understand the BroadcastHandler technology you want to use",
         "Worker with pid \\d+ was terminated due to signal 1",
         "Connection '.*' not found on the application registry",
     ],

--- a/integtest/example_system_test.py
+++ b/integtest/example_system_test.py
@@ -51,11 +51,7 @@ hsi_frag_params = {
 }
 ignored_logfile_problems = {
     "-controller": [
-        'ERROR.*Broadcast:.*Propagating take_control to children',
-        'ERROR.*Broadcast:.*Propagating describe to children',
-        'WARNING.*Broadcast:.*There is no broadcasting service!',
         "Worker with pid \\d+ was terminated due to signal",
-        "Could not understand the BroadcastHandler technology you want to use",
         "Connection '.*' not found on the application registry",
     ],
     "local-connection-server": [

--- a/integtest/long_window_readout_test.py
+++ b/integtest/long_window_readout_test.py
@@ -61,10 +61,6 @@ hsi_frag_params = {
 }
 ignored_logfile_problems = {
     "-controller": [
-        "Propagating take_control to children",
-        "Propagating describe to children",
-        "There is no broadcasting service",
-        "Could not understand the BroadcastHandler technology you want to use",
         "Worker with pid \\d+ was terminated due to signal 1",
         "Connection '.*' not found on the application registry",
     ],

--- a/integtest/minimal_system_quick_test.py
+++ b/integtest/minimal_system_quick_test.py
@@ -61,11 +61,7 @@ hsi_frag_params = {
 }
 ignored_logfile_problems = {
     "-controller": [
-        "ERROR\\s+\\S+\\s+Broadcast:\\s+Propagating take_control to children",
-        "ERROR\\s+\\S+\\s+Broadcast:\\s+Propagating describe to children",
-        "WARNING\\s+\\S+\\s+Broadcast:\\s+There is no broadcasting service!",
         "Worker with pid \\d+ was terminated due to signal",
-        "WARNING\\s+\\S+\\s+BroadcastHandler:\\s+Could not understand the BroadcastHandler technology you want to use",
         "Connection '.*' not found on the application registry",
     ],
     "local-connection-server": [

--- a/integtest/readout_type_scan.py
+++ b/integtest/readout_type_scan.py
@@ -105,10 +105,6 @@ triggertp_frag_params = {
 }
 ignored_logfile_problems = {
     "-controller": [
-        'ERROR.*Broadcast:.*Propagating take_control to children',
-        'ERROR.*Broadcast:.*Propagating describe to children',
-        'WARNING.*Broadcast:.*There is no broadcasting service!',
-        "Could not understand the BroadcastHandler technology you want to use",
         "Worker with pid \\d+ was terminated due to signal 1",
         "Connection '.*' not found on the application registry",
     ],

--- a/integtest/small_footprint_quick_test.py
+++ b/integtest/small_footprint_quick_test.py
@@ -64,10 +64,6 @@ ignored_logfile_problems = {
         "Searching for connections matching uid_regex<errored_frames_q> and data_type Unknown"
     ],
     "-controller": [
-        "Propagating take_control to children",
-        "Propagating describe to children",
-        "There is no broadcasting service",
-        "Could not understand the BroadcastHandler technology you want to use",
         "Worker with pid \\d+ was terminated due to signal 1",
         "Connection '.*' not found on the application registry",
     ],

--- a/integtest/tpstream_writing_test.py
+++ b/integtest/tpstream_writing_test.py
@@ -83,10 +83,6 @@ hsi_frag_params = {
 }
 ignored_logfile_problems = {
     "-controller": [
-        "Propagating take_control to children",
-        "Propagating describe to children",
-        "There is no broadcasting service",
-        "Could not understand the BroadcastHandler technology you want to use",
         "Worker with pid \\d+ was terminated due to signal 1",
         "Connection '.*' not found on the application registry",
     ],


### PR DESCRIPTION
exclusion strings from the integration tests.