### PR TITLE
Added an action plan for the start transition in the tc-maker applica…

### DIFF
--- a/config/daqsystemtest/moduleconfs.data.xml
+++ b/config/daqsystemtest/moduleconfs.data.xml
@@ -103,6 +103,15 @@
  </rel>
 </obj>
 
+<obj class="ActionPlan" id="tc-maker-start">
+ <attr name="execution_policy" type="enum" val="modules-in-series"/>
+ <rel name="command" class="FSMCommand" id="start"/>
+ <rel name="steps">
+  <ref class="DaqModulesGroupByType" id="ta-handler-step"/>
+  <ref class="DaqModulesGroupByType" id="subscriber-step"/>
+ </rel>
+</obj>
+
 <obj class="DFOConf" id="dfoconf-01">
  <attr name="general_queue_timeout_ms" type="u32" val="100"/>
  <attr name="stop_timeout_ms" type="u32" val="100"/>
@@ -141,6 +150,18 @@
 </obj>
 
 <obj class="DaqModulesGroupByType" id="tp-handler-step">
+ <attr name="modules" type="class">
+  <data val="TriggerDataHandlerModule"/>
+ </attr>
+</obj>
+
+<obj class="DaqModulesGroupByType" id="subscriber-step">
+ <attr name="modules" type="class">
+  <data val="DataSubscriberModule"/>
+ </attr>
+</obj>
+
+<obj class="DaqModulesGroupByType" id="ta-handler-step">
  <attr name="modules" type="class">
   <data val="TriggerDataHandlerModule"/>
  </attr>

--- a/config/daqsystemtest/trigger-segment.data.xml
+++ b/config/daqsystemtest/trigger-segment.data.xml
@@ -157,6 +157,9 @@
   <ref class="NetworkConnectionRule" id="tc-net-rule"/>
   <ref class="NetworkConnectionRule" id="data-req-trig-net-rule"/>
  </rel>
+ <rel name="action_plans">
+  <ref class="ActionPlan" id="tc-maker-start"/>
+ </rel>
  <rel name="data_subscriber" class="DataReaderConf" id="ta-subscriber-1"/>
  <rel name="trigger_inputs_handler" class="DataHandlerConf" id="def-ta-handler"/>
 </obj>


### PR DESCRIPTION
…tion to the generate.py script. This is to ensure that the TriggerDataHandlerModule is started before the DataSubscriberModule in that application. This is needed to avoid the situation in which the DSH starts sending TAs to the TDHM before the latter is ready to receive them. When it is  not ready to receive them, the queue between the two modules can fill up, and the DSH emits an error message, which we would like to avoid.

Background information:

- One of the remaining issues that we see in overnight automated regression tests is error messages in the tc-maker-1 log file complaining about the inability to push to the ta_input_ queue within the timeout period.  An example of this is [here](https://github.com/DUNE-DAQ/daq-release/actions/runs/13237473867/job/36945290974).  I believe that what happens is that the two modules in the tc-maker-1 process start in parallel, and some small fraction of the time, the receiver of the TAs starts up late enough (compared to the sender of the TAs) that the queue between the two modules fills up.  I believe that a straightforward fix is to use our ActionPlan technology to consistently ensure that the modules are started up in the "right" order, that is, the order that ensures that the receiver of data is started before the sender of the data.  This PR provides part of the changes to do that.

This PR is correlated with one in the daqconf repo ([PR 557](https://github.com/DUNE-DAQ/daqconf/pull/557)).

Here are steps to demonstrate the failure mode and demonstrate that the code changes in this PR help to eliminate the error.  These instructions locally modify a source code file in the datahandlinglibs repo so that the problematic situation happens all of the time instead of just occasionally.

```
DATE_PREFIX=`date '+%d%b'`
TIME_SUFFIX=`date '+%H%M'`

source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
setup_dbt latest_v5
dbt-create -n NFD_DEV_250212_A9 ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}
cd ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}/sourcecode

git clone https://github.com/DUNE-DAQ/appmodel.git -b develop
git clone https://github.com/DUNE-DAQ/daqconf.git -b develop
git clone https://github.com/DUNE-DAQ/daqsystemtest.git -b develop
git clone https://github.com/DUNE-DAQ/datahandlinglibs.git -b develop
git clone https://github.com/DUNE-DAQ/dfmodules.git -b develop
git clone https://github.com/DUNE-DAQ/fdreadoutlibs.git -b develop
git clone https://github.com/DUNE-DAQ/fdreadoutmodules.git -b develop
git clone https://github.com/DUNE-DAQ/trigger.git -b develop
cd ..

sed -i 's/m_consumer_thread.set_work(&\DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::run_consume/std::this_thread::sleep_for(std::chrono::milliseconds(80));\n    m_consumer_thread.set_work(\&DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::run_consume/' sourcecode/datahandlinglibs/include/datahandlinglibs/models/detail/DataHandlingModel.hxx

dbt-workarea-env
dbt-build -j 12
dbt-workarea-env

daqconf_set_connectivity_service_port local-1x1-config config/daqsystemtest/example-configs.data.xml

daqsystemtest_integtest_bundle.sh -f 6 -l 6 

cd sourcecode/daqsystemtest
git checkout kbiery/tc_maker_action_plan
cd ../daqconf
git checkout kbiery/tc_maker_action_plan
cd ../../

dbt-build -j 12
dbt-workarea-env

daqsystemtest_integtest_bundle.sh -f 6 -l 6 
```

Note that the first running of the 3ru_1df_multirun_test does not run cleanly while the second running works fine.

