### PR TITLE
Tightened up the expected HSI fragment sizes in the two integtests wh…

### DIFF
--- a/integtest/example_system_test.py
+++ b/integtest/example_system_test.py
@@ -49,6 +49,8 @@ hsi_frag_params = {
     "expected_fragment_count": 1,
     "min_size_bytes": 72,
     "max_size_bytes": 100,
+    "frag_sizes_by_TC_type": {"kTiming": {"min_size_bytes": 100, "max_size_bytes": 100},
+                              "default": {"min_size_bytes":  72, "max_size_bytes":  72} }
 }
 ignored_logfile_problems = {
     "-controller": [

--- a/integtest/small_footprint_quick_test.py
+++ b/integtest/small_footprint_quick_test.py
@@ -54,7 +54,7 @@ hsi_frag_params = {
     "fragment_type": "Hardware_Signal",
     "hdf5_source_subsystem": "HW_Signals_Interface",
     "expected_fragment_count": 1,
-    "min_size_bytes": 72,
+    "min_size_bytes": 100,
     "max_size_bytes": 100,
 }
 ignored_logfile_problems = {


### PR DESCRIPTION
…ere it matters, small_footprint_quick_test and example_system_test.

These changes were prompted by the review of open unresolved Issues as part of preparing for v5.3.0+.  In particular, [dfmodules 256](https://github.com/DUNE-DAQ/dfmodules/issues/256) and daqsystemtest #29.

As reminders:

- several integtests in this repo explicitly require zero HSI fragments.  This is not an oversight, and these data file checks should not be removed, IMO.  It is worthwhile to confirm that something that should be missing is, in fact, not present in the data file.  As part of these changes, I confirmed that the min/max files sizes for HSI fragments in those tests are 72 and 100.  That is a very reasonable range in case we ever decide to add HSI fragments to those tests.
- the small_footprint_quick_test only uses kTiming triggers, and those triggers use the HSI, so all HSI fragments in that test should have non-empty size (size == 100).
- the example_system_test uses a mix of trigger types, and the HSI fragment sizes are specified appropriately for each type.
