### PR TITLE
Several changes to help improve integtest console output: …

### DIFF
--- a/integtest/fake_data_producer_test.py
+++ b/integtest/fake_data_producer_test.py
@@ -159,6 +159,11 @@ def test_data_files(run_nanorc):
     # Run some tests on the output data file
     all_ok = True
     all_ok &= len(run_nanorc.data_files) == expected_number_of_data_files
+    print("") # Clear potential dot from pytest
+    if all_ok:
+        print(f"\N{WHITE HEAVY CHECK MARK} The correct number of raw data files was found ({expected_number_of_data_files})")
+    else:
+        print(f"\N{POLICE CARS REVOLVING LIGHT} An incorrect number of raw data files was found, expected {expected_number_of_data_files}, found {len(run_nanorc.data_files)} \N{POLICE CARS REVOLVING LIGHT}")
 
     for idx in range(len(run_nanorc.data_files)):
         data_file = data_file_checks.DataFile(run_nanorc.data_files[idx])

--- a/integtest/long_window_readout_test.py
+++ b/integtest/long_window_readout_test.py
@@ -11,6 +11,10 @@ import integrationtest.data_classes as data_classes
 
 pytest_plugins = "integrationtest.integrationtest_drunc"
 
+# 20-May-2025, KAB: tweak the print() statement default behavior so that it always flushes the output.
+import functools
+print = functools.partial(print, flush=True)
+
 # Values that help determine the running conditions
 output_path_parameter = "."
 number_of_data_producers = 4
@@ -272,6 +276,11 @@ def test_data_files(run_nanorc):
     all_ok = True
     # Run some tests on the output data file
     all_ok &= len(run_nanorc.data_files) == expected_number_of_data_files
+    print("") # Clear potential dot from pytest
+    if all_ok:
+        print(f"\N{WHITE HEAVY CHECK MARK} The correct number of raw data files was found ({expected_number_of_data_files})")
+    else:
+        print(f"\N{POLICE CARS REVOLVING LIGHT} An incorrect number of raw data files was found, expected {expected_number_of_data_files}, found {len(run_nanorc.data_files)} \N{POLICE CARS REVOLVING LIGHT}")
 
     for idx in range(len(run_nanorc.data_files)):
         data_file = data_file_checks.DataFile(run_nanorc.data_files[idx])

--- a/integtest/readout_type_scan.py
+++ b/integtest/readout_type_scan.py
@@ -296,6 +296,11 @@ def test_data_files(run_nanorc):
     # Run some tests on the output data file
     all_ok = True
     all_ok &= len(run_nanorc.data_files) == expected_number_of_data_files
+    print("") # Clear potential dot from pytest
+    if all_ok:
+        print(f"\N{WHITE HEAVY CHECK MARK} The correct number of raw data files was found ({expected_number_of_data_files})")
+    else:
+        print(f"\N{POLICE CARS REVOLVING LIGHT} An incorrect number of raw data files was found, expected {expected_number_of_data_files}, found {len(run_nanorc.data_files)} \N{POLICE CARS REVOLVING LIGHT}")
 
     for idx in range(len(run_nanorc.data_files)):
         data_file = data_file_checks.DataFile(run_nanorc.data_files[idx])

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,4 +2,11 @@
 filterwarnings =
     ignore:.*is a deprecated alias.*:DeprecationWarning
     ignore:.*invalid escape sequence.*:DeprecationWarning
+
 tmp_path_retention_count = 10
+
+# --tb not given    Produces reams of output, with full source code included in tracebacks
+# --tb=no           Just shows location of failure in the test file: no use for tracking down errors
+# --tb=short        Just shows vanilla traceback: very useful, but file names are incomplete and relative
+# --tb=native       Slightly more info than short: still works very well. The full paths may be useful for CI
+addopts = --tb=no


### PR DESCRIPTION
…turned off the pytest traceback; added information about correct number of data files produced (or not); added the flushing of output in the long_window_readout_test so that the listing of files before deletion output isn't garbled.

The current situation in which the `long_window_readout_test` is failing provides a nice opportunity to improve some of our integtest output messages.

1. Now that we have started including the check that the correct number of data files has been produced in our "all_ok" summary status, it can be a little hard to tell whether that individual check has succeeded or passed.  To help in this regard, I've added code to print out messages in either case to the 3 integtests that needed it.  @eflumerf , if you don't like my model of copying the HeavyWhiteCheckMark and PoliceCarsRevolvingLight pattern from integrationtest/data_file_checks.py, we can talk about a different way to help indicate success or failure.
2. To avoid garbled printouts associated with the removal of large data files at the end of the `long_window_readout_test`, I set the default behavior of the Python `print()` command to flush its output in that integtest.
3. Based on a recommendation from Alessandro, I have added control of the `pytest` traceback to the `pytest.ini` file.  This turns off the `pytest` traceback in the case of a test failure since that traceback information is often more confusing than helpful.

To test these changes, one can run the `long_window_readout_test`, `fake_data_producer_test`, and `readout_type_scan` and observe the changes in the output messages.