### PR TITLE
CRT sessions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(daqsystemtest VERSION 4.3.0)
+project(daqsystemtest VERSION 4.4.0)
 
 find_package(daq-cmake REQUIRED)
 

--- a/config/daqsystemtest/ccm.data.xml
+++ b/config/daqsystemtest/ccm.data.xml
@@ -63,7 +63,7 @@
 
 <oks-data>
 
-<info name="" type="" num-of-items="29" oks-format="data" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20231207T110859" last-modified-by="mrigan" last-modified-on="np04-srv-016.cern.ch" last-modification-time="20250312T105152"/>
+<info name="" type="" num-of-items="31" oks-format="data" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20231207T110859" last-modified-by="dergonul" last-modified-on="np04-srv-031.cern.ch" last-modification-time="20250526T125621"/>
 
 <include>
  <file path="schema/confmodel/dunedaq.schema.xml"/>
@@ -77,6 +77,7 @@
  <comment creation-time="20240918T094920" created-by="maroda" created-on="np04-srv-015.cern.ch" author="maroda" text="add local file"/>
  <comment creation-time="20250214T095127" created-by="dergonul" created-on="np04-srv-015.cern.ch" author="dergonul" text="Added new Session with SocketReaderModule"/>
  <comment creation-time="20250312T102000" created-by="mrigan" created-on="np04-srv-016.cern.ch" author="mrigan" text=" "/>
+ <comment creation-time="20250526T125621" created-by="dergonul" created-on="np04-srv-031.cern.ch" author="dergonul" text="Added new sessions for CRTBernFrame and CRTGrenobleFrame"/>
 </comments>
 
 
@@ -128,6 +129,26 @@
 </obj>
 
 <obj class="RCApplication" id="root-controller">
+ <attr name="application_name" type="string" val="drunc-controller"/>
+ <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
+ <rel name="exposes_service">
+  <ref class="Service" id="rccontroller_control"/>
+ </rel>
+ <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
+ <rel name="fsm" class="FSMconfiguration" id="fsmConf-test"/>
+</obj>
+
+<obj class="RCApplication" id="socket-crt-bern-root-controller">
+ <attr name="application_name" type="string" val="drunc-controller"/>
+ <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
+ <rel name="exposes_service">
+  <ref class="Service" id="rccontroller_control"/>
+ </rel>
+ <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
+ <rel name="fsm" class="FSMconfiguration" id="fsmConf-test"/>
+</obj>
+
+<obj class="RCApplication" id="socket-crt-grenoble-root-controller">
  <attr name="application_name" type="string" val="drunc-controller"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="exposes_service">
@@ -208,6 +229,11 @@
  <attr name="value" type="string" val="erstrace,throttle,lstdout,protobufstream(monkafka.cern.ch:30092)"/>
 </obj>
 
+<obj class="Variable" id="local-env-ers-debug-level">
+ <attr name="name" type="string" val="DUNEDAQ_ERS_DEBUG_LEVEL"/>
+ <attr name="value" type="string" val="-1"/>
+</obj>
+
 <obj class="Variable" id="local-env-ers-error">
  <attr name="name" type="string" val="DUNEDAQ_ERS_ERROR"/>
  <attr name="value" type="string" val="erstrace,throttle,lstdout"/>
@@ -231,11 +257,6 @@
 <obj class="Variable" id="local-env-ers-warning">
  <attr name="name" type="string" val="DUNEDAQ_ERS_WARNING"/>
  <attr name="value" type="string" val="erstrace,throttle,lstdout"/>
-</obj>
-
-<obj class="Variable" id="local-env-ers-debug-level">
- <attr name="name" type="string" val="DUNEDAQ_ERS_DEBUG_LEVEL"/>
- <attr name="value" type="string" val="-1"/>
 </obj>
 
 <obj class="VariableSet" id="ehn1-variables">

--- a/config/daqsystemtest/ccm.data.xml
+++ b/config/daqsystemtest/ccm.data.xml
@@ -138,7 +138,7 @@
  <rel name="fsm" class="FSMconfiguration" id="fsmConf-test"/>
 </obj>
 
-<obj class="RCApplication" id="socket-crt-bern-root-controller">
+<obj class="RCApplication" id="crt-bern-root-controller">
  <attr name="application_name" type="string" val="drunc-controller"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="exposes_service">
@@ -148,7 +148,7 @@
  <rel name="fsm" class="FSMconfiguration" id="fsmConf-test"/>
 </obj>
 
-<obj class="RCApplication" id="socket-crt-grenoble-root-controller">
+<obj class="RCApplication" id="crt-grenoble-root-controller">
  <attr name="application_name" type="string" val="drunc-controller"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="exposes_service">

--- a/config/daqsystemtest/connections.data.xml
+++ b/config/daqsystemtest/connections.data.xml
@@ -63,7 +63,7 @@
 
 <oks-data>
 
-<info name="" type="" num-of-items="64" oks-format="data" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20231207T105549" last-modified-by="eflumerf" last-modified-on="ironvirt9.IRONDOMAIN.local" last-modification-time="20241018T200355"/>
+<info name="" type="" num-of-items="72" oks-format="data" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20231207T105549" last-modified-by="dergonul" last-modified-on="np04-srv-031.cern.ch" last-modification-time="20250526T123756"/>
 
 <include>
  <file path="schema/confmodel/dunedaq.schema.xml"/>
@@ -71,6 +71,10 @@
  <file path="schema/appmodel/fdmodules.schema.xml"/>
  <file path="schema/appmodel/trigger.schema.xml"/>
 </include>
+
+<comments>
+ <comment creation-time="20250526T123756" created-by="dergonul" created-on="np04-srv-031.cern.ch" author="dergonul" text="Added CRT queue rules"/>
+</comments>
 
 
 <obj class="NetworkConnectionDescriptor" id="data-req-net-input">
@@ -225,6 +229,16 @@
  <rel name="descriptor" class="NetworkConnectionDescriptor" id="timesync-publisher"/>
 </obj>
 
+<obj class="QueueConnectionRule" id="crt-bern-raw-data-rule">
+ <attr name="destination_class" type="class" val="FDDataHandlerModule"/>
+ <rel name="descriptor" class="QueueDescriptor" id="crt-bern-raw-input"/>
+</obj>
+
+<obj class="QueueConnectionRule" id="crt-grenoble-raw-data-rule">
+ <attr name="destination_class" type="class" val="FDDataHandlerModule"/>
+ <rel name="descriptor" class="QueueDescriptor" id="crt-grenoble-raw-input"/>
+</obj>
+
 <obj class="QueueConnectionRule" id="fa-queue-rule">
  <attr name="destination_class" type="class" val="FragmentAggregatorModule"/>
  <rel name="descriptor" class="QueueDescriptor" id="fa-input"/>
@@ -290,9 +304,33 @@
  <rel name="descriptor" class="QueueDescriptor" id="wib-eth-callback-bypass"/>
 </obj>
 
+<obj class="QueueConnectionRule" id="crt-bern-callback-raw-data-rule">
+ <attr name="destination_class" type="class" val="FDDataHandlerModule"/>
+ <rel name="descriptor" class="QueueDescriptor" id="crt-bern-callback-bypass"/>
+</obj>
+
+<obj class="QueueConnectionRule" id="crt-grenoble-callback-raw-data-rule">
+ <attr name="destination_class" type="class" val="FDDataHandlerModule"/>
+ <rel name="descriptor" class="QueueDescriptor" id="crt-grenoble-callback-bypass"/>
+</obj>
+
 <obj class="QueueConnectionRule" id="wib-eth-raw-data-rule">
  <attr name="destination_class" type="class" val="FDDataHandlerModule"/>
  <rel name="descriptor" class="QueueDescriptor" id="wib-eth-raw-input"/>
+</obj>
+
+<obj class="QueueDescriptor" id="crt-bern-raw-input">
+ <attr name="uid_base" type="string" val="raw_input_"/>
+ <attr name="queue_type" type="enum" val="kFollySPSCQueue"/>
+ <attr name="capacity" type="u32" val="10000"/>
+ <attr name="data_type" type="string" val="CRTBernFrame"/>
+</obj>
+
+<obj class="QueueDescriptor" id="crt-grenoble-raw-input">
+ <attr name="uid_base" type="string" val="raw_input_"/>
+ <attr name="queue_type" type="enum" val="kFollySPSCQueue"/>
+ <attr name="capacity" type="u32" val="10000"/>
+ <attr name="data_type" type="string" val="CRTGrenobleFrame"/>
 </obj>
 
 <obj class="QueueDescriptor" id="data-req-queue-desc">
@@ -377,6 +415,20 @@
  <attr name="queue_type" type="enum" val="kFollySPSCQueue"/>
  <attr name="capacity" type="u32" val="10000"/>
  <attr name="data_type" type="string" val="WIBEthFrame"/>
+</obj>
+
+<obj class="QueueDescriptor" id="crt-bern-callback-bypass">
+ <attr name="uid_base" type="string" val="cb_raw_input_"/>
+ <attr name="queue_type" type="enum" val="kFollySPSCQueue"/>
+ <attr name="capacity" type="u32" val="10000"/>
+ <attr name="data_type" type="string" val="CRTBernFrame"/>
+</obj>
+
+<obj class="QueueDescriptor" id="crt-grenoble-callback-bypass">
+ <attr name="uid_base" type="string" val="cb_raw_input_"/>
+ <attr name="queue_type" type="enum" val="kFollySPSCQueue"/>
+ <attr name="capacity" type="u32" val="10000"/>
+ <attr name="data_type" type="string" val="CRTGrenobleFrame"/>
 </obj>
 
 <obj class="QueueDescriptor" id="wib-eth-raw-input">

--- a/config/daqsystemtest/example-configs.data.xml
+++ b/config/daqsystemtest/example-configs.data.xml
@@ -103,34 +103,24 @@
  <rel name="controller" class="RCApplication" id="root-controller"/>
 </obj>
 
-<obj class="Segment" id="socket-crt-bern-root-segment">
+<obj class="Segment" id="crt-bern-root-segment">
  <rel name="segments">
-  <ref class="Segment" id="socket-ru-crt-bern-segment"/>
+  <ref class="Segment" id="crt-bern-segment"/>
   <ref class="Segment" id="df-segment"/>
   <ref class="Segment" id="trg-segment"/>
   <ref class="Segment" id="hsi-fake-segment"/>
  </rel>
- <rel name="controller" class="RCApplication" id="socket-crt-bern-root-controller"/>
+ <rel name="controller" class="RCApplication" id="crt-bern-root-controller"/>
 </obj>
 
-<obj class="Segment" id="socket-crt-grenoble-root-segment">
+<obj class="Segment" id="crt-grenoble-root-segment">
  <rel name="segments">
-  <ref class="Segment" id="socket-ru-crt-grenoble-segment"/>
+  <ref class="Segment" id="crt-grenoble-segment"/>
   <ref class="Segment" id="df-segment"/>
   <ref class="Segment" id="trg-segment"/>
   <ref class="Segment" id="hsi-fake-segment"/>
  </rel>
- <rel name="controller" class="RCApplication" id="socket-crt-grenoble-root-controller"/>
-</obj>
-
-<obj class="Segment" id="socket-root-segment">
- <rel name="segments">
-  <ref class="Segment" id="socket-ru-segment"/>
-  <ref class="Segment" id="df-segment"/>
-  <ref class="Segment" id="trg-segment"/>
-  <ref class="Segment" id="hsi-fake-segment"/>
- </rel>
- <rel name="controller" class="RCApplication" id="socket-root-controller"/>
+ <rel name="controller" class="RCApplication" id="crt-grenoble-root-controller"/>
 </obj>
 
 <obj class="Session" id="ehn1-local-1x1-config">
@@ -212,7 +202,7 @@
  <rel name="opmon_uri" class="OpMonURI" id="local-opmon-uri"/>
 </obj>
 
-<obj class="Session" id="local-socket-1x1-config">
+<obj class="Session" id="local-crt-bern-1x1-config">
  <attr name="data_request_timeout_ms" type="u32" val="1000"/>
  <attr name="data_rate_slowdown_factor" type="u32" val="1"/>
  <attr name="controller_log_level" type="enum" val="INFO"/>
@@ -231,7 +221,7 @@
   <ref class="TPStreamWriterApplication" id="tp-stream-writer"/>
   <ref class="TriggerApplication" id="tc-maker-1"/>
  </rel>
- <rel name="segment" class="Segment" id="socket-root-segment"/>
+ <rel name="segment" class="Segment" id="crt-bern-root-segment"/>
  <rel name="infrastructure_applications">
   <ref class="ConnectionService" id="local-connection-server"/>
  </rel>
@@ -239,7 +229,7 @@
  <rel name="opmon_uri" class="OpMonURI" id="local-opmon-uri"/>
 </obj>
 
-<obj class="Session" id="local-socket-crt-bern-1x1-config">
+<obj class="Session" id="local-crt-grenoble-1x1-config">
  <attr name="data_request_timeout_ms" type="u32" val="1000"/>
  <attr name="data_rate_slowdown_factor" type="u32" val="1"/>
  <attr name="controller_log_level" type="enum" val="INFO"/>
@@ -258,34 +248,7 @@
   <ref class="TPStreamWriterApplication" id="tp-stream-writer"/>
   <ref class="TriggerApplication" id="tc-maker-1"/>
  </rel>
- <rel name="segment" class="Segment" id="socket-crt-bern-root-segment"/>
- <rel name="infrastructure_applications">
-  <ref class="ConnectionService" id="local-connection-server"/>
- </rel>
- <rel name="detector_configuration" class="DetectorConfig" id="dummy-detector"/>
- <rel name="opmon_uri" class="OpMonURI" id="local-opmon-uri"/>
-</obj>
-
-<obj class="Session" id="local-socket-crt-grenoble-1x1-config">
- <attr name="data_request_timeout_ms" type="u32" val="1000"/>
- <attr name="data_rate_slowdown_factor" type="u32" val="1"/>
- <attr name="controller_log_level" type="enum" val="INFO"/>
- <rel name="connectivity_service" class="ConnectivityService" id="local-connectivity-service-config"/>
- <rel name="environment">
-  <ref class="Variable" id="local-env-ers-verb"/>
-  <ref class="Variable" id="local-env-ers-info"/>
-  <ref class="Variable" id="local-env-ers-warning"/>
-  <ref class="Variable" id="local-env-ers-error"/>
-  <ref class="Variable" id="local-env-ers-fatal"/>
-  <ref class="Variable" id="local-env-ers-debug-level"/>
- </rel>
- <rel name="disabled">
-  <ref class="DFApplication" id="df-02"/>
-  <ref class="DFApplication" id="df-03"/>
-  <ref class="TPStreamWriterApplication" id="tp-stream-writer"/>
-  <ref class="TriggerApplication" id="tc-maker-1"/>
- </rel>
- <rel name="segment" class="Segment" id="socket-crt-grenoble-root-segment"/>
+ <rel name="segment" class="Segment" id="crt-grenoble-root-segment"/>
  <rel name="infrastructure_applications">
   <ref class="ConnectionService" id="local-connection-server"/>
  </rel>

--- a/config/daqsystemtest/example-configs.data.xml
+++ b/config/daqsystemtest/example-configs.data.xml
@@ -63,7 +63,7 @@
 
 <oks-data>
 
-<info name="" type="" num-of-items="8" oks-format="data" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20231207T105549" last-modified-by="dergonul" last-modified-on="np04-srv-015.cern.ch" last-modification-time="20250325T160832"/>
+<info name="" type="" num-of-items="12" oks-format="data" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20231207T105549" last-modified-by="dergonul" last-modified-on="np04-srv-031.cern.ch" last-modification-time="20250526T125621"/>
 
 <include>
  <file path="schema/confmodel/dunedaq.schema.xml"/>
@@ -82,6 +82,7 @@
  <comment creation-time="20240918T124331" created-by="maroda" created-on="np04-srv-015.cern.ch" author="maroda" text="change local session opmon URI"/>
  <comment creation-time="20250214T120354" created-by="dergonul" created-on="np04-srv-015.cern.ch" author="dergonul" text="Added new Session with SocketReaderModule"/>
  <comment creation-time="20250325T160832" created-by="dergonul" created-on="np04-srv-015.cern.ch" author="dergonul" text="Disabled TP"/>
+ <comment creation-time="20250526T125621" created-by="dergonul" created-on="np04-srv-031.cern.ch" author="dergonul" text="Added new session for CRTBernFrame and CRTGrenobleFrame"/>
 </comments>
 
 
@@ -100,6 +101,26 @@
   <ref class="Segment" id="hsi-fake-segment"/>
  </rel>
  <rel name="controller" class="RCApplication" id="root-controller"/>
+</obj>
+
+<obj class="Segment" id="socket-crt-bern-root-segment">
+ <rel name="segments">
+  <ref class="Segment" id="socket-ru-crt-bern-segment"/>
+  <ref class="Segment" id="df-segment"/>
+  <ref class="Segment" id="trg-segment"/>
+  <ref class="Segment" id="hsi-fake-segment"/>
+ </rel>
+ <rel name="controller" class="RCApplication" id="socket-crt-bern-root-controller"/>
+</obj>
+
+<obj class="Segment" id="socket-crt-grenoble-root-segment">
+ <rel name="segments">
+  <ref class="Segment" id="socket-ru-crt-grenoble-segment"/>
+  <ref class="Segment" id="df-segment"/>
+  <ref class="Segment" id="trg-segment"/>
+  <ref class="Segment" id="hsi-fake-segment"/>
+ </rel>
+ <rel name="controller" class="RCApplication" id="socket-crt-grenoble-root-controller"/>
 </obj>
 
 <obj class="Segment" id="socket-root-segment">
@@ -211,6 +232,60 @@
   <ref class="TriggerApplication" id="tc-maker-1"/>
  </rel>
  <rel name="segment" class="Segment" id="socket-root-segment"/>
+ <rel name="infrastructure_applications">
+  <ref class="ConnectionService" id="local-connection-server"/>
+ </rel>
+ <rel name="detector_configuration" class="DetectorConfig" id="dummy-detector"/>
+ <rel name="opmon_uri" class="OpMonURI" id="local-opmon-uri"/>
+</obj>
+
+<obj class="Session" id="local-socket-crt-bern-1x1-config">
+ <attr name="data_request_timeout_ms" type="u32" val="1000"/>
+ <attr name="data_rate_slowdown_factor" type="u32" val="1"/>
+ <attr name="controller_log_level" type="enum" val="INFO"/>
+ <rel name="connectivity_service" class="ConnectivityService" id="local-connectivity-service-config"/>
+ <rel name="environment">
+  <ref class="Variable" id="local-env-ers-verb"/>
+  <ref class="Variable" id="local-env-ers-info"/>
+  <ref class="Variable" id="local-env-ers-warning"/>
+  <ref class="Variable" id="local-env-ers-error"/>
+  <ref class="Variable" id="local-env-ers-fatal"/>
+  <ref class="Variable" id="local-env-ers-debug-level"/>
+ </rel>
+ <rel name="disabled">
+  <ref class="DFApplication" id="df-02"/>
+  <ref class="DFApplication" id="df-03"/>
+  <ref class="TPStreamWriterApplication" id="tp-stream-writer"/>
+  <ref class="TriggerApplication" id="tc-maker-1"/>
+ </rel>
+ <rel name="segment" class="Segment" id="socket-crt-bern-root-segment"/>
+ <rel name="infrastructure_applications">
+  <ref class="ConnectionService" id="local-connection-server"/>
+ </rel>
+ <rel name="detector_configuration" class="DetectorConfig" id="dummy-detector"/>
+ <rel name="opmon_uri" class="OpMonURI" id="local-opmon-uri"/>
+</obj>
+
+<obj class="Session" id="local-socket-crt-grenoble-1x1-config">
+ <attr name="data_request_timeout_ms" type="u32" val="1000"/>
+ <attr name="data_rate_slowdown_factor" type="u32" val="1"/>
+ <attr name="controller_log_level" type="enum" val="INFO"/>
+ <rel name="connectivity_service" class="ConnectivityService" id="local-connectivity-service-config"/>
+ <rel name="environment">
+  <ref class="Variable" id="local-env-ers-verb"/>
+  <ref class="Variable" id="local-env-ers-info"/>
+  <ref class="Variable" id="local-env-ers-warning"/>
+  <ref class="Variable" id="local-env-ers-error"/>
+  <ref class="Variable" id="local-env-ers-fatal"/>
+  <ref class="Variable" id="local-env-ers-debug-level"/>
+ </rel>
+ <rel name="disabled">
+  <ref class="DFApplication" id="df-02"/>
+  <ref class="DFApplication" id="df-03"/>
+  <ref class="TPStreamWriterApplication" id="tp-stream-writer"/>
+  <ref class="TriggerApplication" id="tc-maker-1"/>
+ </rel>
+ <rel name="segment" class="Segment" id="socket-crt-grenoble-root-segment"/>
  <rel name="infrastructure_applications">
   <ref class="ConnectionService" id="local-connection-server"/>
  </rel>

--- a/config/daqsystemtest/moduleconfs.data.xml
+++ b/config/daqsystemtest/moduleconfs.data.xml
@@ -205,7 +205,7 @@
 
 <obj class="DaqModulesGroupByType" id="socket-writer-data-source-step">
  <attr name="modules" type="class">
-  <data val="FakeSocketWriterModule"/>
+  <data val="SocketWriterModule"/>
  </attr>
 </obj>
 
@@ -545,7 +545,7 @@
 </obj>
 
 <obj class="SocketWriterConf" id="def-socket-writer-conf">
- <attr name="template_for" type="class" val="FakeSocketWriterModule"/>
+ <attr name="template_for" type="class" val="SocketWriterModule"/>
  <attr name="emulation_mode" type="bool" val="0"/>
  <attr name="socket_type" type="enum" val="UDP"/>
  <attr name="remote_ip" type="string" val="127.0.0.1"/>

--- a/config/daqsystemtest/moduleconfs.data.xml
+++ b/config/daqsystemtest/moduleconfs.data.xml
@@ -63,7 +63,7 @@
 
 <oks-data>
 
-<info name="" type="" num-of-items="73" oks-format="data" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20231207T105629" last-modified-by="dergonul" last-modified-on="np04-srv-015.cern.ch" last-modification-time="20250526T144643"/>
+<info name="" type="" num-of-items="81" oks-format="data" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20231207T105629" last-modified-by="dergonul" last-modified-on="np04-srv-015.cern.ch" last-modification-time="20250530T152404"/>
 
 <include>
  <file path="schema/confmodel/dunedaq.schema.xml"/>
@@ -77,6 +77,11 @@
 <comments>
  <comment creation-time="20250214T120354" created-by="dergonul" created-on="np04-srv-015.cern.ch" author="dergonul" text="Added socket communication classes"/>
  <comment creation-time="20250526T144643" created-by="dergonul" created-on="np04-srv-015.cern.ch" author="dergonul" text="Added CRT link handlers"/>
+ <comment creation-time="20250530T150821" created-by="dergonul" created-on="np04-srv-015.cern.ch" author="dergonul" text="Added CRTBernReaderConf"/>
+ <comment creation-time="20250530T151321" created-by="dergonul" created-on="np04-srv-015.cern.ch" author="dergonul" text="Added CRTGrenobleReaderConf"/>
+ <comment creation-time="20250530T151933" created-by="dergonul" created-on="np04-srv-015.cern.ch" author="dergonul" text="Added CRT data source steps"/>
+ <comment creation-time="20250530T152100" created-by="dergonul" created-on="np04-srv-015.cern.ch" author="dergonul" text="Added CRT action plans"/>
+ <comment creation-time="20250530T152404" created-by="dergonul" created-on="np04-srv-015.cern.ch" author="dergonul" text="Added CRT action plans"/>
 </comments>
 
 
@@ -84,6 +89,54 @@
  <attr name="plane0" type="u16" val="100"/>
  <attr name="plane1" type="u16" val="100"/>
  <attr name="plane2" type="u16" val="100"/>
+</obj>
+
+<obj class="ActionPlan" id="crt-bern-readout-start">
+ <attr name="execution_policy" type="enum" val="modules-in-parallel"/>
+ <rel name="command" class="FSMCommand" id="start"/>
+ <rel name="steps">
+  <ref class="DaqModulesGroupByType" id="aggregator-step"/>
+  <ref class="DaqModulesGroupByType" id="tp-handler-step"/>
+  <ref class="DaqModulesGroupByType" id="dlh-step"/>
+  <ref class="DaqModulesGroupByType" id="socket-writer-data-source-step"/>
+  <ref class="DaqModulesGroupByType" id="crt-bern-reader-data-source-step"/>
+ </rel>
+</obj>
+
+<obj class="ActionPlan" id="crt-bern-readout-stop">
+ <attr name="execution_policy" type="enum" val="modules-in-parallel"/>
+ <rel name="command" class="FSMCommand" id="stop_trigger_sources"/>
+ <rel name="steps">
+  <ref class="DaqModulesGroupByType" id="crt-bern-reader-data-source-step"/>
+  <ref class="DaqModulesGroupByType" id="socket-writer-data-source-step"/>
+  <ref class="DaqModulesGroupByType" id="dlh-step"/>
+  <ref class="DaqModulesGroupByType" id="tp-handler-step"/>
+  <ref class="DaqModulesGroupByType" id="aggregator-step"/>
+ </rel>
+</obj>
+
+<obj class="ActionPlan" id="crt-grenoble-readout-start">
+ <attr name="execution_policy" type="enum" val="modules-in-parallel"/>
+ <rel name="command" class="FSMCommand" id="start"/>
+ <rel name="steps">
+  <ref class="DaqModulesGroupByType" id="aggregator-step"/>
+  <ref class="DaqModulesGroupByType" id="tp-handler-step"/>
+  <ref class="DaqModulesGroupByType" id="dlh-step"/>
+  <ref class="DaqModulesGroupByType" id="socket-writer-data-source-step"/>
+  <ref class="DaqModulesGroupByType" id="crt-grenoble-reader-data-source-step"/>
+ </rel>
+</obj>
+
+<obj class="ActionPlan" id="crt-grenoble-readout-stop">
+ <attr name="execution_policy" type="enum" val="modules-in-parallel"/>
+ <rel name="command" class="FSMCommand" id="stop_trigger_sources"/>
+ <rel name="steps">
+  <ref class="DaqModulesGroupByType" id="crt-grenoble-reader-data-source-step"/>
+  <ref class="DaqModulesGroupByType" id="socket-writer-data-source-step"/>
+  <ref class="DaqModulesGroupByType" id="dlh-step"/>
+  <ref class="DaqModulesGroupByType" id="tp-handler-step"/>
+  <ref class="DaqModulesGroupByType" id="aggregator-step"/>
+ </rel>
 </obj>
 
 <obj class="ActionPlan" id="readout-start">
@@ -161,6 +214,16 @@
  </rel>
 </obj>
 
+<obj class="CRTBernReaderConf" id="def-crt-bern-receiver-conf">
+ <attr name="template_for" type="class" val="CRTBernReaderModule"/>
+ <attr name="emulation_mode" type="bool" val="0"/>
+</obj>
+
+<obj class="CRTGrenobleReaderConf" id="def-crt-grenoble-receiver-conf">
+ <attr name="template_for" type="class" val="CRTGrenobleReaderModule"/>
+ <attr name="emulation_mode" type="bool" val="0"/>
+</obj>
+
 <obj class="DFOConf" id="dfoconf-01">
  <attr name="general_queue_timeout_ms" type="u32" val="100"/>
  <attr name="stop_timeout_ms" type="u32" val="100"/>
@@ -183,6 +246,18 @@
 <obj class="DaqModulesGroupByType" id="aggregator-step">
  <attr name="modules" type="class">
   <data val="FragmentAggregatorModule"/>
+ </attr>
+</obj>
+
+<obj class="DaqModulesGroupByType" id="crt-bern-reader-data-source-step">
+ <attr name="modules" type="class">
+  <data val="CRTBernReaderModule"/>
+ </attr>
+</obj>
+
+<obj class="DaqModulesGroupByType" id="crt-grenoble-reader-data-source-step">
+ <attr name="modules" type="class">
+  <data val="CRTGrenobleReaderModule"/>
  </attr>
 </obj>
 

--- a/config/daqsystemtest/moduleconfs.data.xml
+++ b/config/daqsystemtest/moduleconfs.data.xml
@@ -63,7 +63,7 @@
 
 <oks-data>
 
-<info name="" type="" num-of-items="66" oks-format="data" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20231207T105629" last-modified-by="dergonul" last-modified-on="np04-srv-031.cern.ch" last-modification-time="20250305T102725"/>
+<info name="" type="" num-of-items="73" oks-format="data" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20231207T105629" last-modified-by="dergonul" last-modified-on="np04-srv-015.cern.ch" last-modification-time="20250526T144643"/>
 
 <include>
  <file path="schema/confmodel/dunedaq.schema.xml"/>
@@ -76,6 +76,7 @@
 
 <comments>
  <comment creation-time="20250214T120354" created-by="dergonul" created-on="np04-srv-015.cern.ch" author="dergonul" text="Added socket communication classes"/>
+ <comment creation-time="20250526T144643" created-by="dergonul" created-on="np04-srv-015.cern.ch" author="dergonul" text="Added CRT link handlers"/>
 </comments>
 
 
@@ -104,15 +105,6 @@
   <ref class="DaqModulesGroupByType" id="dlh-step"/>
   <ref class="DaqModulesGroupByType" id="tp-handler-step"/>
   <ref class="DaqModulesGroupByType" id="aggregator-step"/>
- </rel>
-</obj>
-
-<obj class="ActionPlan" id="tc-maker-start">
- <attr name="execution_policy" type="enum" val="modules-in-series"/>
- <rel name="command" class="FSMCommand" id="start"/>
- <rel name="steps">
-  <ref class="DaqModulesGroupByType" id="ta-handler-step"/>
-  <ref class="DaqModulesGroupByType" id="subscriber-step"/>
  </rel>
 </obj>
 
@@ -157,7 +149,16 @@
   <ref class="DaqModulesGroupByType" id="dlh-step"/>
   <ref class="DaqModulesGroupByType" id="tp-handler-step"/>
   <ref class="DaqModulesGroupByType" id="aggregator-step"/>
- </rel> 
+ </rel>
+</obj>
+
+<obj class="ActionPlan" id="tc-maker-start">
+ <attr name="execution_policy" type="enum" val="modules-in-series"/>
+ <rel name="command" class="FSMCommand" id="start"/>
+ <rel name="steps">
+  <ref class="DaqModulesGroupByType" id="ta-handler-step"/>
+  <ref class="DaqModulesGroupByType" id="subscriber-step"/>
+ </rel>
 </obj>
 
 <obj class="DFOConf" id="dfoconf-01">
@@ -209,12 +210,6 @@
  </attr>
 </obj>
 
-<obj class="DaqModulesGroupByType" id="tp-handler-step">
- <attr name="modules" type="class">
-  <data val="TriggerDataHandlerModule"/>
- </attr>
-</obj>
-
 <obj class="DaqModulesGroupByType" id="subscriber-step">
  <attr name="modules" type="class">
   <data val="DataSubscriberModule"/>
@@ -225,6 +220,30 @@
  <attr name="modules" type="class">
   <data val="TriggerDataHandlerModule"/>
  </attr>
+</obj>
+
+<obj class="DaqModulesGroupByType" id="tp-handler-step">
+ <attr name="modules" type="class">
+  <data val="TriggerDataHandlerModule"/>
+ </attr>
+</obj>
+
+<obj class="DataHandlerConf" id="def-crt-bern-link-handler">
+ <attr name="template_for" type="class" val="FDDataHandlerModule"/>
+ <attr name="input_data_type" type="string" val="CRTBernFrame"/>
+ <attr name="generate_timesync" type="bool" val="1"/>
+ <rel name="request_handler" class="RequestHandler" id="def-data-request-handler"/>
+ <rel name="latency_buffer" class="LatencyBuffer" id="def-latency-buf"/>
+ <rel name="data_processor" class="RawDataProcessor" id="def-wib-processor"/>
+</obj>
+
+<obj class="DataHandlerConf" id="def-crt-grenoble-link-handler">
+ <attr name="template_for" type="class" val="FDDataHandlerModule"/>
+ <attr name="input_data_type" type="string" val="CRTGrenobleFrame"/>
+ <attr name="generate_timesync" type="bool" val="1"/>
+ <rel name="request_handler" class="RequestHandler" id="def-data-request-handler"/>
+ <rel name="latency_buffer" class="LatencyBuffer" id="def-latency-buf"/>
+ <rel name="data_processor" class="RawDataProcessor" id="def-wib-processor"/>
 </obj>
 
 <obj class="DataHandlerConf" id="def-link-handler">
@@ -321,7 +340,6 @@
  <attr name="max_file_size" type="u64" val="4294967296"/>
  <attr name="disable_unique_filename_suffix" type="bool" val="0"/>
  <attr name="free_space_safety_factor" type="s32" val="5"/>
- <attr name="compression_level" type="u8" val="0"/>
  <rel name="file_layout_params" class="HDF5FileLayoutParams" id="default"/>
  <rel name="filename_params" class="FilenameParams" id="default"/>
 </obj>
@@ -333,7 +351,6 @@
  <attr name="max_file_size" type="u64" val="4294967296"/>
  <attr name="disable_unique_filename_suffix" type="bool" val="0"/>
  <attr name="free_space_safety_factor" type="s32" val="5"/>
- <attr name="compression_level" type="u8" val="0"/>
  <rel name="file_layout_params" class="HDF5FileLayoutParams" id="tp_file_layout"/>
  <rel name="filename_params" class="FilenameParams" id="tp-file-params"/>
 </obj>
@@ -537,6 +554,12 @@
  <attr name="periodic_data_transmission_ms" type="u32" val="5"/>
 </obj>
 
+<obj class="SamplesOverThresholdMinima" id="def-sot-minima">
+ <attr name="sot_minimum_plane0" type="u16" val="1"/>
+ <attr name="sot_minimum_plane1" type="u16" val="1"/>
+ <attr name="sot_minimum_plane2" type="u16" val="1"/>
+</obj>
+
 <obj class="SocketReaderConf" id="def-socket-reader-conf">
  <attr name="template_for" type="class" val="SocketReaderModule"/>
  <attr name="emulation_mode" type="bool" val="0"/>
@@ -546,7 +569,6 @@
 
 <obj class="SocketWriterConf" id="def-socket-writer-conf">
  <attr name="template_for" type="class" val="SocketWriterModule"/>
- <attr name="emulation_mode" type="bool" val="0"/>
  <attr name="socket_type" type="enum" val="UDP"/>
  <attr name="remote_ip" type="string" val="127.0.0.1"/>
 </obj>
@@ -647,12 +669,6 @@
 <obj class="TRBConf" id="trb-01">
  <attr name="queues_timeout" type="u32" val="100"/>
  <attr name="trigger_record_timeout_ms" type="u32" val="2858"/>
-</obj>
-
-<obj class="SamplesOverThresholdMinima" id="def-sot-minima">
- <attr name="sot_minimum_plane0" type="u16" val="1"/>
- <attr name="sot_minimum_plane1" type="u16" val="1"/>
- <attr name="sot_minimum_plane2" type="u16" val="1"/>
 </obj>
 
 </oks-data>

--- a/config/daqsystemtest/ru-segment.data.xml
+++ b/config/daqsystemtest/ru-segment.data.xml
@@ -63,7 +63,7 @@
 
 <oks-data>
 
-<info name="" type="" num-of-items="51" oks-format="data" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20231207T105615" last-modified-by="dergonul" last-modified-on="np04-srv-015.cern.ch" last-modification-time="20250325T145413"/>
+<info name="" type="" num-of-items="59" oks-format="data" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20231207T105615" last-modified-by="dergonul" last-modified-on="np04-srv-031.cern.ch" last-modification-time="20250526T125136"/>
 
 <include>
  <file path="schema/confmodel/dunedaq.schema.xml"/>
@@ -101,6 +101,7 @@
  <comment creation-time="20240829T102857" created-by="aoranday" created-on="np04-srv-031.cern.ch" author="aoranday" text="Add AbsRS processor."/>
  <comment creation-time="20250214T120354" created-by="dergonul" created-on="np04-srv-015.cern.ch" author="dergonul" text="Added socket communication classes"/>
  <comment creation-time="20250325T145413" created-by="dergonul" created-on="np04-srv-015.cern.ch" author="dergonul" text="Disabled TP"/>
+ <comment creation-time="20250526T125136" created-by="dergonul" created-on="np04-srv-031.cern.ch" author="dergonul" text="Added ss-crt-bern and ss-crt-grenoble"/>
 </comments>
 
 
@@ -209,15 +210,6 @@
   <ref class="SocketReceiver" id="socket-ru-1-rcv"/>
   <ref class="ResourceSetAND" id="socket_apa1_sender_rset"/>
  </rel>
-</obj>
-
-<obj class="SocketDataSender" id="socket_wib_101_link0">
- <attr name="port" type="u32" val="1234"/>
- <attr name="control_host" type="string" val="localhost"/>
- <rel name="contains">
-  <ref class="DetectorStream" id="stream_100"/>
- </rel>
- <rel name="uses" class="NetworkInterface" id="wib_101_hermes0"/>
 </obj>
 
 <obj class="GeoId" id="g_3_1_1_0">
@@ -356,6 +348,26 @@
  <rel name="fsm" class="FSMconfiguration" id="FSMconfiguration_noAction"/>
 </obj>
 
+<obj class="RCApplication" id="socket-ru-crt-bern-controller">
+ <attr name="application_name" type="string" val="drunc-controller"/>
+ <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
+ <rel name="exposes_service">
+  <ref class="Service" id="rccontroller_control"/>
+ </rel>
+ <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
+ <rel name="fsm" class="FSMconfiguration" id="FSMconfiguration_noAction"/>
+</obj>
+
+<obj class="RCApplication" id="socket-ru-crt-grenoble-controller">
+ <attr name="application_name" type="string" val="drunc-controller"/>
+ <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
+ <rel name="exposes_service">
+  <ref class="Service" id="rccontroller_control"/>
+ </rel>
+ <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
+ <rel name="fsm" class="FSMconfiguration" id="FSMconfiguration_noAction"/>
+</obj>
+
 <obj class="ReadoutApplication" id="ru-01">
  <attr name="application_name" type="string" val="daq_application"/>
  <attr name="tp_generation_enabled" type="bool" val="1"/>
@@ -481,6 +493,92 @@
  <rel name="data_reader" class="SocketReaderConf" id="def-socket-reader-conf"/>
 </obj>
 
+<obj class="ReadoutApplication" id="socket-ru-crt-bern-01">
+ <attr name="application_name" type="string" val="daq_application"/>
+ <attr name="tp_generation_enabled" type="bool" val="0"/>
+ <attr name="ta_generation_enabled" type="bool" val="0"/>
+ <rel name="contains">
+  <ref class="DetectorToDaqConnection" id="socket_conn_apa1"/>
+ </rel>
+ <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
+ <rel name="exposes_service">
+  <ref class="Service" id="daqapp_control"/>
+  <ref class="Service" id="dataRequests"/>
+  <ref class="Service" id="timeSyncs"/>
+  <ref class="Service" id="triggerActivities"/>
+  <ref class="Service" id="triggerPrimitives"/>
+ </rel>
+ <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
+ <rel name="queue_rules">
+  <ref class="QueueConnectionRule" id="fa-queue-rule"/>
+  <ref class="QueueConnectionRule" id="tp-queue-rule"/>
+  <ref class="QueueConnectionRule" id="crt-bern-callback-raw-data-rule"/>
+  <ref class="QueueConnectionRule" id="fd-dlh-data-requests-queue-rule"/>
+ </rel>
+ <rel name="network_rules">
+  <ref class="NetworkConnectionRule" id="ts-net-rule"/>
+  <ref class="NetworkConnectionRule" id="ta-net-rule"/>
+  <ref class="NetworkConnectionRule" id="data-req-readout-net-rule"/>
+  <ref class="NetworkConnectionRule" id="tpset-net-rule"/>
+ </rel>
+ <rel name="action_plans">
+  <ref class="ActionPlan" id="socket-readout-start"/>
+  <ref class="ActionPlan" id="socket-readout-stop"/>
+ </rel>
+ <rel name="tp_source_ids">
+  <ref class="SourceIDConf" id="tp-srcid-1000"/>
+  <ref class="SourceIDConf" id="tp-srcid-1001"/>
+  <ref class="SourceIDConf" id="tp-srcid-1002"/>
+ </rel>
+ <rel name="uses" class="RoHwConfig" id="rohw-1"/>
+ <rel name="link_handler" class="DataHandlerConf" id="def-crt-bern-link-handler"/>
+ <rel name="tp_handler" class="DataHandlerConf" id="def-tp-handler"/>
+ <rel name="data_reader" class="SocketReaderConf" id="def-socket-reader-conf"/>
+</obj>
+
+<obj class="ReadoutApplication" id="socket-ru-crt-grenoble-01">
+ <attr name="application_name" type="string" val="daq_application"/>
+ <attr name="tp_generation_enabled" type="bool" val="0"/>
+ <attr name="ta_generation_enabled" type="bool" val="0"/>
+ <rel name="contains">
+  <ref class="DetectorToDaqConnection" id="socket_conn_apa1"/>
+ </rel>
+ <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
+ <rel name="exposes_service">
+  <ref class="Service" id="daqapp_control"/>
+  <ref class="Service" id="dataRequests"/>
+  <ref class="Service" id="timeSyncs"/>
+  <ref class="Service" id="triggerActivities"/>
+  <ref class="Service" id="triggerPrimitives"/>
+ </rel>
+ <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
+ <rel name="queue_rules">
+  <ref class="QueueConnectionRule" id="fa-queue-rule"/>
+  <ref class="QueueConnectionRule" id="tp-queue-rule"/>
+  <ref class="QueueConnectionRule" id="crt-grenoble-callback-raw-data-rule"/>
+  <ref class="QueueConnectionRule" id="fd-dlh-data-requests-queue-rule"/>
+ </rel>
+ <rel name="network_rules">
+  <ref class="NetworkConnectionRule" id="ts-net-rule"/>
+  <ref class="NetworkConnectionRule" id="ta-net-rule"/>
+  <ref class="NetworkConnectionRule" id="data-req-readout-net-rule"/>
+  <ref class="NetworkConnectionRule" id="tpset-net-rule"/>
+ </rel>
+ <rel name="action_plans">
+  <ref class="ActionPlan" id="socket-readout-start"/>
+  <ref class="ActionPlan" id="socket-readout-stop"/>
+ </rel>
+ <rel name="tp_source_ids">
+  <ref class="SourceIDConf" id="tp-srcid-1000"/>
+  <ref class="SourceIDConf" id="tp-srcid-1001"/>
+  <ref class="SourceIDConf" id="tp-srcid-1002"/>
+ </rel>
+ <rel name="uses" class="RoHwConfig" id="rohw-1"/>
+ <rel name="link_handler" class="DataHandlerConf" id="def-crt-grenoble-link-handler"/>
+ <rel name="tp_handler" class="DataHandlerConf" id="def-tp-handler"/>
+ <rel name="data_reader" class="SocketReaderConf" id="def-socket-reader-conf"/>
+</obj>
+
 <obj class="ResourceSetAND" id="apa1_sender_rset">
  <rel name="contains">
   <ref class="HermesDataSender" id="wib_101_link0"/>
@@ -510,12 +608,37 @@
  <rel name="controller" class="RCApplication" id="ru-controller"/>
 </obj>
 
+<obj class="Segment" id="socket-ru-crt-bern-segment">
+ <rel name="applications">
+  <ref class="SocketSenderApplication" id="ss-crt-bern-01"/>
+  <ref class="ReadoutApplication" id="socket-ru-crt-bern-01"/>
+ </rel>
+ <rel name="controller" class="RCApplication" id="socket-ru-crt-bern-controller"/>
+</obj>
+
+<obj class="Segment" id="socket-ru-crt-grenoble-segment">
+ <rel name="applications">
+  <ref class="SocketSenderApplication" id="ss-crt-grenoble-01"/>
+  <ref class="ReadoutApplication" id="socket-ru-crt-grenoble-01"/>
+ </rel>
+ <rel name="controller" class="RCApplication" id="socket-ru-crt-grenoble-controller"/>
+</obj>
+
 <obj class="Segment" id="socket-ru-segment">
  <rel name="applications">
   <ref class="SocketSenderApplication" id="ss-01"/>
   <ref class="ReadoutApplication" id="socket-ru-01"/>
  </rel>
  <rel name="controller" class="RCApplication" id="socket-ru-controller"/>
+</obj>
+
+<obj class="SocketDataSender" id="socket_wib_101_link0">
+ <attr name="port" type="u32" val="1234"/>
+ <attr name="control_host" type="string" val="localhost"/>
+ <rel name="contains">
+  <ref class="DetectorStream" id="stream_100"/>
+ </rel>
+ <rel name="uses" class="NetworkInterface" id="wib_101_hermes0"/>
 </obj>
 
 <obj class="SocketReceiver" id="socket-ru-1-rcv">
@@ -540,6 +663,76 @@
   <ref class="QueueConnectionRule" id="fa-queue-rule"/>
   <ref class="QueueConnectionRule" id="tp-queue-rule"/>
   <ref class="QueueConnectionRule" id="wib-eth-raw-data-rule"/>
+  <ref class="QueueConnectionRule" id="fd-dlh-data-requests-queue-rule"/>
+ </rel>
+ <rel name="network_rules">
+  <ref class="NetworkConnectionRule" id="ts-net-rule"/>
+  <ref class="NetworkConnectionRule" id="ta-net-rule"/>
+  <ref class="NetworkConnectionRule" id="data-req-readout-net-rule"/>
+  <ref class="NetworkConnectionRule" id="tpset-net-rule"/>
+ </rel>
+ <rel name="action_plans">
+  <ref class="ActionPlan" id="socket-write-start"/>
+  <ref class="ActionPlan" id="socket-write-stop"/>
+ </rel>
+ <rel name="data_writers">
+  <ref class="SocketWriterConf" id="def-socket-writer-conf"/>
+ </rel>
+</obj>
+
+<obj class="SocketSenderApplication" id="ss-crt-bern-01">
+ <attr name="application_name" type="string" val="daq_application"/>
+ <rel name="contains">
+  <ref class="DetectorToDaqConnection" id="socket_conn_apa1"/>
+ </rel>
+ <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
+ <rel name="exposes_service">
+  <ref class="Service" id="daqapp_control"/>
+  <ref class="Service" id="dataRequests"/>
+  <ref class="Service" id="timeSyncs"/>
+  <ref class="Service" id="triggerActivities"/>
+  <ref class="Service" id="triggerPrimitives"/>
+ </rel>
+ <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
+ <rel name="queue_rules">
+  <ref class="QueueConnectionRule" id="fa-queue-rule"/>
+  <ref class="QueueConnectionRule" id="tp-queue-rule"/>
+  <ref class="QueueConnectionRule" id="crt-bern-raw-data-rule"/>
+  <ref class="QueueConnectionRule" id="fd-dlh-data-requests-queue-rule"/>
+ </rel>
+ <rel name="network_rules">
+  <ref class="NetworkConnectionRule" id="ts-net-rule"/>
+  <ref class="NetworkConnectionRule" id="ta-net-rule"/>
+  <ref class="NetworkConnectionRule" id="data-req-readout-net-rule"/>
+  <ref class="NetworkConnectionRule" id="tpset-net-rule"/>
+ </rel>
+ <rel name="action_plans">
+  <ref class="ActionPlan" id="socket-write-start"/>
+  <ref class="ActionPlan" id="socket-write-stop"/>
+ </rel>
+ <rel name="data_writers">
+  <ref class="SocketWriterConf" id="def-socket-writer-conf"/>
+ </rel>
+</obj>
+
+<obj class="SocketSenderApplication" id="ss-crt-grenoble-01">
+ <attr name="application_name" type="string" val="daq_application"/>
+ <rel name="contains">
+  <ref class="DetectorToDaqConnection" id="socket_conn_apa1"/>
+ </rel>
+ <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
+ <rel name="exposes_service">
+  <ref class="Service" id="daqapp_control"/>
+  <ref class="Service" id="dataRequests"/>
+  <ref class="Service" id="timeSyncs"/>
+  <ref class="Service" id="triggerActivities"/>
+  <ref class="Service" id="triggerPrimitives"/>
+ </rel>
+ <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
+ <rel name="queue_rules">
+  <ref class="QueueConnectionRule" id="fa-queue-rule"/>
+  <ref class="QueueConnectionRule" id="tp-queue-rule"/>
+  <ref class="QueueConnectionRule" id="crt-grenoble-raw-data-rule"/>
   <ref class="QueueConnectionRule" id="fd-dlh-data-requests-queue-rule"/>
  </rel>
  <rel name="network_rules">

--- a/config/daqsystemtest/ru-segment.data.xml
+++ b/config/daqsystemtest/ru-segment.data.xml
@@ -191,6 +191,16 @@
  <rel name="geo_id" class="GeoId" id="g_3_2_1_3"/>
 </obj>
 
+<obj class="DetectorStream" id="stream_1001">
+ <attr name="source_id" type="u32" val="1001"/>
+ <rel name="geo_id" class="GeoId" id="g_13_1_1_0"/>
+</obj>
+<obj class="DetectorStream" id="stream_1002">
+ <attr name="source_id" type="u32" val="1002"/>
+ <rel name="geo_id" class="GeoId" id="g_12_1_1_0"/>
+</obj>
+
+
 <obj class="DetectorToDaqConnection" id="conn_apa1">
  <rel name="contains">
   <ref class="DPDKReceiver" id="ru-1-rcv"/>
@@ -212,7 +222,21 @@
  </rel>
 </obj>
 
-<obj class="GeoId" id="g_3_1_1_0">
+<obj class="DetectorToDaqConnection" id="socket_crt_grenoble">
+ <rel name="contains">
+  <ref class="SocketReceiver" id="socket-ru-1-rcv"/>
+  <ref class="ResourceSetAND" id="socket_crt_grenoble_rset"/>
+ </rel>
+</obj>
+
+ <obj class="DetectorToDaqConnection" id="socket_crt_bern">
+  <rel name="contains">
+   <ref class="SocketReceiver" id="socket-ru-1-rcv"/>
+   <ref class="ResourceSetAND" id="socket_crt_bern_rset"/>
+  </rel>
+ </obj>
+
+ <obj class="GeoId" id="g_3_1_1_0">
  <attr name="detector_id" type="u32" val="3"/>
  <attr name="crate_id" type="u32" val="1"/>
  <attr name="slot_id" type="u32" val="1"/>
@@ -266,7 +290,19 @@
  <attr name="stream_id" type="u32" val="3"/>
 </obj>
 
-<obj class="HermesDataSender" id="wib_101_link0">
+<obj class="GeoId" id="g_13_1_1_0">
+ <attr name="detector_id" type="u32" val="13"/>
+ <attr name="crate_id" type="u32" val="1"/>
+ <attr name="slot_id" type="u32" val="1"/>
+</obj>
+
+<obj class="GeoId" id="g_12_1_1_0">
+ <attr name="detector_id" type="u32" val="12"/>
+ <attr name="crate_id" type="u32" val="1"/>
+ <attr name="slot_id" type="u32" val="1"/>
+</obj>
+
+ <obj class="HermesDataSender" id="wib_101_link0">
  <attr name="port" type="u32" val="17476"/>
  <attr name="control_host" type="string" val="localhost"/>
  <rel name="contains">
@@ -498,7 +534,7 @@
  <attr name="tp_generation_enabled" type="bool" val="0"/>
  <attr name="ta_generation_enabled" type="bool" val="0"/>
  <rel name="contains">
-  <ref class="DetectorToDaqConnection" id="socket_conn_apa1"/>
+  <ref class="DetectorToDaqConnection" id="socket_crt_bern"/>
  </rel>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="exposes_service">
@@ -541,7 +577,7 @@
  <attr name="tp_generation_enabled" type="bool" val="0"/>
  <attr name="ta_generation_enabled" type="bool" val="0"/>
  <rel name="contains">
-  <ref class="DetectorToDaqConnection" id="socket_conn_apa1"/>
+  <ref class="DetectorToDaqConnection" id="socket_crt_grenoble"/>
  </rel>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="exposes_service">
@@ -597,6 +633,18 @@
  </rel>
 </obj>
 
+<obj class="ResourceSetAND" id="socket_crt_grenoble_rset">
+ <rel name="contains">
+  <ref class="SocketDataSender" id="socket_sender_crt_grenoble"/>
+ </rel>
+</obj>
+
+<obj class="ResourceSetAND" id="socket_crt_bern_rset">
+ <rel name="contains">
+  <ref class="SocketDataSender" id="socket_sender_crt_bern"/>
+ </rel>
+</obj>
+
 <obj class="RoHwConfig" id="rohw-1">
 </obj>
 
@@ -633,14 +681,32 @@
  <rel name="uses" class="NetworkInterface" id="wib_101_hermes0"/>
 </obj>
 
-<obj class="SocketReceiver" id="socket-ru-1-rcv">
+<obj class="SocketDataSender" id="socket_sender_crt_grenoble">
+ <attr name="port" type="u32" val="1234"/>
+ <attr name="control_host" type="string" val="localhost"/>
+ <rel name="contains">
+  <ref class="DetectorStream" id="stream_1001"/>
+ </rel>
+ <rel name="uses" class="NetworkInterface" id="wib_101_hermes0"/>
+</obj>
+
+<obj class="SocketDataSender" id="socket_sender_crt_bern">
+ <attr name="port" type="u32" val="1234"/>
+ <attr name="control_host" type="string" val="localhost"/>
+ <rel name="contains">
+  <ref class="DetectorStream" id="stream_1002"/>
+ </rel>
+ <rel name="uses" class="NetworkInterface" id="wib_101_hermes0"/>
+</obj>
+
+ <obj class="SocketReceiver" id="socket-ru-1-rcv">
  <rel name="uses" class="NetworkDevice" id="ru_1_readout"/>
 </obj>
 
 <obj class="CRTReaderApplication" id="crt-bern-01">
  <attr name="application_name" type="string" val="daq_application"/>
  <rel name="contains">
-  <ref class="DetectorToDaqConnection" id="socket_conn_apa1"/>
+  <ref class="DetectorToDaqConnection" id="socket_crt_bern"/>
  </rel>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="exposes_service">
@@ -676,7 +742,7 @@
 <obj class="CRTReaderApplication" id="crt-grenoble-01">
  <attr name="application_name" type="string" val="daq_application"/>
  <rel name="contains">
-  <ref class="DetectorToDaqConnection" id="socket_conn_apa1"/>
+  <ref class="DetectorToDaqConnection" id="socket_crt_grenoble"/>
  </rel>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="exposes_service">

--- a/config/daqsystemtest/ru-segment.data.xml
+++ b/config/daqsystemtest/ru-segment.data.xml
@@ -101,7 +101,7 @@
  <comment creation-time="20240829T102857" created-by="aoranday" created-on="np04-srv-031.cern.ch" author="aoranday" text="Add AbsRS processor."/>
  <comment creation-time="20250214T120354" created-by="dergonul" created-on="np04-srv-015.cern.ch" author="dergonul" text="Added socket communication classes"/>
  <comment creation-time="20250325T145413" created-by="dergonul" created-on="np04-srv-015.cern.ch" author="dergonul" text="Disabled TP"/>
- <comment creation-time="20250526T125136" created-by="dergonul" created-on="np04-srv-031.cern.ch" author="dergonul" text="Added ss-crt-bern and ss-crt-grenoble"/>
+ <comment creation-time="20250526T125136" created-by="dergonul" created-on="np04-srv-031.cern.ch" author="dergonul" text="Added crt-bern and crt-grenoble"/>
 </comments>
 
 
@@ -348,7 +348,7 @@
  <rel name="fsm" class="FSMconfiguration" id="FSMconfiguration_noAction"/>
 </obj>
 
-<obj class="RCApplication" id="socket-ru-crt-bern-controller">
+<obj class="RCApplication" id="crt-bern-controller">
  <attr name="application_name" type="string" val="drunc-controller"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="exposes_service">
@@ -358,7 +358,7 @@
  <rel name="fsm" class="FSMconfiguration" id="FSMconfiguration_noAction"/>
 </obj>
 
-<obj class="RCApplication" id="socket-ru-crt-grenoble-controller">
+<obj class="RCApplication" id="crt-grenoble-controller">
  <attr name="application_name" type="string" val="drunc-controller"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="exposes_service">
@@ -493,7 +493,7 @@
  <rel name="data_reader" class="SocketReaderConf" id="def-socket-reader-conf"/>
 </obj>
 
-<obj class="ReadoutApplication" id="socket-ru-crt-bern-01">
+<obj class="ReadoutApplication" id="crt-bern-ru-01">
  <attr name="application_name" type="string" val="daq_application"/>
  <attr name="tp_generation_enabled" type="bool" val="0"/>
  <attr name="ta_generation_enabled" type="bool" val="0"/>
@@ -536,7 +536,7 @@
  <rel name="data_reader" class="SocketReaderConf" id="def-socket-reader-conf"/>
 </obj>
 
-<obj class="ReadoutApplication" id="socket-ru-crt-grenoble-01">
+<obj class="ReadoutApplication" id="crt-grenoble-ru-01">
  <attr name="application_name" type="string" val="daq_application"/>
  <attr name="tp_generation_enabled" type="bool" val="0"/>
  <attr name="ta_generation_enabled" type="bool" val="0"/>
@@ -608,28 +608,20 @@
  <rel name="controller" class="RCApplication" id="ru-controller"/>
 </obj>
 
-<obj class="Segment" id="socket-ru-crt-bern-segment">
+<obj class="Segment" id="crt-bern-segment">
  <rel name="applications">
-  <ref class="SocketSenderApplication" id="ss-crt-bern-01"/>
-  <ref class="ReadoutApplication" id="socket-ru-crt-bern-01"/>
+  <ref class="CRTReaderApplication" id="crt-bern-01"/>
+  <ref class="ReadoutApplication" id="crt-bern-ru-01"/>
  </rel>
- <rel name="controller" class="RCApplication" id="socket-ru-crt-bern-controller"/>
+ <rel name="controller" class="RCApplication" id="crt-bern-controller"/>
 </obj>
 
-<obj class="Segment" id="socket-ru-crt-grenoble-segment">
+<obj class="Segment" id="crt-grenoble-segment">
  <rel name="applications">
-  <ref class="SocketSenderApplication" id="ss-crt-grenoble-01"/>
-  <ref class="ReadoutApplication" id="socket-ru-crt-grenoble-01"/>
+  <ref class="CRTReaderApplication" id="crt-grenoble-01"/>
+  <ref class="ReadoutApplication" id="crt-grenoble-ru-01"/>
  </rel>
- <rel name="controller" class="RCApplication" id="socket-ru-crt-grenoble-controller"/>
-</obj>
-
-<obj class="Segment" id="socket-ru-segment">
- <rel name="applications">
-  <ref class="SocketSenderApplication" id="ss-01"/>
-  <ref class="ReadoutApplication" id="socket-ru-01"/>
- </rel>
- <rel name="controller" class="RCApplication" id="socket-ru-controller"/>
+ <rel name="controller" class="RCApplication" id="crt-grenoble-controller"/>
 </obj>
 
 <obj class="SocketDataSender" id="socket_wib_101_link0">
@@ -645,42 +637,7 @@
  <rel name="uses" class="NetworkDevice" id="ru_1_readout"/>
 </obj>
 
-<obj class="SocketSenderApplication" id="ss-01">
- <attr name="application_name" type="string" val="daq_application"/>
- <rel name="contains">
-  <ref class="DetectorToDaqConnection" id="socket_conn_apa1"/>
- </rel>
- <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
- <rel name="exposes_service">
-  <ref class="Service" id="daqapp_control"/>
-  <ref class="Service" id="dataRequests"/>
-  <ref class="Service" id="timeSyncs"/>
-  <ref class="Service" id="triggerActivities"/>
-  <ref class="Service" id="triggerPrimitives"/>
- </rel>
- <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
- <rel name="queue_rules">
-  <ref class="QueueConnectionRule" id="fa-queue-rule"/>
-  <ref class="QueueConnectionRule" id="tp-queue-rule"/>
-  <ref class="QueueConnectionRule" id="wib-eth-raw-data-rule"/>
-  <ref class="QueueConnectionRule" id="fd-dlh-data-requests-queue-rule"/>
- </rel>
- <rel name="network_rules">
-  <ref class="NetworkConnectionRule" id="ts-net-rule"/>
-  <ref class="NetworkConnectionRule" id="ta-net-rule"/>
-  <ref class="NetworkConnectionRule" id="data-req-readout-net-rule"/>
-  <ref class="NetworkConnectionRule" id="tpset-net-rule"/>
- </rel>
- <rel name="action_plans">
-  <ref class="ActionPlan" id="socket-write-start"/>
-  <ref class="ActionPlan" id="socket-write-stop"/>
- </rel>
- <rel name="data_writers">
-  <ref class="SocketWriterConf" id="def-socket-writer-conf"/>
- </rel>
-</obj>
-
-<obj class="SocketSenderApplication" id="ss-crt-bern-01">
+<obj class="CRTReaderApplication" id="crt-bern-01">
  <attr name="application_name" type="string" val="daq_application"/>
  <rel name="contains">
   <ref class="DetectorToDaqConnection" id="socket_conn_apa1"/>
@@ -707,15 +664,16 @@
   <ref class="NetworkConnectionRule" id="tpset-net-rule"/>
  </rel>
  <rel name="action_plans">
-  <ref class="ActionPlan" id="socket-write-start"/>
-  <ref class="ActionPlan" id="socket-write-stop"/>
+  <ref class="ActionPlan" id="crt-bern-readout-start"/>
+  <ref class="ActionPlan" id="crt-bern-readout-stop"/>  
  </rel>
  <rel name="data_writers">
   <ref class="SocketWriterConf" id="def-socket-writer-conf"/>
  </rel>
+ <rel name="data_reader" class="CRTBernReaderConf" id="def-crt-bern-receiver-conf"/>
 </obj>
 
-<obj class="SocketSenderApplication" id="ss-crt-grenoble-01">
+<obj class="CRTReaderApplication" id="crt-grenoble-01">
  <attr name="application_name" type="string" val="daq_application"/>
  <rel name="contains">
   <ref class="DetectorToDaqConnection" id="socket_conn_apa1"/>
@@ -742,12 +700,13 @@
   <ref class="NetworkConnectionRule" id="tpset-net-rule"/>
  </rel>
  <rel name="action_plans">
-  <ref class="ActionPlan" id="socket-write-start"/>
-  <ref class="ActionPlan" id="socket-write-stop"/>
+  <ref class="ActionPlan" id="crt-grenoble-readout-start"/>
+  <ref class="ActionPlan" id="crt-grenoble-readout-stop"/>  
  </rel>
  <rel name="data_writers">
   <ref class="SocketWriterConf" id="def-socket-writer-conf"/>
  </rel>
+ <rel name="data_reader" class="CRTGrenobleReaderConf" id="def-crt-grenoble-receiver-conf"/>
 </obj>
 
 <obj class="SourceIDConf" id="tp-srcid-1000">

--- a/config/daqsystemtest/ru-segment.data.xml
+++ b/config/daqsystemtest/ru-segment.data.xml
@@ -211,7 +211,7 @@
  </rel>
 </obj>
 
-<obj class="FakeSocketDataSender" id="socket_wib_101_link0">
+<obj class="SocketDataSender" id="socket_wib_101_link0">
  <attr name="port" type="u32" val="1234"/>
  <attr name="control_host" type="string" val="localhost"/>
  <rel name="contains">
@@ -495,7 +495,7 @@
 
 <obj class="ResourceSetAND" id="socket_apa1_sender_rset">
  <rel name="contains">
-  <ref class="FakeSocketDataSender" id="socket_wib_101_link0"/>
+  <ref class="SocketDataSender" id="socket_wib_101_link0"/>
  </rel>
 </obj>
 


### PR DESCRIPTION
![Diagramme sans nom drawio](https://github.com/user-attachments/assets/b1d92df5-7584-4e78-9a48-63fef051c541)
- Added new sessions for `CRTBernFrame` and `CRTGrenobleFrame`.
- `SocketSenderApplication` is no longer needed. (It is obsoleted by `CRTReaderApplication`.)
- `FakeSocketDataSender` is renamed as `SocketDataSender`.