### PR TITLE
[CCM] K8s: changing local con port

### DIFF
--- a/config/daqsystemtest/ccm.data.xml
+++ b/config/daqsystemtest/ccm.data.xml
@@ -87,7 +87,7 @@
  <attr name="commandline_parameters" type="string">
   <data val="Process PID $$;"/>
   <data val="trap &apos;pkill -INT -P $$&apos; EXIT;"/>
-  <data val="gunicorn -b 0.0.0.0:30005 --workers=1 --worker-class=gthread --threads=2 --timeout 5000000000 --log-level=info connection-service.connection-flask:app"/>
+  <data val="gunicorn -b 0.0.0.0:${CONNECTION_PORT} --workers=1 --worker-class=gthread --threads=2 --timeout 5000000000 --log-level=info connection-service.connection-flask:app"/>
  </attr>
  <attr name="threads" type="u16" val="1"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
@@ -179,6 +179,11 @@
  <attr name="value" type="string" val="np04-srv-017"/>
 </obj>
 
+<obj class="Variable" id="local-env-connectivity-port">
+ <attr name="name" type="string" val="CONNECTION_PORT"/>
+ <attr name="value" type="string" val="30005"/>
+</obj>
+
 <obj class="Variable" id="ehn1-env-ers-error">
  <attr name="name" type="string" val="DUNEDAQ_ERS_ERROR"/>
  <attr name="value" type="string" val="erstrace,throttle,lstdout,protobufstream(monkafka.cern.ch:30092)"/>
@@ -248,6 +253,8 @@
   <ref class="Variable" id="ehn1-env-ers-stream-libs"/>
   <ref class="Variable" id="ehn1-env-ers-verb"/>
   <ref class="Variable" id="ehn1-env-ers-warning"/>
+  <ref class="Variable" id="ehn1-env-connectivity-port"/>
+  <ref class="Variable" id="ehn1-env-connectivity-server"/>
  </rel>
 </obj>
 
@@ -259,6 +266,7 @@
   <ref class="Variable" id="local-env-ers-verb"/>
   <ref class="Variable" id="local-env-ers-warning"/>
   <ref class="Variable" id="local-env-ers-debug-level"/>
+  <ref class="Variable" id="local-env-connectivity-port"/>
  </rel>
 </obj>
 

--- a/config/daqsystemtest/ccm.data.xml
+++ b/config/daqsystemtest/ccm.data.xml
@@ -87,7 +87,7 @@
  <attr name="commandline_parameters" type="string">
   <data val="Process PID $$;"/>
   <data val="trap &apos;pkill -INT -P $$&apos; EXIT;"/>
-  <data val="gunicorn -b 0.0.0.0:30000 --workers=1 --worker-class=gthread --threads=2 --timeout 5000000000 --log-level=info connection-service.connection-flask:app"/>
+  <data val="gunicorn -b 0.0.0.0:30005 --workers=1 --worker-class=gthread --threads=2 --timeout 5000000000 --log-level=info connection-service.connection-flask:app"/>
  </attr>
  <attr name="threads" type="u16" val="1"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
@@ -161,7 +161,7 @@
 
 <obj class="Service" id="local-connectivity-service">
  <attr name="protocol" type="string" val="http"/>
- <attr name="port" type="u16" val="30000"/>
+ <attr name="port" type="u16" val="30005"/>
 </obj>
 
 <obj class="Service" id="rccontroller_control">

--- a/config/daqsystemtest/ccm.data.xml
+++ b/config/daqsystemtest/ccm.data.xml
@@ -87,7 +87,7 @@
  <attr name="commandline_parameters" type="string">
   <data val="Process PID $$;"/>
   <data val="trap &apos;pkill -INT -P $$&apos; EXIT;"/>
-  <data val="gunicorn -b 0.0.0.0:5000 --workers=1 --worker-class=gthread --threads=2 --timeout 5000000000 --log-level=info connection-service.connection-flask:app"/>
+  <data val="gunicorn -b 0.0.0.0:30000 --workers=1 --worker-class=gthread --threads=2 --timeout 5000000000 --log-level=info connection-service.connection-flask:app"/>
  </attr>
  <attr name="threads" type="u16" val="1"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
@@ -161,7 +161,7 @@
 
 <obj class="Service" id="local-connectivity-service">
  <attr name="protocol" type="string" val="http"/>
- <attr name="port" type="u16" val="5000"/>
+ <attr name="port" type="u16" val="30000"/>
 </obj>
 
 <obj class="Service" id="rccontroller_control">

--- a/config/daqsystemtest/example-configs.data.xml
+++ b/config/daqsystemtest/example-configs.data.xml
@@ -63,7 +63,7 @@
 
 <oks-data>
 
-<info name="" type="" num-of-items="10" oks-format="data" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20231207T105549" last-modified-by="biery" last-modified-on="daq.fnal.gov" last-modification-time="20250903T173857"/>
+<info name="" type="" num-of-items="10" oks-format="data" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20231207T105549" last-modified-by="mrigan" last-modified-on="np04-srv-016.cern.ch" last-modification-time="20251003T122227"/>
 
 <include>
  <file path="schema/confmodel/dunedaq.schema.xml"/>
@@ -87,6 +87,7 @@
  <comment creation-time="20250522T092014" created-by="mrigan" created-on="np04-srv-016.cern.ch" author="mrigan" text="udpate replay"/>
  <comment creation-time="20250526T125621" created-by="dergonul" created-on="np04-srv-031.cern.ch" author="dergonul" text="Added new session for CRTBernFrame and CRTGrenobleFrame"/>
  <comment creation-time="20250805T092423" created-by="dergonul" created-on="np04-srv-028.cern.ch" author="dergonul" text="Emu CRT configs"/>
+ <comment creation-time="20251003T122227" created-by="mrigan" created-on="np04-srv-016.cern.ch" author="mrigan" text="actually using local vars variableset"/>
 </comments>
 
 
@@ -183,12 +184,7 @@
  </rel>
  <rel name="connectivity_service" class="ConnectivityService" id="local-connectivity-service-config"/>
  <rel name="environment">
-  <ref class="Variable" id="local-env-ers-verb"/>
-  <ref class="Variable" id="local-env-ers-info"/>
-  <ref class="Variable" id="local-env-ers-warning"/>
-  <ref class="Variable" id="local-env-ers-error"/>
-  <ref class="Variable" id="local-env-ers-fatal"/>
-  <ref class="Variable" id="local-env-ers-debug-level"/>
+  <ref class="VariableSet" id="local-variables"/>
  </rel>
  <rel name="segment" class="Segment" id="root-segment"/>
  <rel name="infrastructure_applications">
@@ -204,11 +200,7 @@
  <attr name="controller_log_level" type="enum" val="INFO"/>
  <rel name="connectivity_service" class="ConnectivityService" id="local-connectivity-service-config"/>
  <rel name="environment">
-  <ref class="Variable" id="local-env-ers-verb"/>
-  <ref class="Variable" id="local-env-ers-info"/>
-  <ref class="Variable" id="local-env-ers-warning"/>
-  <ref class="Variable" id="local-env-ers-error"/>
-  <ref class="Variable" id="local-env-ers-fatal"/>
+  <ref class="VariableSet" id="local-variables"/>
  </rel>
  <rel name="segment" class="Segment" id="root-segment"/>
  <rel name="infrastructure_applications">
@@ -230,12 +222,7 @@
  </rel>
  <rel name="connectivity_service" class="ConnectivityService" id="local-connectivity-service-config"/>
  <rel name="environment">
-  <ref class="Variable" id="local-env-ers-verb"/>
-  <ref class="Variable" id="local-env-ers-info"/>
-  <ref class="Variable" id="local-env-ers-warning"/>
-  <ref class="Variable" id="local-env-ers-error"/>
-  <ref class="Variable" id="local-env-ers-fatal"/>
-  <ref class="Variable" id="local-env-ers-debug-level"/>
+  <ref class="VariableSet" id="local-variables"/>
  </rel>
  <rel name="segment" class="Segment" id="socket-root-segment"/>
  <rel name="infrastructure_applications">
@@ -256,12 +243,7 @@
  </rel>
  <rel name="connectivity_service" class="ConnectivityService" id="local-connectivity-service-config"/>
  <rel name="environment">
-  <ref class="Variable" id="local-env-ers-verb"/>
-  <ref class="Variable" id="local-env-ers-info"/>
-  <ref class="Variable" id="local-env-ers-warning"/>
-  <ref class="Variable" id="local-env-ers-error"/>
-  <ref class="Variable" id="local-env-ers-fatal"/>
-  <ref class="Variable" id="local-env-ers-debug-level"/>
+  <ref class="VariableSet" id="local-variables"/>
  </rel>
  <rel name="segment" class="Segment" id="tpreplay-root-segment"/>
  <rel name="infrastructure_applications">


### PR DESCRIPTION
To make local connectivity service work with K8s we need to use ports in K8s allowed range for the nodeport service: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport

This solution makes it possible to use either of the existing process managers. 

More details on the k8s side: https://github.com/DUNE-DAQ/drunc/pull/603.
Associated daqconf PR: https://github.com/DUNE-DAQ/daqconf/pull/603