### PR TITLE
A few minor tweaks to reduce occasional failures in automated regression tests

### DIFF
--- a/integtest/3ru_1df_multirun_test.py
+++ b/integtest/3ru_1df_multirun_test.py
@@ -58,7 +58,7 @@ triggeractivity_frag_params = {
     "hdf5_source_subsystem": "Trigger",
     "expected_fragment_count": 1,
     "min_size_bytes": 72,
-    "max_size_bytes": 400,
+    "max_size_bytes": 504,
 }
 triggertp_frag_params = {
     "fragment_type_description": "Trigger with TPs",

--- a/integtest/3ru_1df_multirun_test.py
+++ b/integtest/3ru_1df_multirun_test.py
@@ -130,6 +130,12 @@ conf_dict.config_substitutions.append(
         obj_class="LatencyBuffer", updates={"size": 200000}
     )
 )
+conf_dict.config_substitutions.append(
+    data_classes.config_substitution(
+        obj_class="DFOConf",
+        updates={"busy_threshold": 3, "free_threshold": 2}
+    )
+)
 
 swtpg_conf = copy.deepcopy(conf_dict)
 swtpg_conf.tpg_enabled = True

--- a/integtest/example_system_test.py
+++ b/integtest/example_system_test.py
@@ -60,7 +60,7 @@ ignored_logfile_problems = {
         "Worker with pid \\d+ was terminated due to signal",
         r"Worker \(pid:\d+\) was sent SIGHUP"
     ],
-    "log_.*": ["connect: Connection refused"],
+    "log_.*": ["connect: Connection refused", "Connection reset by peer", "end of stream"],
 }
 
 # The arguments to pass to the config generator, excluding the json

--- a/integtest/tpstream_writing_test.py
+++ b/integtest/tpstream_writing_test.py
@@ -63,11 +63,11 @@ triggeractivity_frag_params = {
     "fragment_type": "Trigger_Activity",
     "expected_fragment_count": 1,
     "min_size_bytes": 72,
-    "max_size_bytes": 360,
+    "max_size_bytes": 504,
     "debug_mask": 0x0,
-    "frag_sizes_by_TC_type": {"kPrescale": {"min_size_bytes": 216, "max_size_bytes": 360},
+    "frag_sizes_by_TC_type": {"kPrescale": {"min_size_bytes": 216, "max_size_bytes": 504},
                                 "kRandom": {"min_size_bytes":  72, "max_size_bytes": 216},
-                                "default": {"min_size_bytes":  72, "max_size_bytes": 360} }
+                                "default": {"min_size_bytes":  72, "max_size_bytes": 504} }
 }
 triggerprimitive_frag_params = {
     "fragment_type_description": "Trigger Primitive",

--- a/integtest/tpstream_writing_test.py
+++ b/integtest/tpstream_writing_test.py
@@ -52,11 +52,11 @@ triggercandidate_frag_params = {
     "fragment_type": "Trigger_Candidate",
     "expected_fragment_count": 1,
     "min_size_bytes": 128,
-    "max_size_bytes": 208,
+    "max_size_bytes": 264,
     "debug_mask": 0x0,
-    "frag_sizes_by_TC_type": {"kPrescale": {"min_size_bytes": 208, "max_size_bytes": 208},
-                                "kRandom": {"min_size_bytes": 128, "max_size_bytes": 128},
-                                "default": {"min_size_bytes": 128, "max_size_bytes": 208} }
+    "frag_sizes_by_TC_type": {"kPrescale": {"min_size_bytes": 208, "max_size_bytes": 264},
+                                "kRandom": {"min_size_bytes": 128, "max_size_bytes": 264},
+                                "default": {"min_size_bytes": 128, "max_size_bytes": 264} }
 }
 triggeractivity_frag_params = {
     "fragment_type_description": "Trigger Activity",
@@ -66,7 +66,7 @@ triggeractivity_frag_params = {
     "max_size_bytes": 504,
     "debug_mask": 0x0,
     "frag_sizes_by_TC_type": {"kPrescale": {"min_size_bytes": 216, "max_size_bytes": 504},
-                                "kRandom": {"min_size_bytes":  72, "max_size_bytes": 216},
+                                "kRandom": {"min_size_bytes":  72, "max_size_bytes": 360},
                                 "default": {"min_size_bytes":  72, "max_size_bytes": 504} }
 }
 triggerprimitive_frag_params = {


### PR DESCRIPTION
These changes are responses to fairly rare problems that are observed in the automated regression tests in this repo.

The changes are the following:

1. In the `3ru_1df_multirun_test`, an increase in the maximum expected size of TriggerActivity fragments and an increase in the number of busy&free tokens.
    1. We have observed occasional upward fluctuations in the size of TA fragments (beyond the previous max expected size).  These are caused by cases in which there are three TAs inside the fragment, each with one TP inside of them.
        1. Fragment header size of 72 + 3 * (TA data size of 88 + TP data size of 56) = 504
        2. a readout window with three TAs in it is fairly rare, but clearly not impossible.  It is more typical to have one TA with one TP per readout window (i.e. one TriggerRecord).  This produces a TA fragment size of 216.  
        3. This change is not guaranteed to be the end of the story.  A TA could have two or three TPs referenced inside of it.  That means that a TA fragment size larger than 504 is technically possible.  But, for now, my sense is that we should wait until we see it before we make allowance for it.
    1. The increase is the configured number of busy&free tokens was motivated by occasional instances of trigger inhibits throughout data-taking runs (not just at the start). By looking at the timestamps of TriggerDecisions in those runs, I found that there were times when there were 3 TDs received by the DFO in a short time interval (less than 100 ms), and this random fluctuation in the typical interval between TDs would result in a brief trigger inhibit.  Increasing the values from 2 & 1 to 3 & 2 has reduced the occurrence of occasional trigger inhibits (none seen since this change was included).
2. In the `example_system_test`, we have observed several error messages that indicate that DAQ or control processes can't connect to the ConnectivityService at the end of the DAQ session.  The additions made here address a couple of those.
3. In the `tpstream_writer_test`, the changes were to increase the maximum expected sizes of TriggerCandidate and TriggerActivity fragments.
    1. For the TC fragments, we have occasionally seen complaints about sizes of 264.  This happens when there are two TCs in the fragment, one from a kRandom trigger and one from a kPrescale (TP-based) trigger.  
        1. The expected size in this case is (fragment header size of 72) + (the TC size for kRandom triggers of 56) + (the TC size for kPrescale of 56 plus the TA size of 80 [inside the kPrescale TC]) = 264
     1. The explanation for TA size of 504 is the same as 1.i above.
