### PR TITLE
Added another ignored error/warning string for connection server in e…

### DIFF
--- a/integtest/example_system_test.py
+++ b/integtest/example_system_test.py
@@ -58,7 +58,7 @@ ignored_logfile_problems = {
     "local-connection-server": [
         "errorlog: -",
         "Worker with pid \\d+ was terminated due to signal",
-        "Worker \(pid\:\\d+\) was sent SIGHUP"
+        r"Worker \(pid:\d+\) was sent SIGHUP"
     ],
     "log_.*": ["connect: Connection refused"],
 }

--- a/integtest/example_system_test.py
+++ b/integtest/example_system_test.py
@@ -58,6 +58,7 @@ ignored_logfile_problems = {
     "local-connection-server": [
         "errorlog: -",
         "Worker with pid \\d+ was terminated due to signal",
+        "Worker \(pid\:\\d+\) was sent SIGHUP"
     ],
     "log_.*": ["connect: Connection refused"],
 }


### PR DESCRIPTION
…xample_system_test. I suspect that an existing message simply changed slightly with externals v2.2.

Here are sample instructions for demonstrating the problem and verifying the proposed fix.  Please note the failure of the example_system_test before the modified code is included in the software area, and its successful running after the fix is included.

```
DATE_PREFIX=`date '+%d%b'`
TIME_SUFFIX=`date '+%H%M'`

source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
setup_dbt latest_v5
dbt-create -n NFD_DEV_250122_A9 ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}
cd ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}/sourcecode

git clone https://github.com/DUNE-DAQ/daqsystemtest.git -b develop
git clone https://github.com/DUNE-DAQ/hdf5libs.git -b develop
git clone https://github.com/DUNE-DAQ/dfmodules.git -b develop
cd ..

dbt-workarea-env
dbt-build -j 12
dbt-workarea-env

daqconf_set_connectivity_service_port local-1x1-config config/daqsystemtest/example-configs.data.xml

daqsystemtest_integtest_bundle.sh -f 8

cd sourcecode/daqsystemtest
git checkout kbiery/example_config_integtest_tweak
cd ../../

dbt-build -j 12
dbt-workarea-env

daqsystemtest_integtest_bundle.sh -f 8

```