### PR TITLE
Removed no-longer-needed ignored messages from example_system_test

### DIFF
--- a/integtest/example_system_test.py
+++ b/integtest/example_system_test.py
@@ -32,7 +32,7 @@ triggercandidate_frag_params = {
     "hdf5_source_subsystem": "Trigger",
     "expected_fragment_count": 1,
     "min_size_bytes": 128,
-    "max_size_bytes": 216,
+    "max_size_bytes": 264,
 }
 triggertp_frag_params = {
     "fragment_type_description": "Trigger with TPs",
@@ -60,7 +60,7 @@ ignored_logfile_problems = {
         "Worker with pid \\d+ was terminated due to signal",
         r"Worker \(pid:\d+\) was sent SIGHUP"
     ],
-    "log_.*": ["connect: Connection refused", "Connection reset by peer", "end of stream"],
+#    "log_.*": ["connect: Connection refused", "Connection reset by peer", "end of stream"],
 }
 
 # The arguments to pass to the config generator, excluding the json


### PR DESCRIPTION
Now that `drunc` stops the ConnSvc last at the end of each DAQ session, we expect that the DAQ processes will no longer complain about being unable to connect it.  So, I have removed the no-longer-needed "ignored error/warning messages" from the `example_system_test`.

Recall that the problem was that `drunc` had been stopping the ConnSvc first when shutting down a DAQ session.  When it did that, the DAQ processes (which were still running for some small amount of time) tried to talk to the ConnSvc as part of their usual publishing and retrieving of connection information, they were unable to do that, and they printed out error/warning messages.

Independent of all of that, I increased the maximum allowed size of TC fragments from 216 to 264 in the example_system_test.  This is a change that has been made in other integtests, and I saw the need to increase it here recently when running many instances of the example_system_test.

To validate these changes, I simply ran the example_system_test many times and verified that all of the runs were successful.