### PR TITLE
Increased the min_size_bytes for WIBEth fragments from 72 to 7272 in …

### DIFF
--- a/integtest/3ru_1df_multirun_test.py
+++ b/integtest/3ru_1df_multirun_test.py
@@ -41,7 +41,7 @@ wibeth_frag_multi_trig_params = {
     "fragment_type": "WIBEth",
     "hdf5_source_subsystem": "Detector_Readout",
     "expected_fragment_count": (number_of_data_producers * number_of_readout_apps),
-    "min_size_bytes": 72,
+    "min_size_bytes": 7272,
     "max_size_bytes": 14472,
 }
 triggercandidate_frag_params = {

--- a/integtest/3ru_3df_multirun_test.py
+++ b/integtest/3ru_3df_multirun_test.py
@@ -39,7 +39,7 @@ wibeth_frag_multi_trig_params = {
     "fragment_type": "WIBEth",
     "hdf5_source_subsystem": "Detector_Readout",
     "expected_fragment_count": (number_of_data_producers * number_of_readout_apps),
-    "min_size_bytes": 72,
+    "min_size_bytes": 7272,
     "max_size_bytes": 14472,
 }
 triggercandidate_frag_params = {

--- a/integtest/tpstream_writing_test.py
+++ b/integtest/tpstream_writing_test.py
@@ -38,7 +38,7 @@ wibeth_frag_multi_trig_params = {
     "fragment_type": "WIBEth",
     "hdf5_source_subsystem": "Detector_Readout",
     "expected_fragment_count": (number_of_data_producers * number_of_readout_apps),
-    "min_size_bytes": 72,
+    "min_size_bytes": 7272,
     "max_size_bytes": 14472,
 }
 wibeth_tpset_params = {


### PR DESCRIPTION
…several integtests since we believe that there should always be at least one frame retrieved per data request no matter how small the readout window is.

I have tested these changes in conjunction with the changes in other repos that produce the correct number of WIBEth frames more reliably, and that all works as expected.