### PR TITLE
Removing obsolete trigger configs & new default for TCDataProcessor::td_readout_limit

### DIFF
--- a/config/daqsystemtest/moduleconfs.data.xml
+++ b/config/daqsystemtest/moduleconfs.data.xml
@@ -401,9 +401,6 @@
 
 <obj class="MLTConf" id="def-mlt-conf">
  <attr name="template_for" type="class" val="MLTModule"/>
- <attr name="td_out_of_timeout" type="bool" val="1"/>
- <attr name="buffer_timeout" type="u32" val="1"/>
- <attr name="td_readout_limit" type="u32" val="1"/>
  <attr name="latency_monitoring" type="bool" val="1"/>
 </obj>
 
@@ -515,13 +512,11 @@
  <attr name="queue_sizes" type="u32" val="10000"/>
  <attr name="thread_names_prefix" type="string" val="mlt_"/>
  <attr name="latency_monitoring" type="bool" val="1"/>
- <attr name="hsi_trigger_type_passthrough" type="bool" val="0"/>
  <attr name="merge_overlapping_tcs" type="bool" val="1"/>
  <attr name="ignore_overlapping_tcs" type="bool" val="0"/>
  <attr name="td_out_of_timeout" type="bool" val="1"/>
  <attr name="buffer_timeout" type="u32" val="1"/>
- <attr name="td_readout_limit" type="u32" val="1"/>
- <attr name="use_bitwords" type="bool" val="0"/>
+ <attr name="td_readout_limit" type="u32" val="1000000"/>
  <rel name="tc_readout_map">
   <ref class="TCReadoutMap" id="def-tc-map"/>
   <ref class="TCReadoutMap" id="def-hsi-tc-map"/>


### PR DESCRIPTION
Full description in https://github.com/DUNE-DAQ/appmodel/pull/154