### PR TITLE
Added back the ability to specify a non-standard output directory for…

### DIFF
--- a/integtest/long_window_readout_test.py
+++ b/integtest/long_window_readout_test.py
@@ -145,6 +145,13 @@ conf_dict.config_substitutions.append(
         updates={"max_file_size": 4 * 1024 * 1024 * 1024},
     )
 )
+conf_dict.config_substitutions.append(
+    data_classes.config_substitution(
+        obj_class="DataStoreConf",
+        obj_id="default",
+        updates={"directory_path": output_path_parameter},
+    )
+)
 
 trsplit_conf = copy.deepcopy(conf_dict)
 trsplit_conf.config_substitutions.append(

--- a/integtest/tpstream_writing_test.py
+++ b/integtest/tpstream_writing_test.py
@@ -140,6 +140,20 @@ conf_dict.config_substitutions.append(
         updates={"merge_overlapping_tcs": 0},
     )
 )
+conf_dict.config_substitutions.append(
+    data_classes.config_substitution(
+        obj_class="DataStoreConf",
+        obj_id="default",
+        updates={"directory_path": output_dir},
+    )
+)
+conf_dict.config_substitutions.append(
+    data_classes.config_substitution(
+        obj_class="DataStoreConf",
+        obj_id="default_tp_store_conf",
+        updates={"directory_path": output_dir},
+    )
+)
 
 confgen_arguments = {"Software_TPG_System": conf_dict}
 


### PR DESCRIPTION
… data files in a couple of integtests.

This ability was lost in the transition from v4 software to v5 software.

This PR depends on one in the integrationtest repo ([PR 95](https://github.com/DUNE-DAQ/integrationtest/pull/95)).

To test these changes, one needs to create a software area that includes both the changes in the `integrationtest` and `daqsystemtest` repos, and one needs to specify a non-standard value for the `output_path_parameter` local variable in the `long_window_readout_test` and/or the `output_dir` local variable in the `tpstream_writing_test`.