### PR TITLE
DataHandlingModel with IDT

### DIFF
--- a/config/daqsystemtest/connections.data.xml
+++ b/config/daqsystemtest/connections.data.xml
@@ -362,7 +362,7 @@
  <attr name="uid_base" type="string" val="tp_input_"/>
  <attr name="queue_type" type="enum" val="kFollyMPMCQueue"/>
  <attr name="capacity" type="u32" val="10000"/>
- <attr name="data_type" type="string" val="TriggerPrimitive"/>
+ <attr name="data_type" type="string" val="TriggerPrimitiveVector"/>
 </obj>
 
 <obj class="QueueDescriptor" id="trigger-records">

--- a/config/daqsystemtest/moduleconfs.data.xml
+++ b/config/daqsystemtest/moduleconfs.data.xml
@@ -202,7 +202,7 @@
 
 <obj class="DataHandlerConf" id="def-tp-handler">
  <attr name="template_for" type="class" val="TriggerDataHandlerModule"/>
- <attr name="input_data_type" type="string" val="TriggerPrimitive"/>
+ <attr name="input_data_type" type="string" val="TriggerPrimitiveVector"/>
  <attr name="generate_timesync" type="bool" val="0"/>
  <rel name="request_handler" class="RequestHandler" id="def-tp-request-handler"/>
  <rel name="latency_buffer" class="LatencyBuffer" id="def-latency-buf"/>


### PR DESCRIPTION
New data type TriggerPrimitiveVector is added to the database.

[datahandlinglibs pull request](https://github.com/DUNE-DAQ/datahandlinglibs/pull/34)
[trigger pull request](https://github.com/DUNE-DAQ/trigger/pull/362)
[appmodel pull request](https://github.com/DUNE-DAQ/appmodel/pull/155)
[fdreadoutlibs pull request](https://github.com/DUNE-DAQ/fdreadoutlibs/pull/240)
[ehn1-daqconfigs pull request](https://gitlab.cern.ch/dune-daq/online/ehn1-daqconfigs/-/merge_requests/19)

[JIRA task](https://its.cern.ch/jira/browse/EPDTDI-1501)