### PR TITLE
Set the TR queue size to a more reasonable number, and make the TRB

### DIFF
--- a/integtest/long_window_readout_test.py
+++ b/integtest/long_window_readout_test.py
@@ -22,6 +22,7 @@ token_count = 1
 readout_window_time_before = 100000000  # 1.616 second is the intention for b+a
 readout_window_time_after = 1000000
 trigger_record_max_window = 500000  # intention is 8 msec
+tr_queue_size = token_count * (readout_window_time_before + readout_window_time_after) / trigger_record_max_window /  number_of_dataflow_apps
 latency_buffer_size = 600000
 data_rate_slowdown_factor = 1
 minimum_cpu_count = 24
@@ -149,7 +150,18 @@ trsplit_conf = copy.deepcopy(conf_dict)
 trsplit_conf.config_substitutions.append(
     data_classes.config_substitution(
         obj_class="TRBConf",
-        updates={"max_time_window": trigger_record_max_window},
+        updates={
+            "max_time_window": trigger_record_max_window,
+            "trigger_record_timeout_ms": 1000 / trigger_rate
+        },
+    )
+)
+
+trsplit_conf.config_substitutions.append(
+    data_classes.config_substitution(
+        obj_class="QueueDescriptor",
+        obj_id="trigger-records",
+        updates={"capacity": tr_queue_size},
     )
 )
 


### PR DESCRIPTION
timeout equivalent to 1/trigger rate to avoid potential trigger latencies.