### PR TITLE
Several changes to the example_system_test regression test to help it run more reliably

### DIFF
--- a/config/daqsystemtest/moduleconfs.data.xml
+++ b/config/daqsystemtest/moduleconfs.data.xml
@@ -229,8 +229,8 @@
  <attr name="general_queue_timeout_ms" type="u32" val="100"/>
  <attr name="stop_timeout_ms" type="u32" val="100"/>
  <attr name="td_send_retries" type="s32" val="5"/>
- <attr name="busy_threshold" type="s32" val="2"/>
- <attr name="free_threshold" type="s32" val="1"/>
+ <attr name="busy_threshold" type="s32" val="4"/>
+ <attr name="free_threshold" type="s32" val="3"/>
 </obj>
 
 <obj class="DPDKReaderConf" id="def-emu-nic-receiver-conf">

--- a/integtest/example_system_test.py
+++ b/integtest/example_system_test.py
@@ -27,7 +27,7 @@ wibeth_frag_params = {
     "fragment_type": "WIBEth",
     "expected_fragment_count": 0,  # determined later
     "min_size_bytes": 7272,
-    "max_size_bytes": 21672,
+    "max_size_bytes": 28872,
 }
 # sizes: 128 is for one TC with zero TAs inside it (72+56)
 #        208 is for one TC with one TA inside it (72+56+80)
@@ -52,6 +52,8 @@ triggerprimitive_frag_params = {
     "min_size_bytes": 72,
     "max_size_bytes": 168,
 }
+# 03-Jul-2025, KAB: changing the default max size from 72 to 100 to handle cases in which there
+# was a Random or Prescale trigger along with a coincidental HSI event within the readout window.
 hsi_frag_params = {
     "fragment_type_description": "HSI",
     "fragment_type": "Hardware_Signal",
@@ -59,7 +61,7 @@ hsi_frag_params = {
     "min_size_bytes": 72,
     "max_size_bytes": 100,
     "frag_sizes_by_TC_type": {"kTiming": {"min_size_bytes": 100, "max_size_bytes": 100},
-                              "default": {"min_size_bytes":  72, "max_size_bytes":  72} }
+                              "default": {"min_size_bytes":  72, "max_size_bytes": 100} }
 }
 ignored_logfile_problems = {
     "local-connection-server": [


### PR DESCRIPTION
I've recently noticed a few failures in the running of the `example_system_test`, and these changes are a reaction to those.

1. Occasional warning messages about trigger inhibits.
    * The configurations that are provided in the `daqsystemtest/example-configs.data.xml` (and are used by the `example_system_test`) have three types of triggers enabled (kTiming, kRandom, and kPrescale).  This means that it is possible for three TriggerDecisions to be created in a small time window occasionally.  However, the number of available slots that are configured in the TriggerRecordBuilders is 2.  I've confirmed that when we see the trigger inhibit messages, it is just because three triggers happened close in time, and my proposed solution is to increase the configured busy and free settings from 2 & 1 to 4 & 3.

2. Rare complaints about WIBEth fragment sizes that are larger than expected
    * I'm not completely sure what is causing this, but I suspect that it has something to do with the size of the readout window varying when a couple of TriggerCandidates overlap in time.  That should be investigated, and probably should be covered in a different integration/regression test, but in this regression test, I think that we should just bump up the maximum allowed size of WIBEth fragments to avoid these complaints.  The change in size corresponds to just one WIBEth super-chunk, so it is not a big change.

3. Rare complaints about HSI fragment sizes that are larger than expected
    * This appears to be an accidental overlap between an HSI event and a kRandom or kPrescale trigger.  I don't know of any reasonable way to avoid that, so I increased the default maximum allowed size for HSI fragments for non-kTiming triggers to 100.  A size of 100 means that there *is* HSI information in the fragment, whereas a size of 72 means that the HSI fragment is empty.

Testing these changes will likely consist of running the `example_system_test` many times and verifying that none of these problems happen.  E.g.

- `daqsystemtest_integtest_bundle.sh -k example -N 5 --stop-on-fail`

