### PR TITLE
Unify all `<app_id>_control`

### DIFF
--- a/config/daqsystemtest/ccm.data.xml
+++ b/config/daqsystemtest/ccm.data.xml
@@ -63,7 +63,7 @@
 
 <oks-data>
 
-<info name="" type="" num-of-items="27" oks-format="data" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20231207T110859" last-modified-by="plasorak" last-modified-on="np04-srv-019.cern.ch" last-modification-time="20241119T172747"/>
+<info name="" type="" num-of-items="27" oks-format="data" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20231207T110859" last-modified-by="eflumerf" last-modified-on="ironvirt9.mshome.net" last-modification-time="20241120T175651"/>
 
 <include>
  <file path="schema/confmodel/dunedaq.schema.xml"/>
@@ -140,11 +140,6 @@
  <attr name="port" type="u16" val="0"/>
 </obj>
 
-<obj class="Service" id="rccontroller_control">
- <attr name="protocol" type="string" val="grpc"/>
- <attr name="port" type="u16" val="0"/>
-</obj>
-
 <obj class="Service" id="ehn1-connectivity-service">
  <attr name="protocol" type="string" val="http"/>
  <attr name="port" type="u16" val="30005"/>
@@ -153,6 +148,11 @@
 <obj class="Service" id="local-connectivity-service">
  <attr name="protocol" type="string" val="http"/>
  <attr name="port" type="u16" val="5000"/>
+</obj>
+
+<obj class="Service" id="rccontroller_control">
+ <attr name="protocol" type="string" val="grpc"/>
+ <attr name="port" type="u16" val="0"/>
 </obj>
 
 <obj class="Variable" id="ehn1-env-connectivity-port">

--- a/config/daqsystemtest/ccm.data.xml
+++ b/config/daqsystemtest/ccm.data.xml
@@ -129,7 +129,7 @@
  <attr name="application_name" type="string" val="drunc-controller"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="exposes_service">
-  <ref class="Service" id="drunc_control"/>
+  <ref class="Service" id="rccontroller_control"/>
  </rel>
  <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
  <rel name="fsm" class="FSMconfiguration" id="fsmConf-test"/>
@@ -140,7 +140,7 @@
  <attr name="port" type="u16" val="0"/>
 </obj>
 
-<obj class="Service" id="drunc_control">
+<obj class="Service" id="rccontroller_control">
  <attr name="protocol" type="string" val="grpc"/>
  <attr name="port" type="u16" val="0"/>
 </obj>

--- a/config/daqsystemtest/ccm.data.xml
+++ b/config/daqsystemtest/ccm.data.xml
@@ -63,7 +63,7 @@
 
 <oks-data>
 
-<info name="" type="" num-of-items="26" oks-format="data" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20231207T110859" last-modified-by="eflumerf" last-modified-on="ironvirt9.IRONDOMAIN.local" last-modification-time="20241023T204409"/>
+<info name="" type="" num-of-items="27" oks-format="data" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20231207T110859" last-modified-by="plasorak" last-modified-on="np04-srv-019.cern.ch" last-modification-time="20241119T172747"/>
 
 <include>
  <file path="schema/confmodel/dunedaq.schema.xml"/>
@@ -129,10 +129,20 @@
  <attr name="application_name" type="string" val="drunc-controller"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="exposes_service">
-  <ref class="Service" id="root-controller_control"/>
+  <ref class="Service" id="drunc_control"/>
  </rel>
  <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
  <rel name="fsm" class="FSMconfiguration" id="fsmConf-test"/>
+</obj>
+
+<obj class="Service" id="daqapp_control">
+ <attr name="protocol" type="string" val="rest"/>
+ <attr name="port" type="u16" val="0"/>
+</obj>
+
+<obj class="Service" id="drunc_control">
+ <attr name="protocol" type="string" val="grpc"/>
+ <attr name="port" type="u16" val="0"/>
 </obj>
 
 <obj class="Service" id="ehn1-connectivity-service">
@@ -143,11 +153,6 @@
 <obj class="Service" id="local-connectivity-service">
  <attr name="protocol" type="string" val="http"/>
  <attr name="port" type="u16" val="5000"/>
-</obj>
-
-<obj class="Service" id="root-controller_control">
- <attr name="protocol" type="string" val="grpc"/>
- <attr name="port" type="u16" val="0"/>
 </obj>
 
 <obj class="Variable" id="ehn1-env-connectivity-port">

--- a/config/daqsystemtest/df-segment.data.xml
+++ b/config/daqsystemtest/df-segment.data.xml
@@ -71,6 +71,7 @@
  <file path="config/daqsystemtest/connections.data.xml"/>
  <file path="config/daqsystemtest/moduleconfs.data.xml"/>
  <file path="config/daqsystemtest/hosts.data.xml"/>
+ <file path="config/daqsystemtest/ccm.data.xml"/>
 </include>
 
 
@@ -78,7 +79,7 @@
  <attr name="application_name" type="string" val="daq_application"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="exposes_service">
-  <ref class="Service" id="df-01_control"/>
+  <ref class="Service" id="daqapp_control"/>
  </rel>
  <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
  <rel name="source_id" class="SourceIDConf" id="srcid-df-01"/>
@@ -104,7 +105,7 @@
  <attr name="application_name" type="string" val="daq_application"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="exposes_service">
-  <ref class="Service" id="df-02_control"/>
+  <ref class="Service" id="daqapp_control"/>
  </rel>
  <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
  <rel name="source_id" class="SourceIDConf" id="srcid-df-02"/>
@@ -130,7 +131,7 @@
  <attr name="application_name" type="string" val="daq_application"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="exposes_service">
-  <ref class="Service" id="df-03_control"/>
+  <ref class="Service" id="daqapp_control"/>
  </rel>
  <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
  <rel name="source_id" class="SourceIDConf" id="srcid-df-03"/>
@@ -162,7 +163,7 @@
  <attr name="application_name" type="string" val="daq_application"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="exposes_service">
-  <ref class="Service" id="dfo-01_control"/>
+  <ref class="Service" id="daqapp_control"/>
  </rel>
  <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
  <rel name="network_rules">
@@ -177,7 +178,7 @@
  <attr name="application_name" type="string" val="drunc-controller"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="exposes_service">
-  <ref class="Service" id="df-controller_control"/>
+  <ref class="Service" id="drunc_control"/>
  </rel>
  <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
  <rel name="fsm" class="FSMconfiguration" id="FSMconfiguration_noAction"/>
@@ -192,36 +193,6 @@
   <ref class="DFApplication" id="df-03"/>
  </rel>
  <rel name="controller" class="RCApplication" id="df-controller"/>
-</obj>
-
-<obj class="Service" id="df-01_control">
- <attr name="protocol" type="string" val="rest"/>
- <attr name="port" type="u16" val="0"/>
-</obj>
-
-<obj class="Service" id="df-02_control">
- <attr name="protocol" type="string" val="rest"/>
- <attr name="port" type="u16" val="0"/>
-</obj>
-
-<obj class="Service" id="df-03_control">
- <attr name="protocol" type="string" val="rest"/>
- <attr name="port" type="u16" val="0"/>
-</obj>
-
-<obj class="Service" id="df-controller_control">
- <attr name="protocol" type="string" val="grpc"/>
- <attr name="port" type="u16" val="0"/>
-</obj>
-
-<obj class="Service" id="dfo-01_control">
- <attr name="protocol" type="string" val="rest"/>
- <attr name="port" type="u16" val="0"/>
-</obj>
-
-<obj class="Service" id="tp-stream-writer_control">
- <attr name="protocol" type="string" val="rest"/>
- <attr name="port" type="u16" val="0"/>
 </obj>
 
 <obj class="SourceIDConf" id="srcid-df-01">
@@ -252,7 +223,7 @@
  <attr name="application_name" type="string" val="daq_application"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="exposes_service">
-  <ref class="Service" id="tp-stream-writer_control"/>
+  <ref class="Service" id="daqapp_control"/>
  </rel>
  <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
  <rel name="source_id" class="SourceIDConf" id="srcid-tp-stream-writer"/>

--- a/config/daqsystemtest/df-segment.data.xml
+++ b/config/daqsystemtest/df-segment.data.xml
@@ -178,7 +178,7 @@
  <attr name="application_name" type="string" val="drunc-controller"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="exposes_service">
-  <ref class="Service" id="drunc_control"/>
+  <ref class="Service" id="rccontroller_control"/>
  </rel>
  <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
  <rel name="fsm" class="FSMconfiguration" id="FSMconfiguration_noAction"/>

--- a/config/daqsystemtest/hsi-dts-segment.data.xml
+++ b/config/daqsystemtest/hsi-dts-segment.data.xml
@@ -188,7 +188,7 @@
  <attr name="application_name" type="string" val="drunc-controller"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="exposes_service">
-  <ref class="Service" id="drunc_control"/>
+  <ref class="Service" id="rccontroller_control"/>
  </rel>
  <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
  <rel name="fsm" class="FSMconfiguration" id="FSMconfiguration_noAction"/>

--- a/config/daqsystemtest/hsi-dts-segment.data.xml
+++ b/config/daqsystemtest/hsi-dts-segment.data.xml
@@ -72,6 +72,7 @@
  <file path="config/daqsystemtest/connections.data.xml"/>
  <file path="config/daqsystemtest/moduleconfs.data.xml"/>
  <file path="config/daqsystemtest/hosts.data.xml"/>
+ <file path="config/daqsystemtest/ccm.data.xml"/>
  <file path="schema/hsilibs/hsi.schema.xml"/>
 </include>
 
@@ -93,7 +94,7 @@
  <attr name="application_name" type="string" val="daq_application"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="exposes_service">
-  <ref class="Service" id="hsi-dts-01_control"/>
+  <ref class="Service" id="daqapp_control"/>
  </rel>
  <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
  <rel name="source_id" class="SourceIDConf" id="hsi-dts-srcid-01"/>
@@ -113,7 +114,7 @@
  <attr name="application_name" type="string" val="daq_application"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="exposes_service">
-  <ref class="Service" id="dts-hsi-ctrl_control"/>
+  <ref class="Service" id="daqapp_control"/>
  </rel>
  <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
  <rel name="modules">
@@ -152,7 +153,7 @@
  <rel name="exposes_service">
   <ref class="Service" id="dataRequests"/>
   <ref class="Service" id="HSIEvents"/>
-  <ref class="Service" id="hsi-dts-to-tc-app_control"/>
+  <ref class="Service" id="daqapp_control"/>
  </rel>
  <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
  <rel name="source_id" class="SourceIDConf" id="hsi-dts-tc-srcid-1"/>
@@ -187,7 +188,7 @@
  <attr name="application_name" type="string" val="drunc-controller"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="exposes_service">
-  <ref class="Service" id="hsi-dts-controller_control"/>
+  <ref class="Service" id="drunc_control"/>
  </rel>
  <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
  <rel name="fsm" class="FSMconfiguration" id="FSMconfiguration_noAction"/>
@@ -209,26 +210,6 @@
   <ref class="DaqApplication" id="dts-hsi-ctrl"/>
  </rel>
  <rel name="controller" class="RCApplication" id="hsi-dts-controller"/>
-</obj>
-
-<obj class="Service" id="dts-hsi-ctrl_control">
- <attr name="protocol" type="string" val="rest"/>
- <attr name="port" type="u16" val="0"/>
-</obj>
-
-<obj class="Service" id="hsi-dts-01_control">
- <attr name="protocol" type="string" val="rest"/>
- <attr name="port" type="u16" val="0"/>
-</obj>
-
-<obj class="Service" id="hsi-dts-controller_control">
- <attr name="protocol" type="string" val="grpc"/>
- <attr name="port" type="u16" val="0"/>
-</obj>
-
-<obj class="Service" id="hsi-dts-to-tc-app_control">
- <attr name="protocol" type="string" val="rest"/>
- <attr name="port" type="u16" val="0"/>
 </obj>
 
 <obj class="SourceIDConf" id="hsi-dts-srcid-01">

--- a/config/daqsystemtest/hsi-fake-segment.data.xml
+++ b/config/daqsystemtest/hsi-fake-segment.data.xml
@@ -72,6 +72,7 @@
  <file path="config/daqsystemtest/connections.data.xml"/>
  <file path="config/daqsystemtest/moduleconfs.data.xml"/>
  <file path="config/daqsystemtest/hosts.data.xml"/>
+ <file path="config/daqsystemtest/ccm.data.xml"/>
 </include>
 
 <comments>
@@ -98,7 +99,7 @@
  <attr name="application_name" type="string" val="daq_application"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="exposes_service">
-  <ref class="Service" id="hsi-fake-01_control"/>
+  <ref class="Service" id="daqapp_control"/>
  </rel>
  <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
  <rel name="source_id" class="SourceIDConf" id="hsi-fake-srcid-01"/>
@@ -127,7 +128,7 @@
  <rel name="exposes_service">
   <ref class="Service" id="dataRequests"/>
   <ref class="Service" id="HSIEvents"/>
-  <ref class="Service" id="hsi-fake-to-tc-app_control"/>
+  <ref class="Service" id="daqapp_control"/>
  </rel>
  <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
  <rel name="source_id" class="SourceIDConf" id="hsi-fake-tc-srcid-1"/>
@@ -155,7 +156,7 @@
  <attr name="application_name" type="string" val="drunc-controller"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="exposes_service">
-  <ref class="Service" id="hsi-fake-controller_control"/>
+  <ref class="Service" id="drunc_control"/>
  </rel>
  <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
  <rel name="fsm" class="FSMconfiguration" id="FSMconfiguration_noAction"/>
@@ -176,21 +177,6 @@
   <ref class="HSIEventToTCApplication" id="hsi-fake-to-tc-app"/>
  </rel>
  <rel name="controller" class="RCApplication" id="hsi-fake-controller"/>
-</obj>
-
-<obj class="Service" id="hsi-fake-01_control">
- <attr name="protocol" type="string" val="rest"/>
- <attr name="port" type="u16" val="0"/>
-</obj>
-
-<obj class="Service" id="hsi-fake-controller_control">
- <attr name="protocol" type="string" val="grpc"/>
- <attr name="port" type="u16" val="0"/>
-</obj>
-
-<obj class="Service" id="hsi-fake-to-tc-app_control">
- <attr name="protocol" type="string" val="rest"/>
- <attr name="port" type="u16" val="0"/>
 </obj>
 
 <obj class="SourceIDConf" id="hsi-fake-srcid-01">

--- a/config/daqsystemtest/hsi-fake-segment.data.xml
+++ b/config/daqsystemtest/hsi-fake-segment.data.xml
@@ -156,7 +156,7 @@
  <attr name="application_name" type="string" val="drunc-controller"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="exposes_service">
-  <ref class="Service" id="drunc_control"/>
+  <ref class="Service" id="rccontroller_control"/>
  </rel>
  <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
  <rel name="fsm" class="FSMconfiguration" id="FSMconfiguration_noAction"/>

--- a/config/daqsystemtest/ru-segment.data.xml
+++ b/config/daqsystemtest/ru-segment.data.xml
@@ -322,7 +322,7 @@
  <attr name="application_name" type="string" val="drunc-controller"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="exposes_service">
-  <ref class="Service" id="drunc_control"/>
+  <ref class="Service" id="rccontroller_control"/>
  </rel>
  <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
  <rel name="fsm" class="FSMconfiguration" id="FSMconfiguration_noAction"/>

--- a/config/daqsystemtest/ru-segment.data.xml
+++ b/config/daqsystemtest/ru-segment.data.xml
@@ -73,6 +73,7 @@
  <file path="config/daqsystemtest/connections.data.xml"/>
  <file path="config/daqsystemtest/moduleconfs.data.xml"/>
  <file path="config/daqsystemtest/hosts.data.xml"/>
+ <file path="config/daqsystemtest/ccm.data.xml"/>
 </include>
 
 <comments>
@@ -321,7 +322,7 @@
  <attr name="application_name" type="string" val="drunc-controller"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="exposes_service">
-  <ref class="Service" id="ru-controller_control"/>
+  <ref class="Service" id="drunc_control"/>
  </rel>
  <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
  <rel name="fsm" class="FSMconfiguration" id="FSMconfiguration_noAction"/>
@@ -336,7 +337,7 @@
  </rel>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="exposes_service">
-  <ref class="Service" id="ru-01_control"/>
+  <ref class="Service" id="daqapp_control"/>
   <ref class="Service" id="dataRequests"/>
   <ref class="Service" id="timeSyncs"/>
   <ref class="Service" id="triggerActivities"/>
@@ -379,7 +380,7 @@
  </rel>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="exposes_service">
-  <ref class="Service" id="ru-02_control"/>
+  <ref class="Service" id="daqapp_control"/>
  </rel>
  <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
  <rel name="queue_rules">
@@ -430,21 +431,6 @@
   <ref class="ReadoutApplication" id="ru-02"/>
  </rel>
  <rel name="controller" class="RCApplication" id="ru-controller"/>
-</obj>
-
-<obj class="Service" id="ru-01_control">
- <attr name="protocol" type="string" val="rest"/>
- <attr name="port" type="u16" val="0"/>
-</obj>
-
-<obj class="Service" id="ru-02_control">
- <attr name="protocol" type="string" val="rest"/>
- <attr name="port" type="u16" val="0"/>
-</obj>
-
-<obj class="Service" id="ru-controller_control">
- <attr name="protocol" type="string" val="grpc"/>
- <attr name="port" type="u16" val="0"/>
 </obj>
 
 <obj class="SourceIDConf" id="tp-srcid-1000">

--- a/config/daqsystemtest/trigger-segment.data.xml
+++ b/config/daqsystemtest/trigger-segment.data.xml
@@ -73,6 +73,7 @@
  <file path="config/daqsystemtest/moduleconfs.data.xml"/>
  <file path="config/daqsystemtest/hosts.data.xml"/>
  <file path="config/daqsystemtest/fsm.data.xml"/>
+ <file path="config/daqsystemtest/ccm.data.xml"/>
 </include>
 
 <comments>
@@ -87,7 +88,7 @@
   <ref class="Service" id="triggerCandidates"/>
   <ref class="Service" id="triggerInhibits"/>
   <ref class="Service" id="dataRequests"/>
-  <ref class="Service" id="mlt_control"/>
+  <ref class="Service" id="daqapp_control"/>
  </rel>
  <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
  <rel name="source_id" class="SourceIDConf" id="tc-srcid-1"/>
@@ -114,7 +115,7 @@
  <attr name="application_name" type="string" val="drunc-controller"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="exposes_service">
-  <ref class="Service" id="trg-controller_control"/>
+  <ref class="Service" id="drunc_control"/>
  </rel>
  <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
  <rel name="fsm" class="FSMconfiguration" id="FSMconfiguration_noAction"/>
@@ -126,26 +127,6 @@
   <ref class="MLTApplication" id="mlt"/>
  </rel>
  <rel name="controller" class="RCApplication" id="trg-controller"/>
-</obj>
-
-<obj class="Service" id="mlt_control">
- <attr name="protocol" type="string" val="rest"/>
- <attr name="port" type="u16" val="0"/>
-</obj>
-
-<obj class="Service" id="tc-buffer-1_control">
- <attr name="protocol" type="string" val="rest"/>
- <attr name="port" type="u16" val="0"/>
-</obj>
-
-<obj class="Service" id="tc-maker-1_control">
- <attr name="protocol" type="string" val="rest"/>
- <attr name="port" type="u16" val="0"/>
-</obj>
-
-<obj class="Service" id="trg-controller_control">
- <attr name="protocol" type="string" val="grpc"/>
- <attr name="port" type="u16" val="0"/>
 </obj>
 
 <obj class="SourceIDConf" id="ta-srcid-1">
@@ -162,7 +143,7 @@
  <attr name="application_name" type="string" val="daq_application"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="exposes_service">
-  <ref class="Service" id="tc-maker-1_control"/>
+  <ref class="Service" id="daqapp_control"/>
   <ref class="Service" id="triggerActivities"/>
   <ref class="Service" id="dataRequests"/>
  </rel>

--- a/config/daqsystemtest/trigger-segment.data.xml
+++ b/config/daqsystemtest/trigger-segment.data.xml
@@ -115,7 +115,7 @@
  <attr name="application_name" type="string" val="drunc-controller"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="exposes_service">
-  <ref class="Service" id="drunc_control"/>
+  <ref class="Service" id="rccontroller_control"/>
  </rel>
  <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
  <rel name="fsm" class="FSMconfiguration" id="FSMconfiguration_noAction"/>


### PR DESCRIPTION
This PR uses https://github.com/DUNE-DAQ/confmodel/pull/53 to make the application configuration simpler, by removing all the `<app_id>_control` services and unifying them in `daqapp_control` and `drunc_control`.