### PR TITLE
Recent integtest usability improvements pulled in from the develop branch

### DIFF
--- a/integtest/fake_data_producer_test.py
+++ b/integtest/fake_data_producer_test.py
@@ -159,6 +159,11 @@ def test_data_files(run_nanorc):
     # Run some tests on the output data file
     all_ok = True
     all_ok &= len(run_nanorc.data_files) == expected_number_of_data_files
+    print("") # Clear potential dot from pytest
+    if all_ok:
+        print(f"\N{WHITE HEAVY CHECK MARK} The correct number of raw data files was found ({expected_number_of_data_files})")
+    else:
+        print(f"\N{POLICE CARS REVOLVING LIGHT} An incorrect number of raw data files was found, expected {expected_number_of_data_files}, found {len(run_nanorc.data_files)} \N{POLICE CARS REVOLVING LIGHT}")
 
     for idx in range(len(run_nanorc.data_files)):
         data_file = data_file_checks.DataFile(run_nanorc.data_files[idx])

--- a/integtest/long_window_readout_test.py
+++ b/integtest/long_window_readout_test.py
@@ -11,6 +11,10 @@ import integrationtest.data_classes as data_classes
 
 pytest_plugins = "integrationtest.integrationtest_drunc"
 
+# 20-May-2025, KAB: tweak the print() statement default behavior so that it always flushes the output.
+import functools
+print = functools.partial(print, flush=True)
+
 # Values that help determine the running conditions
 output_path_parameter = "."
 number_of_data_producers = 4
@@ -272,6 +276,11 @@ def test_data_files(run_nanorc):
     all_ok = True
     # Run some tests on the output data file
     all_ok &= len(run_nanorc.data_files) == expected_number_of_data_files
+    print("") # Clear potential dot from pytest
+    if all_ok:
+        print(f"\N{WHITE HEAVY CHECK MARK} The correct number of raw data files was found ({expected_number_of_data_files})")
+    else:
+        print(f"\N{POLICE CARS REVOLVING LIGHT} An incorrect number of raw data files was found, expected {expected_number_of_data_files}, found {len(run_nanorc.data_files)} \N{POLICE CARS REVOLVING LIGHT}")
 
     for idx in range(len(run_nanorc.data_files)):
         data_file = data_file_checks.DataFile(run_nanorc.data_files[idx])

--- a/integtest/readout_type_scan.py
+++ b/integtest/readout_type_scan.py
@@ -296,6 +296,11 @@ def test_data_files(run_nanorc):
     # Run some tests on the output data file
     all_ok = True
     all_ok &= len(run_nanorc.data_files) == expected_number_of_data_files
+    print("") # Clear potential dot from pytest
+    if all_ok:
+        print(f"\N{WHITE HEAVY CHECK MARK} The correct number of raw data files was found ({expected_number_of_data_files})")
+    else:
+        print(f"\N{POLICE CARS REVOLVING LIGHT} An incorrect number of raw data files was found, expected {expected_number_of_data_files}, found {len(run_nanorc.data_files)} \N{POLICE CARS REVOLVING LIGHT}")
 
     for idx in range(len(run_nanorc.data_files)):
         data_file = data_file_checks.DataFile(run_nanorc.data_files[idx])

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,4 +2,11 @@
 filterwarnings =
     ignore:.*is a deprecated alias.*:DeprecationWarning
     ignore:.*invalid escape sequence.*:DeprecationWarning
+
 tmp_path_retention_count = 10
+
+# --tb not given    Produces reams of output, with full source code included in tracebacks
+# --tb=no           Just shows location of failure in the test file: no use for tracking down errors
+# --tb=short        Just shows vanilla traceback: very useful, but file names are incomplete and relative
+# --tb=native       Slightly more info than short: still works very well. The full paths may be useful for CI
+addopts = --tb=no

--- a/scripts/daqsystemtest_integtest_bundle.sh
+++ b/scripts/daqsystemtest_integtest_bundle.sh
@@ -14,6 +14,7 @@ Options:
     -h, --help : prints out usage information
     -f <zero-based index of the first test to be run, default=0>
     -l <zero-based index of the last test to be run, default=${last_test_index}>
+    -k <pipe-delimited string to select which tests will be run ('egrep -i' match to test name)>
     -n <number of times to run each individual test, default=1>
     -N <number of times to run the full set of selected tests, default=1>
     --stop-on-failure : causes the script to stop when one of the integtests reports a failure
@@ -27,13 +28,14 @@ Options:
     echo ""
 }
 
-TEMP=`getopt -o hs:f:l:n:N: --long help,stop-on-failure -- "$@"`
+TEMP=`getopt -o hs:f:l:k:n:N: --long help,stop-on-failure -- "$@"`
 eval set -- "$TEMP"
 
 let first_test_index=0
 let individual_test_requested_iterations=1
 let full_set_requested_interations=1
 let stop_on_failure=0
+requested_test_names="*"
 
 while true; do
     case "$1" in
@@ -47,6 +49,10 @@ while true; do
             ;;
         -l)
             let last_test_index=$2
+            shift 2
+            ;;
+        -k)
+            requested_test_names=$2
             shift 2
             ;;
         -n)
@@ -83,7 +89,19 @@ fi
 TIMESTAMP=`date '+%Y%m%d%H%M%S'`
 mkdir -p /tmp/pytest-of-${USER}
 ITGRUNNER_LOG_FILE="/tmp/pytest-of-${USER}/daqsystemtest_integtest_bundle_${TIMESTAMP}.log"
-let total_number_of_tests=(1+${last_test_index}-${first_test_index})*${individual_test_requested_iterations}*${full_set_requested_interations}
+
+let number_of_individual_tests=0
+let test_index=0
+for TEST_NAME in ${integtest_list[@]}; do
+    if [[ ${test_index} -ge ${first_test_index} && ${test_index} -le ${last_test_index} ]]; then
+        requested_test=`echo ${TEST_NAME} | egrep -i ${requested_test_names}`
+        if [[ "${requested_test}" != "" ]]; then
+            let number_of_individual_tests=${number_of_individual_tests}+1
+        fi
+    fi
+    let test_index=${test_index}+1
+done
+let total_number_of_tests=${number_of_individual_tests}*${individual_test_requested_iterations}*${full_set_requested_interations}
 
 # run the tests
 let overall_test_index=0  # this is only used for user feedback
@@ -92,6 +110,8 @@ while [[ ${full_set_loop_count} -lt ${full_set_requested_interations} ]]; do
   let test_index=0
   for TEST_NAME in ${integtest_list[@]}; do
     if [[ ${test_index} -ge ${first_test_index} && ${test_index} -le ${last_test_index} ]]; then
+      requested_test=`echo ${TEST_NAME} | egrep -i ${requested_test_names}`
+      if [[ "${requested_test}" != "" ]]; then
 
       let individual_loop_count=0
       while [[ ${individual_loop_count} -lt ${individual_test_requested_iterations} ]]; do
@@ -122,6 +142,7 @@ while [[ ${full_set_loop_count} -lt ${full_set_requested_interations} ]]; do
         fi
       done
 
+      fi
     fi
     let test_index=${test_index}+1
   done

--- a/scripts/daqsystemtest_integtest_bundle.sh
+++ b/scripts/daqsystemtest_integtest_bundle.sh
@@ -35,7 +35,7 @@ let first_test_index=0
 let individual_test_requested_iterations=1
 let full_set_requested_interations=1
 let stop_on_failure=0
-requested_test_names="*"
+requested_test_names=
 
 while true; do
     case "$1" in
@@ -94,7 +94,7 @@ let number_of_individual_tests=0
 let test_index=0
 for TEST_NAME in ${integtest_list[@]}; do
     if [[ ${test_index} -ge ${first_test_index} && ${test_index} -le ${last_test_index} ]]; then
-        requested_test=`echo ${TEST_NAME} | egrep -i ${requested_test_names}`
+        requested_test=`echo ${TEST_NAME} | egrep -i ${requested_test_names:-${TEST_NAME}}`
         if [[ "${requested_test}" != "" ]]; then
             let number_of_individual_tests=${number_of_individual_tests}+1
         fi
@@ -110,7 +110,7 @@ while [[ ${full_set_loop_count} -lt ${full_set_requested_interations} ]]; do
   let test_index=0
   for TEST_NAME in ${integtest_list[@]}; do
     if [[ ${test_index} -ge ${first_test_index} && ${test_index} -le ${last_test_index} ]]; then
-      requested_test=`echo ${TEST_NAME} | egrep -i ${requested_test_names}`
+      requested_test=`echo ${TEST_NAME} | egrep -i ${requested_test_names:-${TEST_NAME}}`
       if [[ "${requested_test}" != "" ]]; then
 
       let individual_loop_count=0


### PR DESCRIPTION
These changes attempt to make the output from several integtests more easy to understand, and the new bundle script option (-k <substring>) is intended to make the running of tests easier to do.

The original PRs that had these changes (targeted to the `develop` branch) have useful additional information ([here](https://github.com/DUNE-DAQ/daqsystemtest/pull/206) and [here](https://github.com/DUNE-DAQ/daqsystemtest/pull/205)).