### PR TITLE
Added an option (-k) to the bundle script to allow users to specify a…

### DIFF
--- a/scripts/daqsystemtest_integtest_bundle.sh
+++ b/scripts/daqsystemtest_integtest_bundle.sh
@@ -14,6 +14,7 @@ Options:
     -h, --help : prints out usage information
     -f <zero-based index of the first test to be run, default=0>
     -l <zero-based index of the last test to be run, default=${last_test_index}>
+    -k <pipe-delimited string to select which tests will be run ('egrep -i' match to test name)>
     -n <number of times to run each individual test, default=1>
     -N <number of times to run the full set of selected tests, default=1>
     --stop-on-failure : causes the script to stop when one of the integtests reports a failure
@@ -27,13 +28,14 @@ Options:
     echo ""
 }
 
-TEMP=`getopt -o hs:f:l:n:N: --long help,stop-on-failure -- "$@"`
+TEMP=`getopt -o hs:f:l:k:n:N: --long help,stop-on-failure -- "$@"`
 eval set -- "$TEMP"
 
 let first_test_index=0
 let individual_test_requested_iterations=1
 let full_set_requested_interations=1
 let stop_on_failure=0
+requested_test_names="*"
 
 while true; do
     case "$1" in
@@ -47,6 +49,10 @@ while true; do
             ;;
         -l)
             let last_test_index=$2
+            shift 2
+            ;;
+        -k)
+            requested_test_names=$2
             shift 2
             ;;
         -n)
@@ -83,7 +89,19 @@ fi
 TIMESTAMP=`date '+%Y%m%d%H%M%S'`
 mkdir -p /tmp/pytest-of-${USER}
 ITGRUNNER_LOG_FILE="/tmp/pytest-of-${USER}/daqsystemtest_integtest_bundle_${TIMESTAMP}.log"
-let total_number_of_tests=(1+${last_test_index}-${first_test_index})*${individual_test_requested_iterations}*${full_set_requested_interations}
+
+let number_of_individual_tests=0
+let test_index=0
+for TEST_NAME in ${integtest_list[@]}; do
+    if [[ ${test_index} -ge ${first_test_index} && ${test_index} -le ${last_test_index} ]]; then
+        requested_test=`echo ${TEST_NAME} | egrep -i ${requested_test_names}`
+        if [[ "${requested_test}" != "" ]]; then
+            let number_of_individual_tests=${number_of_individual_tests}+1
+        fi
+    fi
+    let test_index=${test_index}+1
+done
+let total_number_of_tests=${number_of_individual_tests}*${individual_test_requested_iterations}*${full_set_requested_interations}
 
 # run the tests
 let overall_test_index=0  # this is only used for user feedback
@@ -92,6 +110,8 @@ while [[ ${full_set_loop_count} -lt ${full_set_requested_interations} ]]; do
   let test_index=0
   for TEST_NAME in ${integtest_list[@]}; do
     if [[ ${test_index} -ge ${first_test_index} && ${test_index} -le ${last_test_index} ]]; then
+      requested_test=`echo ${TEST_NAME} | egrep -i ${requested_test_names}`
+      if [[ "${requested_test}" != "" ]]; then
 
       let individual_loop_count=0
       while [[ ${individual_loop_count} -lt ${individual_test_requested_iterations} ]]; do
@@ -122,6 +142,7 @@ while [[ ${full_set_loop_count} -lt ${full_set_requested_interations} ]]; do
         fi
       done
 
+      fi
     fi
     let test_index=${test_index}+1
   done

--- a/scripts/daqsystemtest_integtest_bundle.sh
+++ b/scripts/daqsystemtest_integtest_bundle.sh
@@ -35,7 +35,7 @@ let first_test_index=0
 let individual_test_requested_iterations=1
 let full_set_requested_interations=1
 let stop_on_failure=0
-requested_test_names="*"
+requested_test_names=
 
 while true; do
     case "$1" in
@@ -94,7 +94,7 @@ let number_of_individual_tests=0
 let test_index=0
 for TEST_NAME in ${integtest_list[@]}; do
     if [[ ${test_index} -ge ${first_test_index} && ${test_index} -le ${last_test_index} ]]; then
-        requested_test=`echo ${TEST_NAME} | egrep -i ${requested_test_names}`
+        requested_test=`echo ${TEST_NAME} | egrep -i ${requested_test_names:-${TEST_NAME}}`
         if [[ "${requested_test}" != "" ]]; then
             let number_of_individual_tests=${number_of_individual_tests}+1
         fi
@@ -110,7 +110,7 @@ while [[ ${full_set_loop_count} -lt ${full_set_requested_interations} ]]; do
   let test_index=0
   for TEST_NAME in ${integtest_list[@]}; do
     if [[ ${test_index} -ge ${first_test_index} && ${test_index} -le ${last_test_index} ]]; then
-      requested_test=`echo ${TEST_NAME} | egrep -i ${requested_test_names}`
+      requested_test=`echo ${TEST_NAME} | egrep -i ${requested_test_names:-${TEST_NAME}}`
       if [[ "${requested_test}" != "" ]]; then
 
       let individual_loop_count=0


### PR DESCRIPTION
… pipe-delimited list of test names to be run (the pipe-delimited list is passed to egrep).

This allows users to more easily run tests without remembering the index of the test(s) of interest.

Examples included:

- `daqsystemtest_integtest_bundle.sh -k example`
- `daqsystemtest_integtest_bundle.sh -f5 -k 3ru`
- `daqsystemtest_integtest_bundle.sh -k 'min|small'`

I chose the letter 'k' for this option in an attempt to be similar to the "pytest -k" option.  However, since the bundle script is currently written in bash and pytest is written in python, the format of the arguments to the "-k" options are different.

- the argument to the bundle script expects 'egrep'-style search arguments (pipe-delimited)
- the argument to the pytest utility supports Python "or" syntax
