### PR TITLE
Removed the obsolete hdf5_source_subsystem parameter from integtest file checking.

### DIFF
--- a/integtest/3ru_1df_multirun_test.py
+++ b/integtest/3ru_1df_multirun_test.py
@@ -31,7 +31,6 @@ minimum_free_memory_gb = 24
 wibeth_frag_params = {
     "fragment_type_description": "WIBEth",
     "fragment_type": "WIBEth",
-    "hdf5_source_subsystem": "Detector_Readout",
     "expected_fragment_count": (number_of_data_producers * number_of_readout_apps),
     "min_size_bytes": 7272,
     "max_size_bytes": 14472,
@@ -77,7 +76,6 @@ triggerprimitive_frag_params = {
 hsi_frag_params = {
     "fragment_type_description": "HSI",
     "fragment_type": "Hardware_Signal",
-    "hdf5_source_subsystem": "HW_Signals_Interface",
     "expected_fragment_count": 0,
     "min_size_bytes": 72,
     "max_size_bytes": 100,

--- a/integtest/3ru_3df_multirun_test.py
+++ b/integtest/3ru_3df_multirun_test.py
@@ -29,7 +29,6 @@ expected_event_count_tolerance = expected_event_count / 10
 wibeth_frag_params = {
     "fragment_type_description": "WIBEth",
     "fragment_type": "WIBEth",
-    "hdf5_source_subsystem": "Detector_Readout",
     "expected_fragment_count": (number_of_data_producers * number_of_readout_apps),
     "min_size_bytes": 7272,
     "max_size_bytes": 14472,
@@ -75,7 +74,6 @@ triggerprimitive_frag_params = {
 hsi_frag_params = {
     "fragment_type_description": "HSI",
     "fragment_type": "Hardware_Signal",
-    "hdf5_source_subsystem": "HW_Signals_Interface",
     "expected_fragment_count": 0,
     "min_size_bytes": 72,
     "max_size_bytes": 100,

--- a/integtest/example_system_test.py
+++ b/integtest/example_system_test.py
@@ -21,7 +21,6 @@ hostname = os.uname().nodename
 wibeth_frag_params = {
     "fragment_type_description": "WIBEth",
     "fragment_type": "WIBEth",
-    "hdf5_source_subsystem": "Detector_Readout",
     "expected_fragment_count": 0,  # determined later
     "min_size_bytes": 7272,
     "max_size_bytes": 21672,
@@ -52,7 +51,6 @@ triggerprimitive_frag_params = {
 hsi_frag_params = {
     "fragment_type_description": "HSI",
     "fragment_type": "Hardware_Signal",
-    "hdf5_source_subsystem": "HW_Signals_Interface",
     "expected_fragment_count": 1,
     "min_size_bytes": 72,
     "max_size_bytes": 100,

--- a/integtest/fake_data_producer_test.py
+++ b/integtest/fake_data_producer_test.py
@@ -32,7 +32,6 @@ expected_event_count_tolerance = 2
 wibeth_frag_params = {
     "fragment_type_description": "WIBEth",
     "fragment_type": "WIBEth",
-    "hdf5_source_subsystem": "Detector_Readout",
     "expected_fragment_count": number_of_data_producers,
     "min_size_bytes": baseline_fragment_size_bytes,
     "max_size_bytes": baseline_fragment_size_bytes_max,

--- a/integtest/long_window_readout_test.py
+++ b/integtest/long_window_readout_test.py
@@ -39,7 +39,6 @@ expected_event_count_tolerance = 9
 wibeth_frag_params = {
     "fragment_type_description": "WIBEth",
     "fragment_type": "WIBEth",
-    "hdf5_source_subsystem": "Detector_Readout",
     "expected_fragment_count": number_of_data_producers * number_of_readout_apps,
     "min_size_bytes": 1764072,
     "max_size_bytes": 1771272,
@@ -47,7 +46,6 @@ wibeth_frag_params = {
 triggercandidate_frag_params = {
     "fragment_type_description": "Trigger Candidate",
     "fragment_type": "Trigger_Candidate",
-    "hdf5_source_subsystem": "Trigger",
     "expected_fragment_count": 1,
     "min_size_bytes": 72,
     "max_size_bytes": 216,

--- a/integtest/minimal_system_quick_test.py
+++ b/integtest/minimal_system_quick_test.py
@@ -22,7 +22,6 @@ expected_event_count_tolerance = 2
 wibeth_frag_params = {
     "fragment_type_description": "WIBEth",
     "fragment_type": "WIBEth",
-    "hdf5_source_subsystem": "Detector_Readout",
     "expected_fragment_count": number_of_data_producers,
     "min_size_bytes": 7272,
     "max_size_bytes": 14472,
@@ -30,7 +29,6 @@ wibeth_frag_params = {
 triggercandidate_frag_params = {
     "fragment_type_description": "Trigger Candidate",
     "fragment_type": "Trigger_Candidate",
-    "hdf5_source_subsystem": "Trigger",
     "expected_fragment_count": 1,
     "min_size_bytes": 128,
     "max_size_bytes": 216,
@@ -38,7 +36,6 @@ triggercandidate_frag_params = {
 hsi_frag_params = {
     "fragment_type_description": "HSI",
     "fragment_type": "Hardware_Signal",
-    "hdf5_source_subsystem": "HW_Signals_Interface",
     "expected_fragment_count": 0,
     "min_size_bytes": 72,
     "max_size_bytes": 100,

--- a/integtest/readout_type_scan.py
+++ b/integtest/readout_type_scan.py
@@ -28,7 +28,6 @@ expected_event_count_tolerance = 2
 wibeth_frag_params = {
     "fragment_type_description": "WIBEth",
     "fragment_type": "WIBEth",
-    "hdf5_source_subsystem": "Detector_Readout",
     "expected_fragment_count": number_of_data_producers,
     "min_size_bytes": 7272,
     "max_size_bytes": 14472,
@@ -36,7 +35,6 @@ wibeth_frag_params = {
 wibeth_frag_multi_trig_params = {
     "fragment_type_description": "WIBEth",
     "fragment_type": "WIBEth",
-    "hdf5_source_subsystem": "Detector_Readout",
     "expected_fragment_count": number_of_data_producers,
     "min_size_bytes": 7272,
     "max_size_bytes": 14472,
@@ -44,7 +42,6 @@ wibeth_frag_multi_trig_params = {
 tde_frag_params = {
     "fragment_type_description": "TDEEth",
     "fragment_type": "TDEEth",
-    "hdf5_source_subsystem": "Detector_Readout",
     "expected_fragment_count": number_of_data_producers,
     "min_size_bytes": 7272,
     "max_size_bytes": 14472,
@@ -57,7 +54,6 @@ tde_frag_params = {
 pds_stream_frag_params = {
     "fragment_type_description": "PDSStream",
     "fragment_type": "DAPHNEStream",
-    "hdf5_source_subsystem": "Detector_Readout",
     "expected_fragment_count": number_of_data_producers,
     "min_size_bytes": 72+461026-20*472,
     "max_size_bytes": 72+461026+20*472,
@@ -65,7 +61,6 @@ pds_stream_frag_params = {
 pds_frag_params = {
     "fragment_type_description": "PDS",
     "fragment_type": "DAPHNE",
-    "hdf5_source_subsystem": "Detector_Readout",
     "expected_fragment_count": number_of_data_producers,
     "min_size_bytes": 435912,
     "max_size_bytes": 1133256,

--- a/integtest/small_footprint_quick_test.py
+++ b/integtest/small_footprint_quick_test.py
@@ -20,7 +20,6 @@ expected_event_count_tolerance = 2
 wib1_frag_hsi_trig_params = {
     "fragment_type_description": "WIB",
     "fragment_type": "ProtoWIB",
-    "hdf5_source_subsystem": "Detector_Readout",
     "expected_fragment_count": number_of_data_producers,
     "min_size_bytes": 37656,
     "max_size_bytes": 37656,
@@ -28,7 +27,6 @@ wib1_frag_hsi_trig_params = {
 wib2_frag_params = {
     "fragment_type_description": "WIB2",
     "fragment_type": "WIB",
-    "hdf5_source_subsystem": "Detector_Readout",
     "expected_fragment_count": number_of_data_producers,
     "min_size_bytes": 29808,
     "max_size_bytes": 30280,
@@ -36,7 +34,6 @@ wib2_frag_params = {
 wibeth_frag_params = {
     "fragment_type_description": "WIBEth",
     "fragment_type": "WIBEth",
-    "hdf5_source_subsystem": "Detector_Readout",
     "expected_fragment_count": number_of_data_producers,
     "min_size_bytes": 14472,
     "max_size_bytes": 21672,
@@ -44,7 +41,6 @@ wibeth_frag_params = {
 triggercandidate_frag_params = {
     "fragment_type_description": "Trigger Candidate",
     "fragment_type": "Trigger_Candidate",
-    "hdf5_source_subsystem": "Trigger",
     "expected_fragment_count": 1,
     "min_size_bytes": 128,
     "max_size_bytes": 216,
@@ -52,7 +48,6 @@ triggercandidate_frag_params = {
 hsi_frag_params = {
     "fragment_type_description": "HSI",
     "fragment_type": "Hardware_Signal",
-    "hdf5_source_subsystem": "HW_Signals_Interface",
     "expected_fragment_count": 1,
     "min_size_bytes": 100,
     "max_size_bytes": 100,


### PR DESCRIPTION
This parameter used to be used as part of identifying specific HDF DataSets (dunedaq data fragments) when the code verified that the expected fragments were present in TriggerRecords, etc.  However, the parameter has been obsolete for quite some time, so I wanted to clean up the code a little and remove them.  My tests show that all daqsystem regression tests still run successfully, but of course, it would be great to someone else to verify that.