### PR TITLE
Minor changes to integtests

### DIFF
--- a/integtest/README.md
+++ b/integtest/README.md
@@ -6,7 +6,7 @@
 Here is a sample command for invoking a test (feel free to keep or drop the options in brackets, as you prefer):
 
 ```
-pytest -s minimal_system_quick_test.py [--nanorc-option log-level debug]  # this nanorc option is still useful even with drunc
+pytest -s minimal_system_quick_test.py [--nanorc-option log-level debug]  # this nanorc option is still useful even when using drunc
 ```
 
 The "-k" pytest option can be used ro selectively run a subset of the configurations in one of our integtest files.  For example:
@@ -19,7 +19,7 @@ For reference, here are the ideas behind the tests that currently exist in this 
 * `minimal_system_quick_test.py` - verify that a small emulator system works and successfully writes data in a short run
 * `readout_type_scan.py` - verify that we can write different types of data (WIBEth, PDS, TPG, etc.)
 * `3ru_3df_multirun_test.py` - verify that a system with multiple RUs and multiple DF Apps works as expected, including TPG
-* `small_footprint_quick_test.py` - verify that an emulator system that uses a small amount of resources works and successfully writes data in a short run
+* `small_footprint_quick_test.py` - like minimal_system_quick_test, but using even fewer computer resources
 * `fake_data_producer_test.py` - verify that the FakeDataProdModule DAQModule works as expected
 * `long_window_readout_test.py` - verify that readout windows that require TriggerRecords to be split into multiple sequences works as expected
 * `3ru_1df_multirun_test.py` - verify that we don't get empty fragments at end run

--- a/integtest/README.md
+++ b/integtest/README.md
@@ -1,4 +1,4 @@
-* 19-Jul-2023, ELF, KAB, and others: notes on existing integtests
+* 04-Nov-2024, ELF, KAB, and others: notes on existing integtests
 
 "integtests" are intended to be automated integration and/or system tests that make use of the
 "pytest" framework to validate the operation of the DAQ system in various scenarios.
@@ -6,15 +6,23 @@
 Here is a sample command for invoking a test (feel free to keep or drop the options in brackets, as you prefer):
 
 ```
-pytest -s minimal_system_quick_test.py [--nanorc-option log-level debug]  # still useful even with drunc
+pytest -s minimal_system_quick_test.py [--nanorc-option log-level debug]  # this nanorc option is still useful even with drunc
+```
+
+The "-k" pytest option can be used ro selectively run a subset of the configurations in one of our integtest files.  For example:
+
+```
+pytest -s -k TPG 3ru_3df_multirun_test.py
 ```
 
 For reference, here are the ideas behind the tests that currently exist in this repository:
 * `minimal_system_quick_test.py` - verify that a small emulator system works and successfully writes data in a short run
 * `readout_type_scan.py` - verify that we can write different types of data (WIBEth, PDS, TPG, etc.)
 * `3ru_3df_multirun_test.py` - verify that a system with multiple RUs and multiple DF Apps works as expected, including TPG
+* `small_footprint_quick_test.py` - verify that an emulator system that uses a small amount of resources works and successfully writes data in a short run
 * `fake_data_producer_test.py` - verify that the FakeDataProdModule DAQModule works as expected
 * `long_window_readout_test.py` - verify that readout windows that require TriggerRecords to be split into multiple sequences works as expected
 * `3ru_1df_multirun_test.py` - verify that we don't get empty fragments at end run
   * this test is also useful in looking into high-CPU-usage scenarios because it uses 3 data producers in 3 RUs
 * `tpstream_writing_test.py` - verify that TPSets are written to the TP-stream file(s)
+* `example_system_test.py` - verify that the example configurations in example-configs.data.xml work as expected

--- a/integtest/minimal_system_quick_test.py
+++ b/integtest/minimal_system_quick_test.py
@@ -48,7 +48,7 @@ triggercandidate_frag_params = {
     "fragment_type": "Trigger_Candidate",
     "hdf5_source_subsystem": "Trigger",
     "expected_fragment_count": 1,
-    "min_size_bytes": 72,
+    "min_size_bytes": 128,
     "max_size_bytes": 216,
 }
 hsi_frag_params = {

--- a/scripts/daqsystemtest_integtest_bundle.sh
+++ b/scripts/daqsystemtest_integtest_bundle.sh
@@ -100,7 +100,7 @@ while [[ ${overall_loop_count} -lt ${overall_run_count} ]]; do
         elif [[ -e "${DBT_AREA_ROOT}/sourcecode/daqsystemtest/integtest/${TEST_NAME}" ]]; then
           pytest -s ${DBT_AREA_ROOT}/sourcecode/daqsystemtest/integtest/${TEST_NAME} | tee -a ${ITGRUNNER_LOG_FILE}
         else
-          pytest -s ${DAQSYSTEMTEST_SHARE}/integtest/${TEST_NAME} | tee -a ${ITGRUNNER_LOG_FILE}
+          pytest -s -p no:cacheprovider ${DAQSYSTEMTEST_SHARE}/integtest/${TEST_NAME} | tee -a ${ITGRUNNER_LOG_FILE}
         fi
         let pytest_return_code=${PIPESTATUS[0]}
 

--- a/scripts/daqsystemtest_integtest_bundle.sh
+++ b/scripts/daqsystemtest_integtest_bundle.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # 10-Oct-2023, KAB
 
-integtest_list=( "minimal_system_quick_test.py" "readout_type_scan.py" "3ru_3df_multirun_test.py" "fake_data_producer_test.py" "long_window_readout_test.py" "3ru_1df_multirun_test.py" "tpstream_writing_test.py" )
+integtest_list=( "minimal_system_quick_test.py" "readout_type_scan.py" "3ru_3df_multirun_test.py" "small_footprint_quick_test.py" "fake_data_producer_test.py" "long_window_readout_test.py" "3ru_1df_multirun_test.py" "tpstream_writing_test.py" "example_system_test.py" )
 
 usage() {
     declare -r script_name=$(basename "$0")


### PR DESCRIPTION
This PR has four small changes:

- The `integtest/README.md` file was updated to include a hint about the `pytest` "-k" option and to describe more of the available tests
- The `-p no:cacheprovider` option was added to the `pytest` command in the bundle script when it calls the test from the base release
- The `small_footprint_quick_test` and `example_system_test` were added to the bundle script
- The minimum expected size for TC fragments was increased from 72 to 128 in the `minimal_system_quick_test` since we expect non-empty TC fragments when using the `RandomTCMakerModule`

I was thinking that we should target these changes to the `prep-release/fddaq-v5.2.0` branch, but I realized that if we merged them to the `develop` branch first, we could test the `no:cacheprovider` change in the next nightly build before merging them to the prep-release branch....