### PR TITLE
Channel map names aligned with the new naming convention.

### DIFF
--- a/config/daqsystemtest/example-configs.data.xml
+++ b/config/daqsystemtest/example-configs.data.xml
@@ -86,7 +86,7 @@
 
 
 <obj class="DetectorConfig" id="dummy-detector">
- <attr name="tpg_channel_map" type="string" val="PD2HDChannelMap"/>
+ <attr name="tpg_channel_map" type="string" val="PD2HDTPCChannelMap"/>
  <attr name="clock_speed_hz" type="u32" val="62500000"/>
  <attr name="op_env" type="string" val="test"/>
  <attr name="offline_data_stream" type="string" val="cosmics"/>

--- a/config/daqsystemtest/example-hsi-configs.data.xml
+++ b/config/daqsystemtest/example-hsi-configs.data.xml
@@ -80,7 +80,7 @@
 
 
 <obj class="DetectorConfig" id="dummy-detector">
- <attr name="tpg_channel_map" type="string" val="PD2HDChannelMap"/>
+ <attr name="tpg_channel_map" type="string" val="PD2HDTPCChannelMap"/>
  <attr name="clock_speed_hz" type="u32" val="62500000"/>
  <attr name="op_env" type="string" val="test"/>
  <attr name="offline_data_stream" type="string" val="cosmics"/>

--- a/config/daqsystemtest/integrationtest-objects.data.xml
+++ b/config/daqsystemtest/integrationtest-objects.data.xml
@@ -102,7 +102,7 @@
 </obj>
 
 <obj class="DetectorConfig" id="dummy-detector">
- <attr name="tpg_channel_map" type="string" val="PD2HDChannelMap"/>
+ <attr name="tpg_channel_map" type="string" val="PD2HDTPCChannelMap"/>
  <attr name="clock_speed_hz" type="u32" val="62500000"/>
  <attr name="op_env" type="string" val="test"/>
  <attr name="offline_data_stream" type="string" val="cosmics"/>

--- a/config/daqsystemtest/moduleconfs.data.xml
+++ b/config/daqsystemtest/moduleconfs.data.xml
@@ -492,7 +492,7 @@
  <attr name="queue_sizes" type="u32" val="10000"/>
  <attr name="thread_names_prefix" type="string" val="postproc-"/>
  <attr name="latency_monitoring" type="bool" val="1"/>
- <attr name="channel_map" type="string" val="PD2HDChannelMap"/>
+ <attr name="channel_map" type="string" val="PD2HDTPCChannelMap"/>
  <rel name="processing_steps">
   <ref class="AVXFrugalPedestalSubtractProcessor" id="tpg-pedsub-proc"/>
   <ref class="AVXThresholdProcessor" id="tpg-threshold-proc"/>

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,9 @@ filterwarnings =
     ignore:.*is a deprecated alias.*:DeprecationWarning
     ignore:.*invalid escape sequence.*:DeprecationWarning
 tmp_path_retention_count = 10
+
+# --tb not given    Produces reams of output, with full source code included in tracebacks
+# --tb=no           Just shows location of failure in the test file: no use for tracking down errors
+# --tb=short        Just shows vanilla traceback: very useful, but file names are incomplete and relative
+# --tb=native       Slightly more info than short: still works very well. The full paths may be useful for CI
+addopts = --tb=native


### PR DESCRIPTION
`PD2HDChannelMap` renamed to `PD2HDTPCChannelMap`