### PR TITLE
Update the asset file that is used in the TDEEth part of the readout_type_scan_test…

### DIFF
--- a/config/daqsystemtest/moduleconfs.data.xml
+++ b/config/daqsystemtest/moduleconfs.data.xml
@@ -768,6 +768,12 @@
  <attr name="time_after" type="u32" val="1001"/>
 </obj>
 
+<obj class="TCReadoutMap" id="prescale-tc-map-entry">
+ <attr name="tc_type_name" type="string" val="kPrescale"/>
+ <attr name="time_before" type="u32" val="2000"/>
+ <attr name="time_after" type="u32" val="5"/>
+</obj>
+
 <obj class="TPCRawDataProcessor" id="def-wib-processor">
  <attr name="queue_sizes" type="u32" val="10000"/>
  <attr name="thread_names_prefix" type="string" val="postproc-"/>

--- a/integtest/readout_type_scan_test.py
+++ b/integtest/readout_type_scan_test.py
@@ -17,7 +17,6 @@ frame_file_required = False
 number_of_data_producers = 2
 run_duration = 20  # seconds
 data_rate_slowdown_factor = 10  # is this still used anywhere?  (KAB, 28-Apr-2050)
-ta_prescale = 100
 
 # Default values for validation parameters
 expected_number_of_data_files = 1
@@ -121,6 +120,13 @@ daphne_triggerprimitive_frag_params = {
     "min_size_bytes": 96,
     "max_size_bytes": 4392,
 }
+tdeeth_triggerprimitive_frag_params = {
+    "fragment_type_description": "Trigger Primitive",
+    "fragment_type": "Trigger_Primitive",
+    "expected_fragment_count": (1 * 3),  # number of readout apps * 3
+    "min_size_bytes": 72,
+    "max_size_bytes": 144,
+}
 ignored_logfile_problems = {
     "-controller": [
         "Worker with pid \\d+ was terminated due to signal 1",
@@ -167,7 +173,7 @@ wib_tpg_conf.config_substitutions.append(
     data_classes.attribute_substitution(
         obj_class="TAMakerPrescaleAlgorithm",
         obj_id="dummy-ta-maker",
-        updates={"prescale": ta_prescale},
+        updates={"prescale": 100},
     )
 )
 
@@ -177,10 +183,36 @@ wibeth_conf.frame_file = "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798"
 
 tde_conf = copy.deepcopy(conf_dict)
 tde_conf.dro_map_config.det_id = 11
-tde_conf.frame_file = "asset://?checksum=692e327ed9d4fcf1830bf73337779884"
+tde_conf.dro_map_config.crate_id_offset = 5
+tde_conf.dro_map_config.slot_id = 3
+#tde_conf.frame_file = "asset://?checksum=692e327ed9d4fcf1830bf73337779884"
+tde_conf.frame_file = "file://np02vd_run039565_tr5266_css530_sample_tdeeth.bin"
+tde_conf.config_substitutions.append(
+    data_classes.attribute_substitution(
+        obj_class="TPCRawDataProcessor",
+        obj_id="def-wib-processor",
+        updates={"channel_map": "PD2VDTPCChannelMap"},
+    )
+)
 
 tde_tpg_conf = copy.deepcopy(tde_conf)
 tde_tpg_conf.tpg_enabled = True
+tde_tpg_conf.config_substitutions.append(
+    data_classes.list_element_addition(
+        obj_class="TCDataProcessor",
+        obj_id="def-tc-processor",
+        rel_name="tc_readout_map",
+        additional_object_class="TCReadoutMap",
+        additional_object_id="prescale-tc-map-entry",
+    )
+)
+tde_tpg_conf.config_substitutions.append(
+    data_classes.attribute_substitution(
+        obj_class="TAMakerPrescaleAlgorithm",
+        obj_id="dummy-ta-maker",
+        updates={"prescale": 50},
+    )
+)
 
 daphne_stream_conf = copy.deepcopy(conf_dict)
 daphne_stream_conf.dro_map_config.det_id = 2  # det_id = 2 for HD_PDS
@@ -298,30 +330,38 @@ def test_data_files(run_nanorc):
         if "WIBEth" in current_test:
             fragment_check_list.append(wibeth_triggerprimitive_frag_params)
             local_expected_event_count += (
-                (6250 / ta_prescale)
+                0.625
                 * number_of_data_producers
                 * run_duration
-                / 100
             )
             local_event_count_tolerance += (
-                (250 / ta_prescale)
+                0.025
                 * number_of_data_producers
                 * run_duration
-                / 100
             )
         if "DAPHNE" in current_test:
             fragment_check_list.append(daphne_triggerprimitive_frag_params)
             local_expected_event_count += (
-                (6250 / ta_prescale)
+                0.3125
                 * number_of_data_producers
                 * run_duration * 3
-                / 200
             )
             local_event_count_tolerance += (
-                (250 / ta_prescale)
+                0.01
                 * number_of_data_producers
                 * run_duration * 6
-                / 250
+            )
+        if "TDEEth" in current_test:
+            fragment_check_list.append(tdeeth_triggerprimitive_frag_params)
+            local_expected_event_count += (
+                0.70
+                * number_of_data_producers
+                * run_duration
+            )
+            local_event_count_tolerance += (
+                0.025
+                * number_of_data_producers
+                * run_duration
             )
 
     # Run some tests on the output data file

--- a/integtest/readout_type_scan_test.py
+++ b/integtest/readout_type_scan_test.py
@@ -178,15 +178,13 @@ wib_tpg_conf.config_substitutions.append(
 )
 
 wibeth_conf = copy.deepcopy(conf_dict)
-# wibeth_conf.frame_file = "asset://?label=WIBEth&subsystem=readout"
 wibeth_conf.frame_file = "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798"
 
 tde_conf = copy.deepcopy(conf_dict)
 tde_conf.dro_map_config.det_id = 11
 tde_conf.dro_map_config.crate_id_offset = 5
 tde_conf.dro_map_config.slot_id = 3
-#tde_conf.frame_file = "asset://?checksum=692e327ed9d4fcf1830bf73337779884"
-tde_conf.frame_file = "file://np02vd_run039565_tr5266_css530_sample_tdeeth.bin"
+tde_conf.frame_file = "asset://?checksum=1793479772dfef8cb23a071a7383520b"
 tde_conf.config_substitutions.append(
     data_classes.attribute_substitution(
         obj_class="TPCRawDataProcessor",

--- a/integtest/readout_type_scan_test.py
+++ b/integtest/readout_type_scan_test.py
@@ -177,8 +177,10 @@ wibeth_conf.frame_file = "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798"
 
 tde_conf = copy.deepcopy(conf_dict)
 tde_conf.dro_map_config.det_id = 11
-tde_conf.frame_file = "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798" # WIBEth All Zeros
-#tde_conf.frame_file = "asset://?checksum=759e5351436bead208cf4963932d6327"
+tde_conf.frame_file = "asset://?checksum=692e327ed9d4fcf1830bf73337779884"
+
+tde_tpg_conf = copy.deepcopy(tde_conf)
+tde_tpg_conf.tpg_enabled = True
 
 daphne_stream_conf = copy.deepcopy(conf_dict)
 daphne_stream_conf.dro_map_config.det_id = 2  # det_id = 2 for HD_PDS
@@ -235,6 +237,7 @@ confgen_arguments = {
     "DAPHNE_System": daphne_conf,
     "DAPHNE_TPG_System": daphne_tpg_conf,
     "TDEEth_System": tde_conf,
+    "TDEEth_TPG_System": tde_tpg_conf,
     "BernCRT_System": bern_crt_conf,
     "GrenobleCRT_System": grenoble_crt_conf
 }


### PR DESCRIPTION
… and add a TDEEth_TPG configuration to that test.

## Description

For quite some time, we have been using a WIBEth binary file in our TDEEth fake-data-replay tests.  The example of this in our regression tests is `daqsystemtest/readout_type_scan_test.py`.  

Recently, we created a binary data file with actual TDEEth data taken at NP02 and made it available in our "assets" system.  The file is named `np02vd_run039565_tr5266_css530_sample_tdeeth.bin` and it has checksum `1793479772dfef8cb23a071a7383520b` in the assets system.  There is hopefully a good amount of information about how this file was created in DUNE-DAQ/daq-assettools#14.

The point of these changes is to make use of this data file in our regression tests and to add TDEEth TPG testing to a regression test.  Both of these changes are in `readout_type_scan_test`.

Shyam pointed out that the PDVD channel map needs to be used with this TDEEth data from NP02.  And, we discovered that the GeoId that is used in the fake-data-replay needs to match the value from the real electronics when the data was taken at NP02.  Both of these are included in the `readout_type_scan_test.py` changes, and the GeoId match also required changes in the `integrationtest` and `daqconf` repos.  Those changes were to add support for integtest-specific values of the electronics crate and slot.

## Testing Suggestions

Here are sample instructions for seeing the changes in action:

```
DATE_PREFIX=`date '+%d%b'`
TIME_SUFFIX=`date '+%H%M'`

source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
setup_dbt latest
dbt-create -n NFD_DEV_251013_A9 ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}
cd ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}/sourcecode

git clone https://github.com/DUNE-DAQ/daqsystemtest.git -b kbiery/new_tde_asset_file
git clone https://github.com/DUNE-DAQ/daqconf.git -b kbiery/crate_slot_for_generate_hwmap
cd ..

dbt-workarea-env

git clone https://github.com/DUNE-DAQ/integrationtest.git -b kbiery/config_list_element_addition
cd integrationtest
pip install -U .
cd ..

dbt-build -j 12
dbt-workarea-env

cd sourcecode/daqsystemtest/integtest

pytest -s -k TDEEth readout_type_scan_test.py

echo
echo " *** Note that both the TDEEth and TDEEth_TPG tests succeeded."
```

And, we can validate the use of the new TDEEth asset file.  This can be done using the following command:

```
cd /tmp/pytest-of-${USER}/pytest-current/run0
tdedecoder.py -n 1 --print-adc-stats integtest_raw_run000101_0000_df-01_dw_0_*.hdf5
```

and noting that the ADC means and RMS values are non-zero, which they weren't before when we were using the WIB all-zeroes file.

## Correlated Issues and/or PRs

The changes in all three repos are coupled, so it will be important to test and merge them together.

* DUNE-DAQ/integrationtest#125
* DUNE-DAQ/daqconf#605

## Useful Coordination

No special coordination will be needed for merging these changes to develop branches beyond announcing the merges on the appropriate Slack channel.
