### PR TITLE
small_footprint_quick_test had been set to show trigger issue #357, move

### DIFF
--- a/integtest/small_footprint_quick_test.py
+++ b/integtest/small_footprint_quick_test.py
@@ -11,8 +11,6 @@ pytest_plugins = "integrationtest.integrationtest_drunc"
 number_of_data_producers = 1
 data_rate_slowdown_factor = 1  # 10 for ProtoWIB/DuneWIB
 run_duration = 20  # seconds
-readout_window_time_before = 1000
-readout_window_time_after = 1001
 
 # Default values for validation parameters
 expected_number_of_data_files = 1
@@ -40,8 +38,8 @@ wibeth_frag_params = {
     "fragment_type": "WIBEth",
     "hdf5_source_subsystem": "Detector_Readout",
     "expected_fragment_count": number_of_data_producers,
-    "min_size_bytes": 7272,
-    "max_size_bytes": 14472,
+    "min_size_bytes": 14472,
+    "max_size_bytes": 21672,
 }
 triggercandidate_frag_params = {
     "fragment_type_description": "Trigger Candidate",
@@ -106,17 +104,7 @@ conf_dict.config_substitutions.append(
     )
 )
 
-conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
-        obj_class="TCReadoutMap",
-        updates={
-            "time_before": readout_window_time_before,
-            "time_after": readout_window_time_after,
-        },
-    )
-)
-
-confgen_arguments = {"MinimalSystem": conf_dict}
+confgen_arguments = {"SmallFootprint": conf_dict}
 # The commands to run in nanorc, as a list
 nanorc_command_list = (
     "boot conf start --run-number 101 wait 1 enable-triggers wait ".split()


### PR DESCRIPTION
that error-reporting integtest to trigger. Fixed
small_footprint_quick_test by removing smaller readout window (use default FakeHSI readout window defined in moduleconfs.data.xml).