### PR TITLE
Removed the attempt_cleanup flag from the example_system_test so that…

### DIFF
--- a/integtest/example_system_test.py
+++ b/integtest/example_system_test.py
@@ -67,7 +67,6 @@ ignored_logfile_problems = {
 # output directory (the test framework handles that)
 
 common_config_obj = data_classes.drunc_config()
-common_config_obj.attempt_cleanup = True
 common_config_obj.op_env = "test"
 common_config_obj.config_db = (
     os.path.dirname(__file__) + "/../config/daqsystemtest/example-configs.data.xml"


### PR DESCRIPTION
… we can run it in parallel with other integtests.

At the moment, the cleanup that is done by the integrationtest infrastructure is fairly brute-force.  It just runs killall on gunicorn and drunc-controller processes.  At some point, we may want that to become more sophisticated, but for the moment, we'll just remove the attempt_cleanup request from the example_system_test.  We believe that this won't hurt anything since the cleanup of processes at the end of a DAQ session by drunc is quite reliable at the moment (so the integrationtest infrastructure doesn't need to do it).
