### PR TITLE
Reduced sample configuration duplication in example configs

### DIFF
--- a/config/daqsystemtest/ccm.data.xml
+++ b/config/daqsystemtest/ccm.data.xml
@@ -129,46 +129,6 @@
  <attr name="type" type="enum" val="file"/>
 </obj>
 
-<obj class="RCApplication" id="crt-bern-root-controller">
- <attr name="application_name" type="string" val="drunc-controller"/>
- <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
- <rel name="exposes_service">
-  <ref class="Service" id="rccontroller_control"/>
- </rel>
- <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
- <rel name="fsm" class="FSMconfiguration" id="fsmConf-test"/>
-</obj>
-
-<obj class="RCApplication" id="crt-grenoble-root-controller">
- <attr name="application_name" type="string" val="drunc-controller"/>
- <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
- <rel name="exposes_service">
-  <ref class="Service" id="rccontroller_control"/>
- </rel>
- <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
- <rel name="fsm" class="FSMconfiguration" id="fsmConf-test"/>
-</obj>
-
-<obj class="RCApplication" id="emu-crt-bern-root-controller">
- <attr name="application_name" type="string" val="drunc-controller"/>
- <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
- <rel name="exposes_service">
-  <ref class="Service" id="rccontroller_control"/>
- </rel>
- <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
- <rel name="fsm" class="FSMconfiguration" id="fsmConf-test"/>
-</obj>
-
-<obj class="RCApplication" id="emu-crt-grenoble-root-controller">
- <attr name="application_name" type="string" val="drunc-controller"/>
- <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
- <rel name="exposes_service">
-  <ref class="Service" id="rccontroller_control"/>
- </rel>
- <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
- <rel name="fsm" class="FSMconfiguration" id="fsmConf-test"/>
-</obj>
-
 <obj class="RCApplication" id="root-controller">
  <attr name="application_name" type="string" val="drunc-controller"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>

--- a/config/daqsystemtest/ccm.data.xml
+++ b/config/daqsystemtest/ccm.data.xml
@@ -63,7 +63,7 @@
 
 <oks-data>
 
-<info name="" type="" num-of-items="32" oks-format="data" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20231207T110859" last-modified-by="dergonul" last-modified-on="np04-srv-028.cern.ch" last-modification-time="20250805T092423"/>
+<info name="" type="" num-of-items="29" oks-format="data" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20231207T110859" last-modified-by="biery" last-modified-on="daq.fnal.gov" last-modification-time="20250903T173857"/>
 
 <include>
  <file path="schema/confmodel/dunedaq.schema.xml"/>

--- a/config/daqsystemtest/example-configs.data.xml
+++ b/config/daqsystemtest/example-configs.data.xml
@@ -63,7 +63,7 @@
 
 <oks-data>
 
-<info name="" type="" num-of-items="14" oks-format="data" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20231207T105549" last-modified-by="dergonul" last-modified-on="np04-srv-028.cern.ch" last-modification-time="20250805T092423"/>
+<info name="" type="" num-of-items="10" oks-format="data" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20231207T105549" last-modified-by="biery" last-modified-on="daq.fnal.gov" last-modification-time="20250903T173857"/>
 
 <include>
  <file path="schema/confmodel/dunedaq.schema.xml"/>
@@ -97,16 +97,6 @@
  <attr name="offline_data_stream" type="string" val="cosmics"/>
 </obj>
 
-<obj class="Segment" id="socket-root-segment">
- <rel name="segments">
-  <ref class="Segment" id="socket-ru-segment"/>
-  <ref class="Segment" id="df-segment"/>
-  <ref class="Segment" id="trg-segment"/>
-  <ref class="Segment" id="hsi-fake-segment"/>
- </rel>
- <rel name="controller" class="RCApplication" id="socket-root-controller"/>
-</obj>
-
 <obj class="Segment" id="root-segment">
  <rel name="segments">
   <ref class="Segment" id="ru-segment"/>
@@ -115,6 +105,16 @@
   <ref class="Segment" id="hsi-fake-segment"/>
  </rel>
  <rel name="controller" class="RCApplication" id="root-controller"/>
+</obj>
+
+<obj class="Segment" id="socket-root-segment">
+ <rel name="segments">
+  <ref class="Segment" id="socket-ru-segment"/>
+  <ref class="Segment" id="df-segment"/>
+  <ref class="Segment" id="trg-segment"/>
+  <ref class="Segment" id="hsi-fake-segment"/>
+ </rel>
+ <rel name="controller" class="RCApplication" id="socket-root-controller"/>
 </obj>
 
 <obj class="Session" id="ehn1-local-1x1-config">

--- a/config/daqsystemtest/example-configs.data.xml
+++ b/config/daqsystemtest/example-configs.data.xml
@@ -97,44 +97,14 @@
  <attr name="offline_data_stream" type="string" val="cosmics"/>
 </obj>
 
-<obj class="Segment" id="crt-bern-root-segment">
+<obj class="Segment" id="socket-root-segment">
  <rel name="segments">
-  <ref class="Segment" id="crt-bern-segment"/>
+  <ref class="Segment" id="socket-ru-segment"/>
   <ref class="Segment" id="df-segment"/>
   <ref class="Segment" id="trg-segment"/>
   <ref class="Segment" id="hsi-fake-segment"/>
  </rel>
- <rel name="controller" class="RCApplication" id="crt-bern-root-controller"/>
-</obj>
-
-<obj class="Segment" id="crt-grenoble-root-segment">
- <rel name="segments">
-  <ref class="Segment" id="crt-grenoble-segment"/>
-  <ref class="Segment" id="df-segment"/>
-  <ref class="Segment" id="trg-segment"/>
-  <ref class="Segment" id="hsi-fake-segment"/>
- </rel>
- <rel name="controller" class="RCApplication" id="crt-grenoble-root-controller"/>
-</obj>
-
-<obj class="Segment" id="emu-crt-bern-root-segment">
- <rel name="segments">
-  <ref class="Segment" id="emu-crt-bern-segment"/>
-  <ref class="Segment" id="df-segment"/>
-  <ref class="Segment" id="trg-segment"/>
-  <ref class="Segment" id="hsi-fake-segment"/>
- </rel>
- <rel name="controller" class="RCApplication" id="emu-crt-bern-root-controller"/>
-</obj>
-
-<obj class="Segment" id="emu-crt-grenoble-root-segment">
- <rel name="segments">
-  <ref class="Segment" id="emu-crt-grenoble-segment"/>
-  <ref class="Segment" id="df-segment"/>
-  <ref class="Segment" id="trg-segment"/>
-  <ref class="Segment" id="hsi-fake-segment"/>
- </rel>
- <rel name="controller" class="RCApplication" id="emu-crt-grenoble-root-controller"/>
+ <rel name="controller" class="RCApplication" id="socket-root-controller"/>
 </obj>
 
 <obj class="Segment" id="root-segment">
@@ -248,7 +218,7 @@
  <rel name="opmon_uri" class="OpMonURI" id="local-opmon-uri"/>
 </obj>
 
-<obj class="Session" id="local-crt-bern-1x1-config">
+<obj class="Session" id="local-socket-1x1-config">
  <attr name="data_request_timeout_ms" type="u32" val="1000"/>
  <attr name="data_rate_slowdown_factor" type="u32" val="1"/>
  <attr name="controller_log_level" type="enum" val="INFO"/>
@@ -267,88 +237,7 @@
   <ref class="Variable" id="local-env-ers-fatal"/>
   <ref class="Variable" id="local-env-ers-debug-level"/>
  </rel>
- <rel name="segment" class="Segment" id="crt-bern-root-segment"/>
- <rel name="infrastructure_applications">
-  <ref class="ConnectionService" id="local-connection-server"/>
- </rel>
- <rel name="detector_configuration" class="DetectorConfig" id="dummy-detector"/>
- <rel name="opmon_uri" class="OpMonURI" id="local-opmon-uri"/>
-</obj>
-
-<obj class="Session" id="local-crt-grenoble-1x1-config">
- <attr name="data_request_timeout_ms" type="u32" val="1000"/>
- <attr name="data_rate_slowdown_factor" type="u32" val="1"/>
- <attr name="controller_log_level" type="enum" val="INFO"/>
- <rel name="disabled">
-  <ref class="DFApplication" id="df-02"/>
-  <ref class="DFApplication" id="df-03"/>
-  <ref class="TPStreamWriterApplication" id="tp-stream-writer"/>
-  <ref class="TriggerApplication" id="tc-maker-1"/>
- </rel>
- <rel name="connectivity_service" class="ConnectivityService" id="local-connectivity-service-config"/>
- <rel name="environment">
-  <ref class="Variable" id="local-env-ers-verb"/>
-  <ref class="Variable" id="local-env-ers-info"/>
-  <ref class="Variable" id="local-env-ers-warning"/>
-  <ref class="Variable" id="local-env-ers-error"/>
-  <ref class="Variable" id="local-env-ers-fatal"/>
-  <ref class="Variable" id="local-env-ers-debug-level"/>
- </rel>
- <rel name="segment" class="Segment" id="crt-grenoble-root-segment"/>
- <rel name="infrastructure_applications">
-  <ref class="ConnectionService" id="local-connection-server"/>
- </rel>
- <rel name="detector_configuration" class="DetectorConfig" id="dummy-detector"/>
- <rel name="opmon_uri" class="OpMonURI" id="local-opmon-uri"/>
-</obj>
-
-<obj class="Session" id="local-emu-crt-bern-1x1-config">
- <attr name="data_request_timeout_ms" type="u32" val="1000"/>
- <attr name="data_rate_slowdown_factor" type="u32" val="1"/>
- <attr name="controller_log_level" type="enum" val="INFO"/>
- <rel name="disabled">
-  <ref class="DFApplication" id="df-02"/>
-  <ref class="DFApplication" id="df-03"/>
-  <ref class="TPStreamWriterApplication" id="tp-stream-writer"/>
-  <ref class="TriggerApplication" id="tc-maker-1"/>
- </rel>
- <rel name="connectivity_service" class="ConnectivityService" id="local-connectivity-service-config"/>
- <rel name="environment">
-  <ref class="Variable" id="local-env-ers-verb"/>
-  <ref class="Variable" id="local-env-ers-info"/>
-  <ref class="Variable" id="local-env-ers-warning"/>
-  <ref class="Variable" id="local-env-ers-error"/>
-  <ref class="Variable" id="local-env-ers-fatal"/>
-  <ref class="Variable" id="local-env-ers-debug-level"/>
- </rel>
- <rel name="segment" class="Segment" id="emu-crt-bern-root-segment"/>
- <rel name="infrastructure_applications">
-  <ref class="ConnectionService" id="local-connection-server"/>
- </rel>
- <rel name="detector_configuration" class="DetectorConfig" id="dummy-detector"/>
- <rel name="opmon_uri" class="OpMonURI" id="local-opmon-uri"/>
-</obj>
-
-<obj class="Session" id="local-emu-crt-grenoble-1x1-config">
- <attr name="data_request_timeout_ms" type="u32" val="1000"/>
- <attr name="data_rate_slowdown_factor" type="u32" val="1"/>
- <attr name="controller_log_level" type="enum" val="INFO"/>
- <rel name="disabled">
-  <ref class="DFApplication" id="df-02"/>
-  <ref class="DFApplication" id="df-03"/>
-  <ref class="TPStreamWriterApplication" id="tp-stream-writer"/>
-  <ref class="TriggerApplication" id="tc-maker-1"/>
- </rel>
- <rel name="connectivity_service" class="ConnectivityService" id="local-connectivity-service-config"/>
- <rel name="environment">
-  <ref class="Variable" id="local-env-ers-verb"/>
-  <ref class="Variable" id="local-env-ers-info"/>
-  <ref class="Variable" id="local-env-ers-warning"/>
-  <ref class="Variable" id="local-env-ers-error"/>
-  <ref class="Variable" id="local-env-ers-fatal"/>
-  <ref class="Variable" id="local-env-ers-debug-level"/>
- </rel>
- <rel name="segment" class="Segment" id="emu-crt-grenoble-root-segment"/>
+ <rel name="segment" class="Segment" id="socket-root-segment"/>
  <rel name="infrastructure_applications">
   <ref class="ConnectionService" id="local-connection-server"/>
  </rel>

--- a/config/daqsystemtest/moduleconfs.data.xml
+++ b/config/daqsystemtest/moduleconfs.data.xml
@@ -96,43 +96,7 @@
  <attr name="plane2" type="u16" val="100"/>
 </obj>
 
-<obj class="ActionPlan" id="crt-bern-readout-start">
- <attr name="execution_policy" type="enum" val="modules-in-parallel"/>
- <rel name="command" class="FSMCommand" id="start"/>
- <rel name="steps">
-  <ref class="DaqModulesGroupByType" id="socket-writer-data-source-step"/>
-  <ref class="DaqModulesGroupByType" id="crt-bern-reader-data-source-step"/>
- </rel>
-</obj>
-
-<obj class="ActionPlan" id="crt-bern-readout-stop">
- <attr name="execution_policy" type="enum" val="modules-in-parallel"/>
- <rel name="command" class="FSMCommand" id="stop_trigger_sources"/>
- <rel name="steps">
-  <ref class="DaqModulesGroupByType" id="crt-bern-reader-data-source-step"/>
-  <ref class="DaqModulesGroupByType" id="socket-writer-data-source-step"/>
- </rel>
-</obj>
-
-<obj class="ActionPlan" id="crt-grenoble-readout-start">
- <attr name="execution_policy" type="enum" val="modules-in-parallel"/>
- <rel name="command" class="FSMCommand" id="start"/>
- <rel name="steps">
-  <ref class="DaqModulesGroupByType" id="socket-writer-data-source-step"/>
-  <ref class="DaqModulesGroupByType" id="crt-grenoble-reader-data-source-step"/>
- </rel>
-</obj>
-
-<obj class="ActionPlan" id="crt-grenoble-readout-stop">
- <attr name="execution_policy" type="enum" val="modules-in-parallel"/>
- <rel name="command" class="FSMCommand" id="stop_trigger_sources"/>
- <rel name="steps">
-  <ref class="DaqModulesGroupByType" id="crt-grenoble-reader-data-source-step"/>
-  <ref class="DaqModulesGroupByType" id="socket-writer-data-source-step"/>
- </rel>
-</obj>
-
-<obj class="ActionPlan" id="emu-crt-readout-start">
+<obj class="ActionPlan" id="crt-readout-start">
  <attr name="execution_policy" type="enum" val="modules-in-parallel"/>
  <rel name="command" class="FSMCommand" id="start"/>
  <rel name="steps">
@@ -141,7 +105,7 @@
  </rel>
 </obj>
 
-<obj class="ActionPlan" id="emu-crt-readout-stop">
+<obj class="ActionPlan" id="crt-readout-stop">
  <attr name="execution_policy" type="enum" val="modules-in-parallel"/>
  <rel name="command" class="FSMCommand" id="stop_trigger_sources"/>
  <rel name="steps">
@@ -214,7 +178,7 @@
 <obj class="CRTReaderConf" id="def-emu-crt-receiver-conf">
  <attr name="template_for" type="class" val="FDFakeReaderModule"/>
  <attr name="emulation_mode" type="bool" val="1"/>
- <rel name="emulation_conf" class="StreamEmulationParameters" id="stream-emu"/>
+ <rel name="emulation_conf" class="StreamEmulationParameters" id="crt-stream-emu"/>
 </obj>
 
 <obj class="DFOConf" id="dfoconf-01">
@@ -678,6 +642,16 @@
  <attr name="random_population_size" type="u32" val="100000"/>
  <attr name="frame_error_rate_hz" type="float" val="0"/>
  <attr name="generate_periodic_adc_pattern" type="bool" val="1"/>
+ <attr name="TP_rate_per_channel" type="float" val="1"/>
+</obj>
+
+<obj class="StreamEmulationParameters" id="crt-stream-emu">
+ <attr name="data_file_name" type="string" val="/cvmfs/dunedaq.opensciencegrid.org/assets/files/d/d/1/wibeth_output_all_zeros.bin"/>
+ <attr name="input_file_size_limit" type="u32" val="5777280"/>
+ <attr name="set_t0" type="bool" val="1"/>
+ <attr name="random_population_size" type="u32" val="100000"/>
+ <attr name="frame_error_rate_hz" type="float" val="0"/>
+ <attr name="generate_periodic_adc_pattern" type="bool" val="0"/>
  <attr name="TP_rate_per_channel" type="float" val="1"/>
 </obj>
 

--- a/config/daqsystemtest/moduleconfs.data.xml
+++ b/config/daqsystemtest/moduleconfs.data.xml
@@ -63,7 +63,7 @@
 
 <oks-data>
 
-<info name="" type="" num-of-items="89" oks-format="data" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20231207T105629" last-modified-by="dergonul" last-modified-on="np04-srv-028.cern.ch" last-modification-time="20250805T092423"/>
+<info name="" type="" num-of-items="87" oks-format="data" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20231207T105629" last-modified-by="biery" last-modified-on="daq.fnal.gov" last-modification-time="20250903T173857"/>
 
 <include>
  <file path="schema/confmodel/dunedaq.schema.xml"/>
@@ -91,6 +91,7 @@
 
 
 <obj class="AVXThresholdProcessor" id="tpg-threshold-proc">
+ <attr name="metric_collect_time_sample_period" type="u64" val="256"/>
  <attr name="plane0" type="u16" val="100"/>
  <attr name="plane1" type="u16" val="100"/>
  <attr name="plane2" type="u16" val="100"/>
@@ -201,61 +202,70 @@
 </obj>
 
 <obj class="DaqModulesGroupByType" id="aggregator-step">
+ <attr name="optional" type="bool" val="0"/>
  <attr name="modules" type="class">
   <data val="FragmentAggregatorModule"/>
  </attr>
 </obj>
 
 <obj class="DaqModulesGroupByType" id="crt-bern-reader-data-source-step">
+ <attr name="optional" type="bool" val="0"/>
  <attr name="modules" type="class">
   <data val="CRTBernReaderModule"/>
  </attr>
 </obj>
 
 <obj class="DaqModulesGroupByType" id="crt-grenoble-reader-data-source-step">
+ <attr name="optional" type="bool" val="0"/>
  <attr name="modules" type="class">
   <data val="CRTGrenobleReaderModule"/>
  </attr>
 </obj>
 
 <obj class="DaqModulesGroupByType" id="data-source-step">
+ <attr name="optional" type="bool" val="0"/>
  <attr name="modules" type="class">
   <data val="FDFakeReaderModule"/>
  </attr>
 </obj>
 
 <obj class="DaqModulesGroupByType" id="dlh-step">
+ <attr name="optional" type="bool" val="0"/>
  <attr name="modules" type="class">
   <data val="FDDataHandlerModule"/>
  </attr>
 </obj>
 
+<obj class="DaqModulesGroupByType" id="optional-tp-handler-step">
+ <attr name="optional" type="bool" val="1"/>
+ <attr name="modules" type="class">
+  <data val="TriggerDataHandlerModule"/>
+ </attr>
+</obj>
+
 <obj class="DaqModulesGroupByType" id="socket-reader-data-source-step">
+ <attr name="optional" type="bool" val="0"/>
  <attr name="modules" type="class">
   <data val="SocketReaderModule"/>
  </attr>
 </obj>
 
 <obj class="DaqModulesGroupByType" id="socket-writer-data-source-step">
+ <attr name="optional" type="bool" val="0"/>
  <attr name="modules" type="class">
   <data val="SocketWriterModule"/>
  </attr>
 </obj>
 
 <obj class="DaqModulesGroupByType" id="subscriber-step">
+ <attr name="optional" type="bool" val="0"/>
  <attr name="modules" type="class">
   <data val="DataSubscriberModule"/>
  </attr>
 </obj>
 
 <obj class="DaqModulesGroupByType" id="ta-handler-step">
- <attr name="modules" type="class">
-  <data val="TriggerDataHandlerModule"/>
- </attr>
-</obj>
-
-<obj class="DaqModulesGroupByType" id="optional-tp-handler-step">
- <attr name="optional" type="bool" val="1"/>
+ <attr name="optional" type="bool" val="0"/>
  <attr name="modules" type="class">
   <data val="TriggerDataHandlerModule"/>
  </attr>
@@ -382,6 +392,12 @@
  <rel name="data_processor" class="TPDataProcessor" id="tp-processor"/>
 </obj>
 
+<obj class="DataProcessor" id="def-base-processor">
+ <attr name="queue_sizes" type="u32" val="10000"/>
+ <attr name="thread_names_prefix" type="string" val="postproc-"/>
+ <attr name="latency_monitoring" type="bool" val="1"/>
+</obj>
+
 <obj class="DataReaderConf" id="ta-subscriber-1">
  <attr name="template_for" type="class" val="DataSubscriberModule"/>
  <attr name="emulation_mode" type="bool" val="0"/>
@@ -425,9 +441,6 @@
  <attr name="max_write_retry_time_ms" type="s32" val="1000"/>
  <attr name="write_retry_time_increase_factor" type="s32" val="2"/>
  <rel name="data_store_params" class="DataStoreConf" id="default"/>
-</obj>
-
-<obj class="DataProcessor" id="def-base-processor">
 </obj>
 
 <obj class="FilenameParams" id="default">
@@ -635,16 +648,6 @@
  <attr name="remote_ip" type="string" val="127.0.0.1"/>
 </obj>
 
-<obj class="StreamEmulationParameters" id="stream-emu">
- <attr name="data_file_name" type="string" val="/cvmfs/dunedaq.opensciencegrid.org/assets/files/d/d/1/wibeth_output_all_zeros.bin"/>
- <attr name="input_file_size_limit" type="u32" val="5777280"/>
- <attr name="set_t0" type="bool" val="1"/>
- <attr name="random_population_size" type="u32" val="100000"/>
- <attr name="frame_error_rate_hz" type="float" val="0"/>
- <attr name="generate_periodic_adc_pattern" type="bool" val="1"/>
- <attr name="TP_rate_per_channel" type="float" val="1"/>
-</obj>
-
 <obj class="StreamEmulationParameters" id="crt-stream-emu">
  <attr name="data_file_name" type="string" val="/cvmfs/dunedaq.opensciencegrid.org/assets/files/d/d/1/wibeth_output_all_zeros.bin"/>
  <attr name="input_file_size_limit" type="u32" val="5777280"/>
@@ -652,6 +655,16 @@
  <attr name="random_population_size" type="u32" val="100000"/>
  <attr name="frame_error_rate_hz" type="float" val="0"/>
  <attr name="generate_periodic_adc_pattern" type="bool" val="0"/>
+ <attr name="TP_rate_per_channel" type="float" val="1"/>
+</obj>
+
+<obj class="StreamEmulationParameters" id="stream-emu">
+ <attr name="data_file_name" type="string" val="/cvmfs/dunedaq.opensciencegrid.org/assets/files/d/d/1/wibeth_output_all_zeros.bin"/>
+ <attr name="input_file_size_limit" type="u32" val="5777280"/>
+ <attr name="set_t0" type="bool" val="1"/>
+ <attr name="random_population_size" type="u32" val="100000"/>
+ <attr name="frame_error_rate_hz" type="float" val="0"/>
+ <attr name="generate_periodic_adc_pattern" type="bool" val="1"/>
  <attr name="TP_rate_per_channel" type="float" val="1"/>
 </obj>
 
@@ -733,6 +746,7 @@
  <attr name="thread_names_prefix" type="string" val="postproc-"/>
  <attr name="latency_monitoring" type="bool" val="1"/>
  <attr name="channel_map" type="string" val="PD2HDTPCChannelMap"/>
+ <attr name="metric_collect_opmon_rate" type="u32" val="1"/>
  <rel name="processing_steps">
   <ref class="AVXFrugalPedestalSubtractProcessor" id="tpg-pedsub-proc"/>
   <ref class="AVXThresholdProcessor" id="tpg-threshold-proc"/>

--- a/config/daqsystemtest/ru-segment.data.xml
+++ b/config/daqsystemtest/ru-segment.data.xml
@@ -128,7 +128,7 @@
  <attr name="scale_factor_plane2" type="u8" val="10"/>
 </obj>
 
-<obj class="CRTReaderApplication" id="crt-bern-01">
+<obj class="CRTReaderApplication" id="crt-data-source-01">
  <attr name="application_name" type="string" val="daq_application"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="exposes_service">
@@ -139,84 +139,15 @@
   <ref class="QueueConnectionRule" id="crt-bern-raw-data-rule"/>
  </rel>
  <rel name="action_plans">
-  <ref class="ActionPlan" id="crt-bern-readout-start"/>
-  <ref class="ActionPlan" id="crt-bern-readout-stop"/>
- </rel>
- <rel name="data_writers">
-  <ref class="SocketWriterConf" id="def-socket-writer-conf"/>
- </rel>
- <rel name="data_reader" class="CRTBernReaderConf" id="def-crt-bern-receiver-conf"/>
- <rel name="detector_connections">
-  <ref class="NetworkDetectorToDaqConnection" id="socket_crt_bern"/>
- </rel>
-</obj>
-
-<obj class="CRTReaderApplication" id="crt-grenoble-01">
- <attr name="application_name" type="string" val="daq_application"/>
- <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
- <rel name="exposes_service">
-  <ref class="Service" id="daqapp_control"/>
- </rel>
- <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
- <rel name="queue_rules">
-  <ref class="QueueConnectionRule" id="crt-grenoble-raw-data-rule"/>
- </rel>
- <rel name="action_plans">
-  <ref class="ActionPlan" id="crt-grenoble-readout-start"/>
-  <ref class="ActionPlan" id="crt-grenoble-readout-stop"/>
- </rel>
- <rel name="data_writers">
-  <ref class="SocketWriterConf" id="def-socket-writer-conf"/>
- </rel>
- <rel name="data_reader" class="CRTGrenobleReaderConf" id="def-crt-grenoble-receiver-conf"/>
- <rel name="detector_connections">
-  <ref class="NetworkDetectorToDaqConnection" id="socket_crt_grenoble"/>
- </rel>
-</obj>
-
-<obj class="CRTReaderApplication" id="emu-crt-bern-01">
- <attr name="application_name" type="string" val="daq_application"/>
- <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
- <rel name="exposes_service">
-  <ref class="Service" id="daqapp_control"/>
- </rel>
- <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
- <rel name="queue_rules">
-  <ref class="QueueConnectionRule" id="crt-bern-raw-data-rule"/>
- </rel>
- <rel name="action_plans">
-  <ref class="ActionPlan" id="emu-crt-readout-start"/>
-  <ref class="ActionPlan" id="emu-crt-readout-stop"/>
+  <ref class="ActionPlan" id="crt-readout-start"/>
+  <ref class="ActionPlan" id="crt-readout-stop"/>
  </rel>
  <rel name="data_writers">
   <ref class="SocketWriterConf" id="def-socket-writer-conf"/>
  </rel>
  <rel name="data_reader" class="CRTReaderConf" id="def-emu-crt-receiver-conf"/>
  <rel name="detector_connections">
-  <ref class="NetworkDetectorToDaqConnection" id="socket_crt_bern"/>
- </rel>
-</obj>
-
-<obj class="CRTReaderApplication" id="emu-crt-grenoble-01">
- <attr name="application_name" type="string" val="daq_application"/>
- <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
- <rel name="exposes_service">
-  <ref class="Service" id="daqapp_control"/>
- </rel>
- <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
- <rel name="queue_rules">
-  <ref class="QueueConnectionRule" id="crt-grenoble-raw-data-rule"/>
- </rel>
- <rel name="action_plans">
-  <ref class="ActionPlan" id="emu-crt-readout-start"/>
-  <ref class="ActionPlan" id="emu-crt-readout-stop"/>
- </rel>
- <rel name="data_writers">
-  <ref class="SocketWriterConf" id="def-socket-writer-conf"/>
- </rel>
- <rel name="data_reader" class="CRTReaderConf" id="def-emu-crt-receiver-conf"/>
- <rel name="detector_connections">
-  <ref class="NetworkDetectorToDaqConnection" id="socket_crt_grenoble"/>
+  <ref class="NetworkDetectorToDaqConnection" id="socket_crt"/>
  </rel>
 </obj>
 
@@ -249,14 +180,9 @@
  <rel name="geo_id" class="GeoId" id="g_3_1_1_0"/>
 </obj>
 
-<obj class="DetectorStream" id="stream_1001">
- <attr name="source_id" type="u32" val="1001"/>
+<obj class="DetectorStream" id="stream_1007">
+ <attr name="source_id" type="u32" val="1007"/>
  <rel name="geo_id" class="GeoId" id="g_13_1_1_0"/>
-</obj>
-
-<obj class="DetectorStream" id="stream_1002">
- <attr name="source_id" type="u32" val="1002"/>
- <rel name="geo_id" class="GeoId" id="g_12_1_1_0"/>
 </obj>
 
 <obj class="DetectorStream" id="stream_101">
@@ -398,16 +324,9 @@
  <rel name="net_receiver" class="DPDKReceiver" id="ru-2-rcv"/>
 </obj>
 
-<obj class="NetworkDetectorToDaqConnection" id="socket_crt_bern">
+<obj class="NetworkDetectorToDaqConnection" id="socket_crt">
  <rel name="net_senders">
-  <ref class="SocketDataSender" id="socket_sender_crt_bern"/>
- </rel>
- <rel name="net_receiver" class="SocketReceiver" id="socket-ru-1-rcv"/>
-</obj>
-
-<obj class="NetworkDetectorToDaqConnection" id="socket_crt_grenoble">
- <rel name="net_senders">
-  <ref class="SocketDataSender" id="socket_sender_crt_grenoble"/>
+  <ref class="SocketDataSender" id="socket_sender_crt"/>
  </rel>
  <rel name="net_receiver" class="SocketReceiver" id="socket-ru-1-rcv"/>
 </obj>
@@ -459,46 +378,6 @@
  <attr name="network_name" type="enum" val="Control"/>
 </obj>
 
-<obj class="RCApplication" id="crt-bern-controller">
- <attr name="application_name" type="string" val="drunc-controller"/>
- <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
- <rel name="exposes_service">
-  <ref class="Service" id="rccontroller_control"/>
- </rel>
- <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
- <rel name="fsm" class="FSMconfiguration" id="FSMconfiguration_noAction"/>
-</obj>
-
-<obj class="RCApplication" id="crt-grenoble-controller">
- <attr name="application_name" type="string" val="drunc-controller"/>
- <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
- <rel name="exposes_service">
-  <ref class="Service" id="rccontroller_control"/>
- </rel>
- <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
- <rel name="fsm" class="FSMconfiguration" id="FSMconfiguration_noAction"/>
-</obj>
-
-<obj class="RCApplication" id="emu-crt-bern-controller">
- <attr name="application_name" type="string" val="drunc-controller"/>
- <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
- <rel name="exposes_service">
-  <ref class="Service" id="rccontroller_control"/>
- </rel>
- <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
- <rel name="fsm" class="FSMconfiguration" id="FSMconfiguration_noAction"/>
-</obj>
-
-<obj class="RCApplication" id="emu-crt-grenoble-controller">
- <attr name="application_name" type="string" val="drunc-controller"/>
- <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
- <rel name="exposes_service">
-  <ref class="Service" id="rccontroller_control"/>
- </rel>
- <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
- <rel name="fsm" class="FSMconfiguration" id="FSMconfiguration_noAction"/>
-</obj>
-
 <obj class="RCApplication" id="ru-controller">
  <attr name="application_name" type="string" val="drunc-controller"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
@@ -519,7 +398,7 @@
  <rel name="fsm" class="FSMconfiguration" id="FSMconfiguration_noAction"/>
 </obj>
 
-<obj class="ReadoutApplication" id="crt-bern-ru-01">
+<obj class="ReadoutApplication" id="socket-ru-01">
  <attr name="application_name" type="string" val="daq_application"/>
  <attr name="tp_generation_enabled" type="bool" val="0"/>
  <attr name="ta_generation_enabled" type="bool" val="0"/>
@@ -528,166 +407,26 @@
   <ref class="Service" id="daqapp_control"/>
   <ref class="Service" id="dataRequests"/>
   <ref class="Service" id="timeSyncs"/>
-  <ref class="Service" id="triggerActivities"/>
-  <ref class="Service" id="triggerPrimitives"/>
  </rel>
  <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
  <rel name="queue_rules">
   <ref class="QueueConnectionRule" id="fa-queue-rule"/>
-  <ref class="QueueConnectionRule" id="tp-queue-rule"/>
   <ref class="QueueConnectionRule" id="crt-bern-callback-raw-data-rule"/>
   <ref class="QueueConnectionRule" id="fd-dlh-data-requests-queue-rule"/>
  </rel>
  <rel name="network_rules">
   <ref class="NetworkConnectionRule" id="ts-net-rule"/>
-  <ref class="NetworkConnectionRule" id="ta-net-rule"/>
   <ref class="NetworkConnectionRule" id="data-req-readout-net-rule"/>
-  <ref class="NetworkConnectionRule" id="tpset-net-rule"/>
  </rel>
  <rel name="action_plans">
   <ref class="ActionPlan" id="socket-readout-start"/>
   <ref class="ActionPlan" id="socket-readout-stop"/>
- </rel>
- <rel name="tp_source_ids">
-  <ref class="SourceIDConf" id="tp-srcid-1000"/>
-  <ref class="SourceIDConf" id="tp-srcid-1001"/>
-  <ref class="SourceIDConf" id="tp-srcid-1002"/>
  </rel>
  <rel name="uses" class="RoHwConfig" id="rohw-1"/>
  <rel name="link_handler" class="DataHandlerConf" id="def-crt-bern-link-handler"/>
- <rel name="tp_handler" class="DataHandlerConf" id="def-tp-handler"/>
  <rel name="data_reader" class="SocketReaderConf" id="def-socket-reader-conf"/>
  <rel name="detector_connections">
-  <ref class="NetworkDetectorToDaqConnection" id="socket_crt_bern"/>
- </rel>
-</obj>
-
-<obj class="ReadoutApplication" id="crt-grenoble-ru-01">
- <attr name="application_name" type="string" val="daq_application"/>
- <attr name="tp_generation_enabled" type="bool" val="0"/>
- <attr name="ta_generation_enabled" type="bool" val="0"/>
- <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
- <rel name="exposes_service">
-  <ref class="Service" id="daqapp_control"/>
-  <ref class="Service" id="dataRequests"/>
-  <ref class="Service" id="timeSyncs"/>
-  <ref class="Service" id="triggerActivities"/>
-  <ref class="Service" id="triggerPrimitives"/>
- </rel>
- <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
- <rel name="queue_rules">
-  <ref class="QueueConnectionRule" id="fa-queue-rule"/>
-  <ref class="QueueConnectionRule" id="tp-queue-rule"/>
-  <ref class="QueueConnectionRule" id="crt-grenoble-callback-raw-data-rule"/>
-  <ref class="QueueConnectionRule" id="fd-dlh-data-requests-queue-rule"/>
- </rel>
- <rel name="network_rules">
-  <ref class="NetworkConnectionRule" id="ts-net-rule"/>
-  <ref class="NetworkConnectionRule" id="ta-net-rule"/>
-  <ref class="NetworkConnectionRule" id="data-req-readout-net-rule"/>
-  <ref class="NetworkConnectionRule" id="tpset-net-rule"/>
- </rel>
- <rel name="action_plans">
-  <ref class="ActionPlan" id="socket-readout-start"/>
-  <ref class="ActionPlan" id="socket-readout-stop"/>
- </rel>
- <rel name="tp_source_ids">
-  <ref class="SourceIDConf" id="tp-srcid-1000"/>
-  <ref class="SourceIDConf" id="tp-srcid-1001"/>
-  <ref class="SourceIDConf" id="tp-srcid-1002"/>
- </rel>
- <rel name="uses" class="RoHwConfig" id="rohw-1"/>
- <rel name="link_handler" class="DataHandlerConf" id="def-crt-grenoble-link-handler"/>
- <rel name="tp_handler" class="DataHandlerConf" id="def-tp-handler"/>
- <rel name="data_reader" class="SocketReaderConf" id="def-socket-reader-conf"/>
- <rel name="detector_connections">
-  <ref class="NetworkDetectorToDaqConnection" id="socket_crt_grenoble"/>
- </rel>
-</obj>
-
-<obj class="ReadoutApplication" id="emu-crt-bern-ru-01">
- <attr name="application_name" type="string" val="daq_application"/>
- <attr name="tp_generation_enabled" type="bool" val="0"/>
- <attr name="ta_generation_enabled" type="bool" val="0"/>
- <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
- <rel name="exposes_service">
-  <ref class="Service" id="daqapp_control"/>
-  <ref class="Service" id="dataRequests"/>
-  <ref class="Service" id="timeSyncs"/>
-  <ref class="Service" id="triggerActivities"/>
-  <ref class="Service" id="triggerPrimitives"/>
- </rel>
- <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
- <rel name="queue_rules">
-  <ref class="QueueConnectionRule" id="fa-queue-rule"/>
-  <ref class="QueueConnectionRule" id="tp-queue-rule"/>
-  <ref class="QueueConnectionRule" id="crt-bern-callback-raw-data-rule"/>
-  <ref class="QueueConnectionRule" id="fd-dlh-data-requests-queue-rule"/>
- </rel>
- <rel name="network_rules">
-  <ref class="NetworkConnectionRule" id="ts-net-rule"/>
-  <ref class="NetworkConnectionRule" id="ta-net-rule"/>
-  <ref class="NetworkConnectionRule" id="data-req-readout-net-rule"/>
-  <ref class="NetworkConnectionRule" id="tpset-net-rule"/>
- </rel>
- <rel name="action_plans">
-  <ref class="ActionPlan" id="socket-readout-start"/>
-  <ref class="ActionPlan" id="socket-readout-stop"/>
- </rel>
- <rel name="tp_source_ids">
-  <ref class="SourceIDConf" id="tp-srcid-1000"/>
-  <ref class="SourceIDConf" id="tp-srcid-1001"/>
-  <ref class="SourceIDConf" id="tp-srcid-1002"/>
- </rel>
- <rel name="uses" class="RoHwConfig" id="rohw-1"/>
- <rel name="link_handler" class="DataHandlerConf" id="def-crt-bern-link-handler"/>
- <rel name="tp_handler" class="DataHandlerConf" id="def-tp-handler"/>
- <rel name="data_reader" class="SocketReaderConf" id="def-socket-reader-conf"/>
- <rel name="detector_connections">
-  <ref class="NetworkDetectorToDaqConnection" id="socket_crt_bern"/>
- </rel>
-</obj>
-
-<obj class="ReadoutApplication" id="emu-crt-grenoble-ru-01">
- <attr name="application_name" type="string" val="daq_application"/>
- <attr name="tp_generation_enabled" type="bool" val="0"/>
- <attr name="ta_generation_enabled" type="bool" val="0"/>
- <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
- <rel name="exposes_service">
-  <ref class="Service" id="daqapp_control"/>
-  <ref class="Service" id="dataRequests"/>
-  <ref class="Service" id="timeSyncs"/>
-  <ref class="Service" id="triggerActivities"/>
-  <ref class="Service" id="triggerPrimitives"/>
- </rel>
- <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
- <rel name="queue_rules">
-  <ref class="QueueConnectionRule" id="fa-queue-rule"/>
-  <ref class="QueueConnectionRule" id="tp-queue-rule"/>
-  <ref class="QueueConnectionRule" id="crt-grenoble-callback-raw-data-rule"/>
-  <ref class="QueueConnectionRule" id="fd-dlh-data-requests-queue-rule"/>
- </rel>
- <rel name="network_rules">
-  <ref class="NetworkConnectionRule" id="ts-net-rule"/>
-  <ref class="NetworkConnectionRule" id="ta-net-rule"/>
-  <ref class="NetworkConnectionRule" id="data-req-readout-net-rule"/>
-  <ref class="NetworkConnectionRule" id="tpset-net-rule"/>
- </rel>
- <rel name="action_plans">
-  <ref class="ActionPlan" id="socket-readout-start"/>
-  <ref class="ActionPlan" id="socket-readout-stop"/>
- </rel>
- <rel name="tp_source_ids">
-  <ref class="SourceIDConf" id="tp-srcid-1000"/>
-  <ref class="SourceIDConf" id="tp-srcid-1001"/>
-  <ref class="SourceIDConf" id="tp-srcid-1002"/>
- </rel>
- <rel name="uses" class="RoHwConfig" id="rohw-1"/>
- <rel name="link_handler" class="DataHandlerConf" id="def-crt-grenoble-link-handler"/>
- <rel name="tp_handler" class="DataHandlerConf" id="def-tp-handler"/>
- <rel name="data_reader" class="SocketReaderConf" id="def-socket-reader-conf"/>
- <rel name="detector_connections">
-  <ref class="NetworkDetectorToDaqConnection" id="socket_crt_grenoble"/>
+  <ref class="NetworkDetectorToDaqConnection" id="socket_crt"/>
  </rel>
 </obj>
 
@@ -776,36 +515,12 @@
 <obj class="RoHwConfig" id="rohw-1">
 </obj>
 
-<obj class="Segment" id="crt-bern-segment">
+<obj class="Segment" id="socket-ru-segment">
  <rel name="applications">
-  <ref class="CRTReaderApplication" id="crt-bern-01"/>
-  <ref class="ReadoutApplication" id="crt-bern-ru-01"/>
+  <ref class="CRTReaderApplication" id="crt-data-source-01"/>
+  <ref class="ReadoutApplication" id="socket-ru-01"/>
  </rel>
- <rel name="controller" class="RCApplication" id="crt-bern-controller"/>
-</obj>
-
-<obj class="Segment" id="crt-grenoble-segment">
- <rel name="applications">
-  <ref class="CRTReaderApplication" id="crt-grenoble-01"/>
-  <ref class="ReadoutApplication" id="crt-grenoble-ru-01"/>
- </rel>
- <rel name="controller" class="RCApplication" id="crt-grenoble-controller"/>
-</obj>
-
-<obj class="Segment" id="emu-crt-bern-segment">
- <rel name="applications">
-  <ref class="CRTReaderApplication" id="emu-crt-bern-01"/>
-  <ref class="ReadoutApplication" id="emu-crt-bern-ru-01"/>
- </rel>
- <rel name="controller" class="RCApplication" id="emu-crt-bern-controller"/>
-</obj>
-
-<obj class="Segment" id="emu-crt-grenoble-segment">
- <rel name="applications">
-  <ref class="CRTReaderApplication" id="emu-crt-grenoble-01"/>
-  <ref class="ReadoutApplication" id="emu-crt-grenoble-ru-01"/>
- </rel>
- <rel name="controller" class="RCApplication" id="emu-crt-grenoble-controller"/>
+ <rel name="controller" class="RCApplication" id="socket-ru-controller"/>
 </obj>
 
 <obj class="Segment" id="ru-segment">
@@ -816,20 +531,11 @@
  <rel name="controller" class="RCApplication" id="ru-controller"/>
 </obj>
 
-<obj class="SocketDataSender" id="socket_sender_crt_bern">
+<obj class="SocketDataSender" id="socket_sender_crt">
  <attr name="port" type="u32" val="1234"/>
  <attr name="control_host" type="string" val="localhost"/>
  <rel name="streams">
-  <ref class="DetectorStream" id="stream_1002"/>
- </rel>
- <rel name="uses" class="NetworkInterface" id="crt_101_asio0"/>
-</obj>
-
-<obj class="SocketDataSender" id="socket_sender_crt_grenoble">
- <attr name="port" type="u32" val="1234"/>
- <attr name="control_host" type="string" val="localhost"/>
- <rel name="streams">
-  <ref class="DetectorStream" id="stream_1001"/>
+  <ref class="DetectorStream" id="stream_1007"/>
  </rel>
  <rel name="uses" class="NetworkInterface" id="crt_101_asio0"/>
 </obj>

--- a/config/daqsystemtest/ru-segment.data.xml
+++ b/config/daqsystemtest/ru-segment.data.xml
@@ -63,7 +63,7 @@
 
 <oks-data>
 
-<info name="" type="" num-of-items="66" oks-format="data" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20231207T105615" last-modified-by="dergonul" last-modified-on="np04-srv-028.cern.ch" last-modification-time="20250805T092423"/>
+<info name="" type="" num-of-items="52" oks-format="data" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20231207T105615" last-modified-by="biery" last-modified-on="daq.fnal.gov" last-modification-time="20250903T173857"/>
 
 <include>
  <file path="schema/confmodel/dunedaq.schema.xml"/>
@@ -107,6 +107,7 @@
 
 
 <obj class="AVXAbsRunSumProcessor" id="tpg-absrs-proc">
+ <attr name="metric_collect_time_sample_period" type="u64" val="256"/>
  <attr name="memory_factor_plane0" type="u8" val="8"/>
  <attr name="memory_factor_plane1" type="u8" val="8"/>
  <attr name="memory_factor_plane2" type="u8" val="8"/>
@@ -116,10 +117,12 @@
 </obj>
 
 <obj class="AVXFrugalPedestalSubtractProcessor" id="tpg-pedsub-proc">
+ <attr name="metric_collect_time_sample_period" type="u64" val="256"/>
  <attr name="accum_limit" type="u8" val="10"/>
 </obj>
 
 <obj class="AVXRunSumProcessor" id="tpg-rs-proc">
+ <attr name="metric_collect_time_sample_period" type="u64" val="256"/>
  <attr name="memory_factor_plane0" type="u8" val="8"/>
  <attr name="memory_factor_plane1" type="u8" val="8"/>
  <attr name="memory_factor_plane2" type="u8" val="8"/>
@@ -351,6 +354,15 @@
  <attr name="pcie_addr" type="string" val="0"/>
 </obj>
 
+<obj class="NetworkInterface" id="crt_101_asio0">
+ <attr name="mac_address" type="string" val="00:00:00:00:00:00"/>
+ <attr name="ip_address" type="string">
+  <data val="123.456.101.000"/>
+ </attr>
+ <attr name="interface_name" type="string" val="asio0"/>
+ <attr name="network_name" type="enum" val="Control"/>
+</obj>
+
 <obj class="NetworkInterface" id="wib_101_hermes0">
  <attr name="mac_address" type="string" val="00:00:00:00:00:00"/>
  <attr name="ip_address" type="string">
@@ -366,15 +378,6 @@
   <data val="123.456.101.001"/>
  </attr>
  <attr name="interface_name" type="string" val="hermes0"/>
- <attr name="network_name" type="enum" val="Control"/>
-</obj>
-
-<obj class="NetworkInterface" id="crt_101_asio0">
- <attr name="mac_address" type="string" val="00:00:00:00:00:00"/>
- <attr name="ip_address" type="string">
-  <data val="123.456.101.000"/>
- </attr>
- <attr name="interface_name" type="string" val="asio0"/>
  <attr name="network_name" type="enum" val="Control"/>
 </obj>
 
@@ -396,38 +399,6 @@
  </rel>
  <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
  <rel name="fsm" class="FSMconfiguration" id="FSMconfiguration_noAction"/>
-</obj>
-
-<obj class="ReadoutApplication" id="socket-ru-01">
- <attr name="application_name" type="string" val="daq_application"/>
- <attr name="tp_generation_enabled" type="bool" val="0"/>
- <attr name="ta_generation_enabled" type="bool" val="0"/>
- <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
- <rel name="exposes_service">
-  <ref class="Service" id="daqapp_control"/>
-  <ref class="Service" id="dataRequests"/>
-  <ref class="Service" id="timeSyncs"/>
- </rel>
- <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
- <rel name="queue_rules">
-  <ref class="QueueConnectionRule" id="fa-queue-rule"/>
-  <ref class="QueueConnectionRule" id="crt-bern-callback-raw-data-rule"/>
-  <ref class="QueueConnectionRule" id="fd-dlh-data-requests-queue-rule"/>
- </rel>
- <rel name="network_rules">
-  <ref class="NetworkConnectionRule" id="ts-net-rule"/>
-  <ref class="NetworkConnectionRule" id="data-req-readout-net-rule"/>
- </rel>
- <rel name="action_plans">
-  <ref class="ActionPlan" id="socket-readout-start"/>
-  <ref class="ActionPlan" id="socket-readout-stop"/>
- </rel>
- <rel name="uses" class="RoHwConfig" id="rohw-1"/>
- <rel name="link_handler" class="DataHandlerConf" id="def-crt-bern-link-handler"/>
- <rel name="data_reader" class="SocketReaderConf" id="def-socket-reader-conf"/>
- <rel name="detector_connections">
-  <ref class="NetworkDetectorToDaqConnection" id="socket_crt"/>
- </rel>
 </obj>
 
 <obj class="ReadoutApplication" id="ru-01">
@@ -512,15 +483,39 @@
  </rel>
 </obj>
 
-<obj class="RoHwConfig" id="rohw-1">
+<obj class="ReadoutApplication" id="socket-ru-01">
+ <attr name="application_name" type="string" val="daq_application"/>
+ <attr name="tp_generation_enabled" type="bool" val="0"/>
+ <attr name="ta_generation_enabled" type="bool" val="0"/>
+ <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
+ <rel name="exposes_service">
+  <ref class="Service" id="daqapp_control"/>
+  <ref class="Service" id="dataRequests"/>
+  <ref class="Service" id="timeSyncs"/>
+ </rel>
+ <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
+ <rel name="queue_rules">
+  <ref class="QueueConnectionRule" id="fa-queue-rule"/>
+  <ref class="QueueConnectionRule" id="crt-bern-callback-raw-data-rule"/>
+  <ref class="QueueConnectionRule" id="fd-dlh-data-requests-queue-rule"/>
+ </rel>
+ <rel name="network_rules">
+  <ref class="NetworkConnectionRule" id="ts-net-rule"/>
+  <ref class="NetworkConnectionRule" id="data-req-readout-net-rule"/>
+ </rel>
+ <rel name="action_plans">
+  <ref class="ActionPlan" id="socket-readout-start"/>
+  <ref class="ActionPlan" id="socket-readout-stop"/>
+ </rel>
+ <rel name="uses" class="RoHwConfig" id="rohw-1"/>
+ <rel name="link_handler" class="DataHandlerConf" id="def-crt-bern-link-handler"/>
+ <rel name="data_reader" class="SocketReaderConf" id="def-socket-reader-conf"/>
+ <rel name="detector_connections">
+  <ref class="NetworkDetectorToDaqConnection" id="socket_crt"/>
+ </rel>
 </obj>
 
-<obj class="Segment" id="socket-ru-segment">
- <rel name="applications">
-  <ref class="CRTReaderApplication" id="crt-data-source-01"/>
-  <ref class="ReadoutApplication" id="socket-ru-01"/>
- </rel>
- <rel name="controller" class="RCApplication" id="socket-ru-controller"/>
+<obj class="RoHwConfig" id="rohw-1">
 </obj>
 
 <obj class="Segment" id="ru-segment">
@@ -529,6 +524,14 @@
   <ref class="ReadoutApplication" id="ru-02"/>
  </rel>
  <rel name="controller" class="RCApplication" id="ru-controller"/>
+</obj>
+
+<obj class="Segment" id="socket-ru-segment">
+ <rel name="applications">
+  <ref class="CRTReaderApplication" id="crt-data-source-01"/>
+  <ref class="ReadoutApplication" id="socket-ru-01"/>
+ </rel>
+ <rel name="controller" class="RCApplication" id="socket-ru-controller"/>
 </obj>
 
 <obj class="SocketDataSender" id="socket_sender_crt">

--- a/integtest/3ru_1df_multirun_test.py
+++ b/integtest/3ru_1df_multirun_test.py
@@ -117,25 +117,25 @@ conf_dict.session = "3ru1df"
 conf_dict.tpg_enabled = False
 
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_id=conf_dict.session,
         obj_class="Session",
         updates={"data_rate_slowdown_factor": data_rate_slowdown_factor},
     )
 )
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="RandomTCMakerConf",
         updates={"trigger_rate_hz": trigger_rate},
     )
 )
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="LatencyBuffer", updates={"size": 200000}
     )
 )
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="DFOConf",
         updates={"busy_threshold": 3, "free_threshold": 2}
     )
@@ -147,7 +147,7 @@ swtpg_conf.frame_file = (
     "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798"  # WIBEth All Zeros
 )
 swtpg_conf.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="TAMakerPrescaleAlgorithm",
         obj_id="dummy-ta-maker",
         updates={"prescale": ta_prescale},

--- a/integtest/3ru_3df_multirun_test.py
+++ b/integtest/3ru_3df_multirun_test.py
@@ -103,20 +103,20 @@ conf_dict.tpg_enabled = False
 conf_dict.n_df_apps = number_of_dataflow_apps
 
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_id=conf_dict.session,
         obj_class="Session",
         updates={"data_rate_slowdown_factor": data_rate_slowdown_factor},
     )
 )
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="RandomTCMakerConf",
         updates={"trigger_rate_hz": trigger_rate},
     )
 )
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="LatencyBuffer", updates={"size": 200000}
     )
 )
@@ -127,7 +127,7 @@ swtpg_conf.frame_file = (
     "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798"  # WIBEth All Zeros
 )
 swtpg_conf.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="TAMakerPrescaleAlgorithm",
         obj_id="dummy-ta-maker",
         updates={"prescale": ta_prescale},

--- a/integtest/fake_data_producer_test.py
+++ b/integtest/fake_data_producer_test.py
@@ -60,7 +60,7 @@ conf_dict.use_fakedataprod = True
 conf_dict.dro_map_config.n_streams = number_of_data_producers
 
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
      obj_id="random-tc-generator",
      obj_class="RandomTCMakerConf",
         updates={"trigger_rate_hz": 1},
@@ -68,7 +68,7 @@ conf_dict.config_substitutions.append(
 )
 
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_id="dummy-detector",
         obj_class="DetectorConfig",
         updates={"clock_speed_hz": 1000000000}, # FakeDataProd uses nanoseconds as its timestamps
@@ -78,7 +78,7 @@ conf_dict.config_substitutions.append(
 doublewindow_conf = copy.deepcopy(conf_dict)
 
 doublewindow_conf.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="TCReadoutMap",
         obj_id = "def-random-readout",
         updates={

--- a/integtest/long_window_readout_test.py
+++ b/integtest/long_window_readout_test.py
@@ -109,27 +109,27 @@ conf_dict.n_df_apps = number_of_dataflow_apps
 conf_dict.fake_hsi_enabled = False
 
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_id=conf_dict.session,
         obj_class="Session",
         updates={"data_rate_slowdown_factor": data_rate_slowdown_factor},
     )
 )
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="LatencyBuffer", updates={"size": latency_buffer_size}
     )
 )
 
 
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="RandomTCMakerConf",
         updates={"trigger_rate_hz": trigger_rate},
     )
 )
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="TCReadoutMap",
         obj_id = "def-random-readout",
         updates={
@@ -139,14 +139,14 @@ conf_dict.config_substitutions.append(
     )
 )
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="DataStoreConf",
         obj_id="default",
         updates={"max_file_size": 4 * 1024 * 1024 * 1024},
     )
 )
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="DataStoreConf",
         obj_id="default",
         updates={"directory_path": output_path_parameter},
@@ -155,7 +155,7 @@ conf_dict.config_substitutions.append(
 
 trsplit_conf = copy.deepcopy(conf_dict)
 trsplit_conf.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="TRBConf",
         updates={
             "max_time_window": trigger_record_max_window,
@@ -165,7 +165,7 @@ trsplit_conf.config_substitutions.append(
 )
 
 trsplit_conf.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="QueueDescriptor",
         obj_id="trigger-records",
         updates={"capacity": tr_queue_size},

--- a/integtest/minimal_system_quick_test.py
+++ b/integtest/minimal_system_quick_test.py
@@ -71,7 +71,7 @@ conf_dict.tpg_enabled = False
 # For testing, specify connectivity service port (default is 0, a random port is chosen for the Connectivity Service)
 #conf_dict.connsvc_port = 12345
 
-substitution = data_classes.config_substitution(
+substitution = data_classes.attribute_substitution(
     obj_id="random-tc-generator",
     obj_class="RandomTCMakerConf",
     updates={"trigger_rate_hz": 1},

--- a/integtest/readout_type_scan_test.py
+++ b/integtest/readout_type_scan_test.py
@@ -145,14 +145,14 @@ conf_dict.tpg_enabled = False
 conf_dict.frame_file = "asset://?label=ProtoWIB&subsystem=readout"  # ProtoWIB
 
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_id=conf_dict.session,
         obj_class="Session",
         updates={"data_rate_slowdown_factor": data_rate_slowdown_factor},
     )
 )
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="RandomTCMakerConf",
         updates={"trigger_rate_hz": 1},
     )
@@ -164,7 +164,7 @@ wib_tpg_conf.frame_file = (
     "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798"  # WIBEth All Zeros
 )
 wib_tpg_conf.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="TAMakerPrescaleAlgorithm",
         obj_id="dummy-ta-maker",
         updates={"prescale": ta_prescale},
@@ -185,7 +185,7 @@ daphne_stream_conf.dro_map_config.det_id = 2  # det_id = 2 for HD_PDS
 daphne_stream_conf.frame_file = "asset://?label=DAPHNEStream&subsystem=readout"
 
 daphne_stream_conf.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="TCReadoutMap",
         obj_id = "def-random-readout",
         updates={
@@ -199,7 +199,7 @@ daphne_conf = copy.deepcopy(conf_dict)
 daphne_conf.dro_map_config.det_id = 2  # det_id = 2 for HD_PDS
 daphne_conf.frame_file = "asset://?checksum=a8990a9eb3a505d4ded62dfdfa9e2681"
 daphne_conf.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="TCReadoutMap",
         obj_id = "def-random-readout",
         updates={
@@ -212,7 +212,7 @@ daphne_conf.config_substitutions.append(
 daphne_tpg_conf = copy.deepcopy(daphne_conf)
 daphne_tpg_conf.tpg_enabled = True
 daphne_tpg_conf.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="TAMakerPrescaleAlgorithm",
         obj_id="dummy-ta-maker",
         updates={"prescale": 750},

--- a/integtest/small_footprint_quick_test.py
+++ b/integtest/small_footprint_quick_test.py
@@ -68,18 +68,18 @@ conf_dict.tpg_enabled = False
 conf_dict.fake_hsi_enabled = True
 
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_id=conf_dict.session,
         obj_class="Session",
         updates={"data_rate_slowdown_factor": data_rate_slowdown_factor},
     )
 )
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(obj_class="LatencyBuffer", updates={"size": 50000})
+    data_classes.attribute_substitution(obj_class="LatencyBuffer", updates={"size": 50000})
 )
 
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="FakeHSIEventGeneratorConf",
         updates={"trigger_rate": 1.0},
     )

--- a/integtest/tpreplay_test.py
+++ b/integtest/tpreplay_test.py
@@ -121,7 +121,7 @@ local_db.commit()
 
 ## update TP Replay Module
 tpreplay_local_conf.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="TPReplayModuleConf",
         obj_id="tpreplay-tp-maker",
         updates={
@@ -135,7 +135,7 @@ tpreplay_local_conf.config_substitutions.append(
 
 ## update replay session SourceIDs
 tpreplay_local_conf.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="TPReplayApplication",
         obj_id="tpreplay",
         updates={
@@ -145,7 +145,7 @@ tpreplay_local_conf.config_substitutions.append(
 
 ## update random TC maker
 tpreplay_local_conf.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_id="random-tc-generator",
         obj_class="RandomTCMakerConf",
         updates={
@@ -155,7 +155,7 @@ tpreplay_local_conf.config_substitutions.append(
 
 ## update HSI
 tpreplay_local_conf.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_id="fakehsi",
         obj_class="FakeHSIEventGeneratorConf",
         updates={
@@ -167,7 +167,7 @@ tpreplay_local_conf.config_substitutions.append(
 tpreplay_np04_conf = copy.deepcopy(tpreplay_local_conf)
 # update
 tpreplay_np04_conf.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="TPReplayApplication",
         obj_id="tpreplay",
         updates={
@@ -175,7 +175,7 @@ tpreplay_np04_conf.config_substitutions.append(
             },)
 )
 tpreplay_np04_conf.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="TPReplayModuleConf",
         obj_id="tpreplay-tp-maker",
         updates={
@@ -187,7 +187,7 @@ tpreplay_np04_conf.config_substitutions.append(
             },)
 )
 tpreplay_np04_conf.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="TPStreamConf",
         obj_id="tp-stream-1",
         updates={
@@ -195,7 +195,7 @@ tpreplay_np04_conf.config_substitutions.append(
             },)
 )
 tpreplay_np04_conf.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="TPStreamConf",
         obj_id="tp-stream-2",
         updates={
@@ -203,7 +203,7 @@ tpreplay_np04_conf.config_substitutions.append(
             },)
 )
 tpreplay_np04_conf.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="TAMakerPrescaleAlgorithm",
         obj_id="dummy-ta-maker",
         updates={
@@ -211,7 +211,7 @@ tpreplay_np04_conf.config_substitutions.append(
             },)
 )
 tpreplay_np04_conf.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="TCMakerPrescaleAlgorithm",
         obj_id="tc-pass-through-algo",
         updates={

--- a/integtest/tpstream_writing_test.py
+++ b/integtest/tpstream_writing_test.py
@@ -116,46 +116,46 @@ conf_dict.frame_file = (
 )
 
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_id=conf_dict.session,
         obj_class="Session",
         updates={"data_rate_slowdown_factor": data_rate_slowdown_factor},
     )
 )
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="RandomTCMakerConf",
         updates={"trigger_rate_hz": pulser_trigger_rate},
     )
 )
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="LatencyBuffer", updates={"size": 200000}
     )
 )
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="TAMakerPrescaleAlgorithm",
         obj_id="dummy-ta-maker",
         updates={"prescale": 25},
     )
 )
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="TCDataProcessor",
         obj_id="def-tc-processor",
         updates={"merge_overlapping_tcs": 0},
     )
 )
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="DataStoreConf",
         obj_id="default",
         updates={"directory_path": output_dir},
     )
 )
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="DataStoreConf",
         obj_id="default_tp_store_conf",
         updates={"directory_path": output_dir},

--- a/integtest/trigger_bitwords_test.py
+++ b/integtest/trigger_bitwords_test.py
@@ -78,7 +78,7 @@ tpstream_writer = db.get_dal(class_name="TPStreamWriterApplication", uid="tp-str
 local_conf.disabled.append(tpstream_writer)
 disabled_list = [db.get_dal(class_name=obj.className(), uid=obj.id) for obj in local_conf.disabled]
 onebyone_local_conf.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="Session",
         obj_id="local-1x1-config",
         updates={"disabled": []},
@@ -86,7 +86,7 @@ onebyone_local_conf.config_substitutions.append(
 )
 # Disable TC merging
 onebyone_local_conf.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="TCDataProcessor",
         obj_id="def-tc-processor",
         updates={
@@ -120,7 +120,7 @@ for conf in configs:
 ### Bitwords configs
 # Prescale
 prescale_bitword_conf.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="TCDataProcessor",
         obj_id="def-tc-processor",
         updates={
@@ -130,7 +130,7 @@ prescale_bitword_conf.config_substitutions.append(
 
 # Timing
 timing_bitword_conf.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="TCDataProcessor",
         obj_id="def-tc-processor",
         updates={
@@ -140,7 +140,7 @@ timing_bitword_conf.config_substitutions.append(
 
 # Supernova
 supernova_bitword_conf.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="TriggerBitword",
         obj_id="test-bitword",
         updates={
@@ -149,7 +149,7 @@ supernova_bitword_conf.config_substitutions.append(
 )
 supernova_bitword = db.get_dal(class_name="TriggerBitword", uid="test-bitword")
 supernova_bitword_conf.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="TCDataProcessor",
         obj_id="def-tc-processor",
         updates={
@@ -159,7 +159,7 @@ supernova_bitword_conf.config_substitutions.append(
 
 # Series
 series_bitword_conf.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="TCDataProcessor",
         obj_id="def-tc-processor",
         updates={
@@ -169,7 +169,7 @@ series_bitword_conf.config_substitutions.append(
 
 # Coincidence
 coincidence_bitword_conf.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="TriggerBitword",
         obj_id="test-bitword",
         updates={
@@ -178,7 +178,7 @@ coincidence_bitword_conf.config_substitutions.append(
 )
 coincidence_bitword = db.get_dal(class_name="TriggerBitword", uid="test-bitword")
 coincidence_bitword_conf.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="TCDataProcessor",
         obj_id="def-tc-processor",
         updates={
@@ -187,31 +187,31 @@ coincidence_bitword_conf.config_substitutions.append(
             },)
 )
 coincidence_bitword_conf.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_id="random-tc-generator",
         obj_class="RandomTCMakerConf",
         updates={"trigger_rate_hz": 40},)
 )
 coincidence_bitword_conf.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_id="def-random-readout",
         obj_class="TCReadoutMap",
         updates={"time_before": 62500, "time_after": 62500},)
 )
 coincidence_bitword_conf.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_id="fakehsi",
         obj_class="FakeHSIEventGeneratorConf",
         updates={"trigger_rate": 30},)
 )
 coincidence_bitword_conf.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_id="def-tc-map",
         obj_class="TCReadoutMap",
         updates={"time_before": 62500, "time_after": 62500},)
 )
 coincidence_bitword_conf.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_id="def-hsi-tc-map",
         obj_class="TCReadoutMap",
         updates={"time_before": 62500, "time_after": 62500},)


### PR DESCRIPTION
## Description

I've modified ccm.data.xml, example-configs.data.xml, moduleconfs.data.xml, and ru-segment.data.xml so that instead of having four sets of configuration objects for CRT Bern vs. Grenoble, and FDFakeReaderModule vs. CRTxyzReaderModule, there is only one set of config objects that gets appropriately modified by the integtests that make use of the local-socket-1x1 system configuration.

This was motivated by a desire to reduce complexity of what we see in the example configs.

## Testing Suggestions

Please see the suggestions in the parent Issue, DUNE-DAQ/daq-deliverables#181