### PR TITLE
Removed ignored logfile problem strings that are no longer needed. 

### DIFF
--- a/integtest/3ru_1df_multirun_test.py
+++ b/integtest/3ru_1df_multirun_test.py
@@ -83,9 +83,7 @@ ignored_logfile_problems = {
     ],
     "connectivity-service": [
         "errorlog: -",
-        "Worker with pid \\d+ was terminated due to signal 1",
     ],
-    "log_.*_3ru1df_": ["connect: Connection refused"],
 }
 
 # Determine if this computer is powerful enough for these tests

--- a/integtest/3ru_3df_multirun_test.py
+++ b/integtest/3ru_3df_multirun_test.py
@@ -81,9 +81,7 @@ ignored_logfile_problems = {
     ],
     "connectivity-service": [
         "errorlog: -",
-        "Worker with pid \\d+ was terminated due to signal 1",
     ],
-    "log_.*_3ru3df_": ["connect: Connection refused"],
 }
 
 # The next three variable declarations *must* be present as globals in the test

--- a/integtest/fake_data_producer_test.py
+++ b/integtest/fake_data_producer_test.py
@@ -44,9 +44,7 @@ ignored_logfile_problems = {
     ],
     "connectivity-service": [
         "errorlog: -",
-        "Worker with pid \\d+ was terminated due to signal",
     ],
-    "log_.*_minimal_": ["connect: Connection refused"],
 }
 
 # The next three variable declarations *must* be present as globals in the test

--- a/integtest/long_window_readout_test.py
+++ b/integtest/long_window_readout_test.py
@@ -60,9 +60,7 @@ ignored_logfile_problems = {
     ],
     "connectivity-service": [
         "errorlog: -",
-        "Worker with pid \\d+ was terminated due to signal 1",
     ],
-    "log_.*_longwindow_": ["connect: Connection refused"],
 }
 
 # Determine if the conditions are right for these tests

--- a/integtest/minimal_system_quick_test.py
+++ b/integtest/minimal_system_quick_test.py
@@ -66,9 +66,7 @@ ignored_logfile_problems = {
     ],
     "connectivity-service": [
         "errorlog: -",
-        "Worker with pid \\d+ was terminated due to signal",
     ],
-    "log_.*_minimal_": ["connect: Connection refused"],
 }
 
 # The next three variable declarations *must* be present as globals in the test

--- a/integtest/readout_type_scan.py
+++ b/integtest/readout_type_scan.py
@@ -101,9 +101,7 @@ ignored_logfile_problems = {
     ],
     "connectivity-service": [
         "errorlog: -",
-        "Worker with pid \\d+ was terminated due to signal 1",
     ],
-    "log_.*_readout_": ["connect: Connection refused"],
 }
 
 # The next three variable declarations *must* be present as globals in the test

--- a/integtest/small_footprint_quick_test.py
+++ b/integtest/small_footprint_quick_test.py
@@ -69,9 +69,7 @@ ignored_logfile_problems = {
     ],
     "connectivity-service": [
         "errorlog: -",
-        "Worker with pid \\d+ was terminated due to signal 1",
     ],
-    "log_.*_smallfootprint_": ["connect: Connection refused"],
 }
 
 # The next three variable declarations *must* be present as globals in the test

--- a/integtest/tpstream_writing_test.py
+++ b/integtest/tpstream_writing_test.py
@@ -90,9 +90,7 @@ ignored_logfile_problems = {
     ],
     "connectivity-service": [
         "errorlog: -",
-        "Worker with pid \\d+ was terminated due to signal 1",
     ],
-    "log_.*_tpstream_": ["connect: Connection refused"],
 }
 
 object_databases = ["config/daqsystemtest/integrationtest-objects.data.xml"]


### PR DESCRIPTION
Those problem strings were typically caused by the ConnectivityService shutting down before DAQ applications, and we don't do that for the integtests that have been modified.

I have re-run these integtests several times with these changes, and I haven't seen any problems, so my sense is that it is safe to remove these excluded strings.
