### PR TITLE
Fixed the connectivity-service ignored_logfile_problems string 

### DIFF
--- a/integtest/3ru_1df_multirun_test.py
+++ b/integtest/3ru_1df_multirun_test.py
@@ -81,7 +81,7 @@ ignored_logfile_problems = {
         "Worker with pid \\d+ was terminated due to signal 1",
         "Connection '.*' not found on the application registry",
     ],
-    "local-connection-server": [
+    "connectivity-service": [
         "errorlog: -",
         "Worker with pid \\d+ was terminated due to signal 1",
     ],

--- a/integtest/3ru_3df_multirun_test.py
+++ b/integtest/3ru_3df_multirun_test.py
@@ -79,7 +79,7 @@ ignored_logfile_problems = {
         "Worker with pid \\d+ was terminated due to signal 1",
         "Connection '.*' not found on the application registry",
     ],
-    "local-connection-server": [
+    "connectivity-service": [
         "errorlog: -",
         "Worker with pid \\d+ was terminated due to signal 1",
     ],

--- a/integtest/fake_data_producer_test.py
+++ b/integtest/fake_data_producer_test.py
@@ -42,7 +42,7 @@ ignored_logfile_problems = {
         "Worker with pid \\d+ was terminated due to signal",
         "Connection '.*' not found on the application registry",
     ],
-    "local-connection-server": [
+    "connectivity-service": [
         "errorlog: -",
         "Worker with pid \\d+ was terminated due to signal",
     ],

--- a/integtest/long_window_readout_test.py
+++ b/integtest/long_window_readout_test.py
@@ -58,7 +58,7 @@ ignored_logfile_problems = {
         "Worker with pid \\d+ was terminated due to signal 1",
         "Connection '.*' not found on the application registry",
     ],
-    "local-connection-server": [
+    "connectivity-service": [
         "errorlog: -",
         "Worker with pid \\d+ was terminated due to signal 1",
     ],

--- a/integtest/minimal_system_quick_test.py
+++ b/integtest/minimal_system_quick_test.py
@@ -64,7 +64,7 @@ ignored_logfile_problems = {
         "Worker with pid \\d+ was terminated due to signal",
         "Connection '.*' not found on the application registry",
     ],
-    "local-connection-server": [
+    "connectivity-service": [
         "errorlog: -",
         "Worker with pid \\d+ was terminated due to signal",
     ],

--- a/integtest/readout_type_scan.py
+++ b/integtest/readout_type_scan.py
@@ -99,7 +99,7 @@ ignored_logfile_problems = {
         "Worker with pid \\d+ was terminated due to signal 1",
         "Connection '.*' not found on the application registry",
     ],
-    "local-connection-server": [
+    "connectivity-service": [
         "errorlog: -",
         "Worker with pid \\d+ was terminated due to signal 1",
     ],

--- a/integtest/small_footprint_quick_test.py
+++ b/integtest/small_footprint_quick_test.py
@@ -67,7 +67,7 @@ ignored_logfile_problems = {
         "Worker with pid \\d+ was terminated due to signal 1",
         "Connection '.*' not found on the application registry",
     ],
-    "local-connection-server": [
+    "connectivity-service": [
         "errorlog: -",
         "Worker with pid \\d+ was terminated due to signal 1",
     ],

--- a/integtest/tpstream_writing_test.py
+++ b/integtest/tpstream_writing_test.py
@@ -86,7 +86,7 @@ ignored_logfile_problems = {
         "Worker with pid \\d+ was terminated due to signal 1",
         "Connection '.*' not found on the application registry",
     ],
-    "local-connection-server": [
+    "connectivity-service": [
         "errorlog: -",
         "Worker with pid \\d+ was terminated due to signal 1",
     ],


### PR DESCRIPTION
… in the integtests that needed it.

I found that these integtests were not ignoring the specified phrases in the Connectivity Service log when when I set the ConnSvc debug level to 2 in integrationtest/python/integrationtest/integrationtest_drunc.py for testing a different problem.

With these changes, the daqsystemtest integtests run cleanly even when this debug level of 2 is set.