### PR TITLE
Modified the fragment_error_bit checks in integtests to skip Trigger fragments

### DIFF
--- a/integtest/3ru_1df_multirun_test.py
+++ b/integtest/3ru_1df_multirun_test.py
@@ -28,15 +28,7 @@ expected_event_count_tolerance = math.ceil(expected_event_count / 10)
 minimum_cpu_count = 18
 minimum_free_memory_gb = 24
 
-wibeth_frag_hsi_trig_params = {
-    "fragment_type_description": "WIBEth",
-    "fragment_type": "WIBEth",
-    "hdf5_source_subsystem": "Detector_Readout",
-    "expected_fragment_count": (number_of_data_producers * number_of_readout_apps),
-    "min_size_bytes": 7272,
-    "max_size_bytes": 14472,
-}
-wibeth_frag_multi_trig_params = {
+wibeth_frag_params = {
     "fragment_type_description": "WIBEth",
     "fragment_type": "WIBEth",
     "hdf5_source_subsystem": "Detector_Readout",
@@ -228,7 +220,7 @@ def test_data_files(run_nanorc):
 
     local_expected_event_count = expected_event_count
     local_event_count_tolerance = expected_event_count_tolerance
-    fragment_check_list = [triggercandidate_frag_params, hsi_frag_params]
+    fragment_check_list = [triggercandidate_frag_params, hsi_frag_params, wibeth_frag_params]
     if run_nanorc.confgen_config.tpg_enabled:
         local_expected_event_count += (
             (6250 / ta_prescale)
@@ -244,15 +236,8 @@ def test_data_files(run_nanorc):
             * run_duration
             / 100
         )
-        # fragment_check_list.append(wib1_frag_multi_trig_params) # ProtoWIB
-        # fragment_check_list.append(wib2_frag_multi_trig_params) # DuneWIB
-        fragment_check_list.append(wibeth_frag_multi_trig_params)  # WIBEth
         fragment_check_list.append(triggertp_frag_params)
         fragment_check_list.append(triggeractivity_frag_params)
-    else:
-        # fragment_check_list.append(wib1_frag_hsi_trig_params) # ProtoWIB
-        # fragment_check_list.append(wib2_frag_hsi_trig_params) # DuneWIB
-        fragment_check_list.append(wibeth_frag_hsi_trig_params)  # WIBEth
 
     # Run some tests on the output data file
     assert len(run_nanorc.data_files) == expected_number_of_data_files

--- a/integtest/3ru_3df_multirun_test.py
+++ b/integtest/3ru_3df_multirun_test.py
@@ -26,15 +26,7 @@ check_for_logfile_errors = True
 expected_event_count = run_duration * trigger_rate / number_of_dataflow_apps
 expected_event_count_tolerance = expected_event_count / 10
 
-wibeth_frag_hsi_trig_params = {
-    "fragment_type_description": "WIBEth",
-    "fragment_type": "WIBEth",
-    "hdf5_source_subsystem": "Detector_Readout",
-    "expected_fragment_count": (number_of_data_producers * number_of_readout_apps),
-    "min_size_bytes": 7272,
-    "max_size_bytes": 14472,
-}
-wibeth_frag_multi_trig_params = {
+wibeth_frag_params = {
     "fragment_type_description": "WIBEth",
     "fragment_type": "WIBEth",
     "hdf5_source_subsystem": "Detector_Readout",
@@ -182,7 +174,7 @@ def test_data_files(run_nanorc):
     local_event_count_tolerance = expected_event_count_tolerance
     low_number_of_files = expected_number_of_data_files
     high_number_of_files = expected_number_of_data_files
-    fragment_check_list = [triggercandidate_frag_params, hsi_frag_params]
+    fragment_check_list = [triggercandidate_frag_params, hsi_frag_params, wibeth_frag_params]
     if run_nanorc.confgen_config.tpg_enabled:
         local_expected_event_count += (
             (6250 / ta_prescale)
@@ -198,16 +190,13 @@ def test_data_files(run_nanorc):
             * run_duration
             / (100 * number_of_dataflow_apps)
         )
-        # fragment_check_list.append(wib2_frag_multi_trig_params) # DuneWIB
-        fragment_check_list.append(wibeth_frag_multi_trig_params)  # WIBEth
         fragment_check_list.append(triggertp_frag_params)
         fragment_check_list.append(triggeractivity_frag_params)
     else:
         low_number_of_files -= number_of_dataflow_apps
         if low_number_of_files < 1:
             low_number_of_files = 1
-        # fragment_check_list.append(wib2_frag_hsi_trig_params) # DuneWIB
-        fragment_check_list.append(wibeth_frag_hsi_trig_params)  # WIBEth
+    nontrig_fragment_check_list = [hsi_frag_params, wibeth_frag_params]
 
     # Run some tests on the output data file
     assert (
@@ -230,5 +219,6 @@ def test_data_files(run_nanorc):
             all_ok &= data_file_checks.check_fragment_sizes(
                 data_file, fragment_check_list[jdx]
             )
-            all_ok &= data_file_checks.check_fragment_error_flags( data_file, fragment_check_list[jdx])
+        for kdx in range(len(nontrig_fragment_check_list)):
+            all_ok &= data_file_checks.check_fragment_error_flags( data_file, nontrig_fragment_check_list[kdx])
     assert all_ok

--- a/integtest/minimal_system_quick_test.py
+++ b/integtest/minimal_system_quick_test.py
@@ -19,22 +19,6 @@ expected_number_of_data_files = 1
 check_for_logfile_errors = True
 expected_event_count = run_duration
 expected_event_count_tolerance = 2
-wib1_frag_hsi_trig_params = {
-    "fragment_type_description": "WIB",
-    "fragment_type": "ProtoWIB",
-    "hdf5_source_subsystem": "Detector_Readout",
-    "expected_fragment_count": number_of_data_producers,
-    "min_size_bytes": 37656,
-    "max_size_bytes": 37656,
-}
-wib2_frag_params = {
-    "fragment_type_description": "WIB2",
-    "fragment_type": "WIB",
-    "hdf5_source_subsystem": "Detector_Readout",
-    "expected_fragment_count": number_of_data_producers,
-    "min_size_bytes": 29808,
-    "max_size_bytes": 30280,
-}
 wibeth_frag_params = {
     "fragment_type_description": "WIBEth",
     "fragment_type": "WIBEth",
@@ -154,9 +138,8 @@ def test_data_files(run_nanorc):
     assert len(run_nanorc.data_files) == expected_number_of_data_files
 
     fragment_check_list = [triggercandidate_frag_params, hsi_frag_params]
-    # fragment_check_list.append(wib1_frag_hsi_trig_params) # ProtoWIB
-    # fragment_check_list.append(wib2_frag_params) # DuneWIB
-    fragment_check_list.append(wibeth_frag_params)  # WIBEth
+    fragment_check_list.append(wibeth_frag_params)
+    nontrig_fragment_check_list = [hsi_frag_params, wibeth_frag_params]
 
     all_ok = True
     for idx in range(len(run_nanorc.data_files)):
@@ -173,6 +156,7 @@ def test_data_files(run_nanorc):
             all_ok &= data_file_checks.check_fragment_sizes(
                 data_file, fragment_check_list[jdx]
             )
-            all_ok &= data_file_checks.check_fragment_error_flags( data_file, fragment_check_list[jdx])
+        for kdx in range(len(nontrig_fragment_check_list)):
+            all_ok &= data_file_checks.check_fragment_error_flags( data_file, nontrig_fragment_check_list[kdx])
 
     assert all_ok


### PR DESCRIPTION
These changes were made in the spirit of a compromise that allows us to move forward with fragment-error-bit checking, but not have integtests always failing because TriggerCandidate fragments always have the kIncomplete bit set.  

This has been discussed in the 12-Feb Core Software meeting, and it Slack messages in the daq-release-preparation channel on 17-Mar.

I also did a little cleanup in a few integtests, removing stale code.
