### PR TITLE
Adding debug variables

### DIFF
--- a/config/daqsystemtest/ccm.data.xml
+++ b/config/daqsystemtest/ccm.data.xml
@@ -224,7 +224,7 @@
 
 <obj class="Variable" id="local-env-dunedaq-ers-debug-level">
  <attr name="name" type="string" val="DUNEDAQ_ERS_DEBUG_LEVEL"/>
- <attr name="value" type="string" val="0"/>
+ <attr name="value" type="string" val="-1"/>
 </obj>
 
 <obj class="VariableSet" id="ehn1-variables">

--- a/config/daqsystemtest/ccm.data.xml
+++ b/config/daqsystemtest/ccm.data.xml
@@ -224,7 +224,7 @@
 
 <obj class="Variable" id="local-env-dunedaq-ers-debug-level">
  <attr name="name" type="string" val="DUNEDAQ_ERS_DEBUG_LEVEL"/>
- <attr name="value" type="string" val="-1"/>
+ <attr name="value" type="string" val="0"/>
 </obj>
 
 <obj class="VariableSet" id="ehn1-variables">
@@ -245,6 +245,7 @@
   <ref class="Variable" id="local-env-ers-info"/>
   <ref class="Variable" id="local-env-ers-verb"/>
   <ref class="Variable" id="local-env-ers-warning"/>
+  <ref class="Variable" id="local-env-dunedaq-ers-debug-level"/>
  </rel>
 </obj>
 

--- a/config/daqsystemtest/ccm.data.xml
+++ b/config/daqsystemtest/ccm.data.xml
@@ -222,13 +222,8 @@
  <attr name="value" type="string" val="erstrace,throttle,lstdout"/>
 </obj>
 
-<obj class="Variable" id="local-env-tlog-debug">
+<obj class="Variable" id="local-env-dunedaq-ers-debug-level">
  <attr name="name" type="string" val="DUNEDAQ_ERS_DEBUG_LEVEL"/>
- <attr name="value" type="string" val="0"/>
-</obj>
-
-<obj class="Variable" id="trace-lvl">
- <attr name="name" type="string" val="TRACE_LVLS"/>
  <attr name="value" type="string" val="-1"/>
 </obj>
 

--- a/config/daqsystemtest/ccm.data.xml
+++ b/config/daqsystemtest/ccm.data.xml
@@ -63,7 +63,7 @@
 
 <oks-data>
 
-<info name="" type="" num-of-items="27" oks-format="data" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20231207T110859" last-modified-by="eflumerf" last-modified-on="ironvirt9.mshome.net" last-modification-time="20241120T175651"/>
+<info name="" type="" num-of-items="29" oks-format="data" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20231207T110859" last-modified-by="mrigan" last-modified-on="np04-srv-016.cern.ch" last-modification-time="20250312T105152"/>
 
 <include>
  <file path="schema/confmodel/dunedaq.schema.xml"/>
@@ -75,6 +75,7 @@
  <comment creation-time="20240208T094131" created-by="eflumerf" created-on="ironvirt9.mshome.net" author="eflumerf" text="reformat"/>
  <comment creation-time="20240909T081245" created-by="glehmann" created-on="np04-srv-024.cern.ch" author="glehmann" text=" "/>
  <comment creation-time="20240918T094920" created-by="maroda" created-on="np04-srv-015.cern.ch" author="maroda" text="add local file"/>
+ <comment creation-time="20250312T102000" created-by="mrigan" created-on="np04-srv-016.cern.ch" author="mrigan" text=" "/>
 </comments>
 
 
@@ -219,6 +220,16 @@
 <obj class="Variable" id="local-env-ers-warning">
  <attr name="name" type="string" val="DUNEDAQ_ERS_WARNING"/>
  <attr name="value" type="string" val="erstrace,throttle,lstdout"/>
+</obj>
+
+<obj class="Variable" id="local-env-tlog-debug">
+ <attr name="name" type="string" val="DUNEDAQ_ERS_DEBUG_LEVEL"/>
+ <attr name="value" type="string" val="0"/>
+</obj>
+
+<obj class="Variable" id="trace-lvl">
+ <attr name="name" type="string" val="TRACE_LVLS"/>
+ <attr name="value" type="string" val="-1"/>
 </obj>
 
 <obj class="VariableSet" id="ehn1-variables">

--- a/config/daqsystemtest/ccm.data.xml
+++ b/config/daqsystemtest/ccm.data.xml
@@ -222,7 +222,7 @@
  <attr name="value" type="string" val="erstrace,throttle,lstdout"/>
 </obj>
 
-<obj class="Variable" id="local-env-dunedaq-ers-debug-level">
+<obj class="Variable" id="local-env-ers-debug-level">
  <attr name="name" type="string" val="DUNEDAQ_ERS_DEBUG_LEVEL"/>
  <attr name="value" type="string" val="-1"/>
 </obj>
@@ -245,7 +245,7 @@
   <ref class="Variable" id="local-env-ers-info"/>
   <ref class="Variable" id="local-env-ers-verb"/>
   <ref class="Variable" id="local-env-ers-warning"/>
-  <ref class="Variable" id="local-env-dunedaq-ers-debug-level"/>
+  <ref class="Variable" id="local-env-ers-debug-level"/>
  </rel>
 </obj>
 

--- a/config/daqsystemtest/example-configs.data.xml
+++ b/config/daqsystemtest/example-configs.data.xml
@@ -144,6 +144,7 @@
   <ref class="Variable" id="local-env-ers-warning"/>
   <ref class="Variable" id="local-env-ers-error"/>
   <ref class="Variable" id="local-env-ers-fatal"/>
+  <ref class="Variable" id="local-env-dunedaq-ers-debug-level"/>
  </rel>
  <rel name="disabled">
   <ref class="DFApplication" id="df-02"/>

--- a/config/daqsystemtest/example-configs.data.xml
+++ b/config/daqsystemtest/example-configs.data.xml
@@ -144,7 +144,7 @@
   <ref class="Variable" id="local-env-ers-warning"/>
   <ref class="Variable" id="local-env-ers-error"/>
   <ref class="Variable" id="local-env-ers-fatal"/>
-  <ref class="Variable" id="local-env-dunedaq-ers-debug-level"/>
+  <ref class="Variable" id="local-env-ers-debug-level"/>
  </rel>
  <rel name="disabled">
   <ref class="DFApplication" id="df-02"/>


### PR DESCRIPTION
I find these variables useful when developing / debugging. 
Is there a reason they should not be part of the pre-defined set?