### PR TITLE
A quick fix for recent occasional failures in the long_window_readout_test

### DIFF
--- a/integtest/long_window_readout_test.py
+++ b/integtest/long_window_readout_test.py
@@ -304,17 +304,17 @@ def test_cleanup(run_nanorc):
             pathlist_string += " " + str(data_file.parent)
 
     if pathlist_string and filelist_string:
-        print("============================================")
-        print("Listing the hdf5 files before deleting them:")
-        print("============================================")
+        print("============================================", flush=True)
+        print("Listing the hdf5 files before deleting them:", flush=True)
+        print("============================================", flush=True)
 
         os.system(f"df -h {pathlist_string}")
-        print("--------------------")
+        print("--------------------", flush=True)
         os.system(f"ls -alF {filelist_string}")
 
         for data_file in run_nanorc.data_files:
             data_file.unlink()
 
-        print("--------------------")
+        print("--------------------", flush=True)
         os.system(f"df -h {pathlist_string}")
-        print("============================================")
+        print("============================================", flush=True)

--- a/integtest/long_window_readout_test.py
+++ b/integtest/long_window_readout_test.py
@@ -178,14 +178,14 @@ if sufficient_disk_space and sufficient_resources_on_this_computer:
     nanorc_command_list += (
         "start --trigger-rate ".split()
         + [str(trigger_rate)]
-        + "--run-number 101 wait 15 enable-triggers wait ".split()
+        + "--run-number 101 wait 10 enable-triggers wait ".split()
         + [str(run_duration)]
         + "disable-triggers wait 2 drain-dataflow wait 2 stop-trigger-sources stop wait 2".split()
     )
     nanorc_command_list += (
         "start --trigger-rate ".split()
         + [str(trigger_rate)]
-        + "--run-number 102 wait 15 enable-triggers wait ".split()
+        + "--run-number 102 wait 10 enable-triggers wait ".split()
         + [str(run_duration)]
         + "disable-triggers wait 2 drain-dataflow wait 2 stop-trigger-sources stop wait 2".split()
     )


### PR DESCRIPTION
After `fddaq-v5.3.2-rc1` was cut, several people noticed failures when running the `long_window_readout_test` (a regression test in this repo).  

The error messages included complaints about `TriggerDecision 3 didn't complete within timeout in run 101` and `DFOModule encountered run number mismatch: recvd (101) != 102 from TRB at connection trigger_decision_df-01 for trigger_number 3`.

After a little investigation, I remembered that the data-taking runs in the LWR test should only have 2 TriggerRecords.  And, when I looked at the trigger times versus the time window when triggers were enabled, I saw that there was an opportunity for 3 triggers at 0.05 Hz to sneak in during a 40 second run.  

A quick fix was to change the timing of the enabled-trigger window a little bit so that it is very unlikely to allow three triggers to occur.  That is part of this PR.

Additional investigation is needed to understand why the time between triggers in the current DAQ code is not reliably 20 seconds for a 0.05 Hz trigger rate.  It _was_ reliable in earlier versions of the code, and it is not yet clear what changed.

An additional change that was made in this PR was to add "flush=True" arguments to the print statements in the LWR test cleanup routine so that they get interleaved correctly with the "os" calls that are also in that routine.

With these changes, I have run this test 10+ times and not seen any failures.