### PR TITLE
Cleaned up a few integration tests and improved some variable names in the bundle script.

### DIFF
--- a/integtest/3ru_1df_multirun_test.py
+++ b/integtest/3ru_1df_multirun_test.py
@@ -254,17 +254,19 @@ def test_data_files(run_nanorc):
     # Run some tests on the output data file
     assert len(run_nanorc.data_files) == expected_number_of_data_files
 
+    all_ok = True
     for idx in range(len(run_nanorc.data_files)):
         data_file = data_file_checks.DataFile(run_nanorc.data_files[idx])
-        assert data_file_checks.sanity_check(data_file)
-        assert data_file_checks.check_file_attributes(data_file)
-        assert data_file_checks.check_event_count(
+        all_ok &= data_file_checks.sanity_check(data_file)
+        all_ok &= data_file_checks.check_file_attributes(data_file)
+        all_ok &= data_file_checks.check_event_count(
             data_file, local_expected_event_count, local_event_count_tolerance
         )
         for jdx in range(len(fragment_check_list)):
-            assert data_file_checks.check_fragment_count(
+            all_ok &= data_file_checks.check_fragment_count(
                 data_file, fragment_check_list[jdx]
             )
-            assert data_file_checks.check_fragment_sizes(
+            all_ok &= data_file_checks.check_fragment_sizes(
                 data_file, fragment_check_list[jdx]
             )
+    assert all_ok

--- a/integtest/fake_data_producer_test.py
+++ b/integtest/fake_data_producer_test.py
@@ -143,8 +143,6 @@ def test_log_files(run_nanorc):
 def test_data_files(run_nanorc):
     local_expected_event_count = expected_event_count
     local_event_count_tolerance = expected_event_count_tolerance
-    # frag_params=wib1_frag_hsi_trig_params # ProtoWIB
-    # frag_params=wib2_frag_params # DuneWIB
     frag_params = wibeth_frag_params
     current_test = os.environ.get("PYTEST_CURRENT_TEST")
     if "Double" in current_test:

--- a/integtest/small_footprint_quick_test.py
+++ b/integtest/small_footprint_quick_test.py
@@ -17,20 +17,6 @@ expected_number_of_data_files = 1
 check_for_logfile_errors = True
 expected_event_count = run_duration
 expected_event_count_tolerance = 2
-wib1_frag_hsi_trig_params = {
-    "fragment_type_description": "WIB",
-    "fragment_type": "ProtoWIB",
-    "expected_fragment_count": number_of_data_producers,
-    "min_size_bytes": 37656,
-    "max_size_bytes": 37656,
-}
-wib2_frag_params = {
-    "fragment_type_description": "WIB2",
-    "fragment_type": "WIB",
-    "expected_fragment_count": number_of_data_producers,
-    "min_size_bytes": 29808,
-    "max_size_bytes": 30280,
-}
 wibeth_frag_params = {
     "fragment_type_description": "WIBEth",
     "fragment_type": "WIBEth",
@@ -128,21 +114,21 @@ def test_data_files(run_nanorc):
     assert len(run_nanorc.data_files) == expected_number_of_data_files
 
     fragment_check_list = [triggercandidate_frag_params, hsi_frag_params]
-    # fragment_check_list.append(wib1_frag_hsi_trig_params) # ProtoWIB
-    # fragment_check_list.append(wib2_frag_params) # DuneWIB
     fragment_check_list.append(wibeth_frag_params)  # WIBEth
 
+    all_ok = True
     for idx in range(len(run_nanorc.data_files)):
         data_file = data_file_checks.DataFile(run_nanorc.data_files[idx])
-        assert data_file_checks.sanity_check(data_file)
-        assert data_file_checks.check_file_attributes(data_file)
-        assert data_file_checks.check_event_count(
+        all_ok &= data_file_checks.sanity_check(data_file)
+        all_ok &= data_file_checks.check_file_attributes(data_file)
+        all_ok &= data_file_checks.check_event_count(
             data_file, expected_event_count, expected_event_count_tolerance
         )
         for jdx in range(len(fragment_check_list)):
-            assert data_file_checks.check_fragment_count(
+            all_ok &= data_file_checks.check_fragment_count(
                 data_file, fragment_check_list[jdx]
             )
-            assert data_file_checks.check_fragment_sizes(
+            all_ok &= data_file_checks.check_fragment_sizes(
                 data_file, fragment_check_list[jdx]
             )
+    assert all_ok

--- a/integtest/tpstream_writing_test.py
+++ b/integtest/tpstream_writing_test.py
@@ -230,20 +230,22 @@ def test_data_files(run_nanorc):
         or len(run_nanorc.data_files) == low_number_of_files
     )
 
+    all_ok = True
     for idx in range(len(run_nanorc.data_files)):
         data_file = data_file_checks.DataFile(run_nanorc.data_files[idx])
-        assert data_file_checks.sanity_check(data_file)
-        assert data_file_checks.check_file_attributes(data_file)
-        assert data_file_checks.check_event_count(
+        all_ok &= data_file_checks.sanity_check(data_file)
+        all_ok &= data_file_checks.check_file_attributes(data_file)
+        all_ok &= data_file_checks.check_event_count(
             data_file, local_expected_event_count, local_event_count_tolerance
         )
         for jdx in range(len(fragment_check_list)):
-            assert data_file_checks.check_fragment_count(
+            all_ok &= data_file_checks.check_fragment_count(
                 data_file, fragment_check_list[jdx]
             )
-            assert data_file_checks.check_fragment_sizes(
+            all_ok &= data_file_checks.check_fragment_sizes(
                 data_file, fragment_check_list[jdx]
             )
+    assert all_ok
 
 
 def test_tpstream_files(run_nanorc):
@@ -256,17 +258,19 @@ def test_tpstream_files(run_nanorc):
 
     assert len(tpstream_files) == 2  # one for each run
 
+    all_ok = True
     for idx in range(len(tpstream_files)):
         data_file = data_file_checks.DataFile(tpstream_files[idx])
-        # assert data_file_checks.sanity_check(data_file) # Sanity check doesn't work for stream files
-        assert data_file_checks.check_file_attributes(data_file)
-        assert data_file_checks.check_event_count(
+        # all_ok &= data_file_checks.sanity_check(data_file) # Sanity check doesn't work for stream files
+        all_ok &= data_file_checks.check_file_attributes(data_file)
+        all_ok &= data_file_checks.check_event_count(
             data_file, local_expected_event_count, local_event_count_tolerance
         )
         for jdx in range(len(fragment_check_list)):
-            assert data_file_checks.check_fragment_count(
+            all_ok &= data_file_checks.check_fragment_count(
                 data_file, fragment_check_list[jdx]
             )
-            assert data_file_checks.check_fragment_sizes(
+            all_ok &= data_file_checks.check_fragment_sizes(
                 data_file, fragment_check_list[jdx]
             )
+    assert all_ok

--- a/scripts/daqsystemtest_integtest_bundle.sh
+++ b/scripts/daqsystemtest_integtest_bundle.sh
@@ -2,6 +2,7 @@
 # 10-Oct-2023, KAB
 
 integtest_list=( "minimal_system_quick_test.py" "readout_type_scan.py" "3ru_3df_multirun_test.py" "small_footprint_quick_test.py" "fake_data_producer_test.py" "long_window_readout_test.py" "3ru_1df_multirun_test.py" "tpstream_writing_test.py" "example_system_test.py" )
+let last_test_index=${#integtest_list[@]}-1
 
 usage() {
     declare -r script_name=$(basename "$0")
@@ -12,7 +13,7 @@ Usage:
 Options:
     -h, --help : prints out usage information
     -f <zero-based index of the first test to be run, default=0>
-    -l <zero-based index of the last test to be run, default=999>
+    -l <zero-based index of the last test to be run, default=${last_test_index}>
     -n <number of times to run each individual test, default=1>
     -N <number of times to run the full set of selected tests, default=1>
     --stop-on-failure : causes the script to stop when one of the integtests reports a failure
@@ -30,9 +31,8 @@ TEMP=`getopt -o hs:f:l:n:N: --long help,stop-on-failure -- "$@"`
 eval set -- "$TEMP"
 
 let first_test_index=0
-let last_test_index=${#integtest_list[@]}-1
-let individual_run_count=1
-let overall_run_count=1
+let individual_test_requested_iterations=1
+let full_set_requested_interations=1
 let stop_on_failure=0
 
 while true; do
@@ -50,11 +50,11 @@ while true; do
             shift 2
             ;;
         -n)
-            let individual_run_count=$2
+            let individual_test_requested_iterations=$2
             shift 2
             ;;
         -N)
-            let overall_run_count=$2
+            let full_set_requested_interations=$2
             shift 2
             ;;
         --stop-on-failure)
@@ -83,18 +83,18 @@ fi
 TIMESTAMP=`date '+%Y%m%d%H%M%S'`
 mkdir -p /tmp/pytest-of-${USER}
 ITGRUNNER_LOG_FILE="/tmp/pytest-of-${USER}/daqsystemtest_integtest_bundle_${TIMESTAMP}.log"
-let total_number_of_tests=(1+${last_test_index}-${first_test_index})*${individual_run_count}*${overall_run_count}
+let total_number_of_tests=(1+${last_test_index}-${first_test_index})*${individual_test_requested_iterations}*${full_set_requested_interations}
 
 # run the tests
 let overall_test_index=0  # this is only used for user feedback
-let overall_loop_count=0
-while [[ ${overall_loop_count} -lt ${overall_run_count} ]]; do
+let full_set_loop_count=0
+while [[ ${full_set_loop_count} -lt ${full_set_requested_interations} ]]; do
   let test_index=0
   for TEST_NAME in ${integtest_list[@]}; do
     if [[ ${test_index} -ge ${first_test_index} && ${test_index} -le ${last_test_index} ]]; then
 
       let individual_loop_count=0
-      while [[ ${individual_loop_count} -lt ${individual_run_count} ]]; do
+      while [[ ${individual_loop_count} -lt ${individual_test_requested_iterations} ]]; do
         let overall_test_index=${overall_test_index}+1
         echo ""
         echo -e "\U0001F535 \033[0;34mStarting test ${overall_test_index} of ${total_number_of_tests}...\033[0m \U0001F535" | tee -a ${ITGRUNNER_LOG_FILE}
@@ -126,7 +126,7 @@ while [[ ${overall_loop_count} -lt ${overall_run_count} ]]; do
     let test_index=${test_index}+1
   done
 
-  let overall_loop_count=${overall_loop_count}+1
+  let full_set_loop_count=${full_set_loop_count}+1
 done
 
 # print out summary information


### PR DESCRIPTION
One of the goals for the integration/regression tests in this package has been to make improvements consistently in all of them (not just some of them).  

One of the recent improvements is to run **_all_** data_file_checks before aborting the test, if there are errors found.

This PR consistently applies that particular improvement to all of the integtests.

Another change is to improve the naming of a couple of the variables in the bundle script to make their meaning more clear.  (This came about when I tried to copy the current state of the `daqsystemtest` bundle script to the `dfmodules` bundle script and realized that these names could be improved.)

I'm hopeful that these changes can be made both for an upcoming patch release and on the `develop` branch.  (this PR is targeted to the patch branch)

Here are suggested steps for validating these changes:
```
DATE_PREFIX=`date '+%d%b'`
TIME_SUFFIX=`date '+%H%M'`

source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
setup_dbt fddaq-v5.3.1
dbt-create fddaq-v5.3.1-a9 ${DATE_PREFIX}FDv5.3.2Dev_${TIME_SUFFIX}
cd ${DATE_PREFIX}FDv5.3.2Dev_${TIME_SUFFIX}/sourcecode

git clone https://github.com/DUNE-DAQ/daqsystemtest.git -b kbiery/integtest_cleanup
cd ..

dbt-workarea-env
git clone https://github.com/DUNE-DAQ/drunc.git -b patch/fddaq-v5.3.x
cd drunc ; pip install -U . ; cd ..
dbt-build -j 12
dbt-workarea-env

daqsystemtest_integtest_bundle.sh --stop-on-fail
```
