### PR TITLE
Added two new parameters in the TPCRawDataProcessor

### DIFF
--- a/config/daqsystemtest/moduleconfs.data.xml
+++ b/config/daqsystemtest/moduleconfs.data.xml
@@ -769,6 +769,9 @@
 </obj>
 
 <obj class="TPCRawDataProcessor" id="def-wib-processor">
+ <attr name="frame_count_limit" type="u32" val="100"/>
+ <attr name="tp_count_limit" type="u32" val="0"/>
+ <attr name="queue_sizes" type="u32" val="10000"/>
  <attr name="queue_sizes" type="u32" val="10000"/>
  <attr name="thread_names_prefix" type="string" val="postproc-"/>
  <attr name="latency_monitoring" type="bool" val="1"/>

--- a/config/daqsystemtest/moduleconfs.data.xml
+++ b/config/daqsystemtest/moduleconfs.data.xml
@@ -772,7 +772,6 @@
  <attr name="frame_count_limit" type="u32" val="100"/>
  <attr name="tp_count_limit" type="u32" val="0"/>
  <attr name="queue_sizes" type="u32" val="10000"/>
- <attr name="queue_sizes" type="u32" val="10000"/>
  <attr name="thread_names_prefix" type="string" val="postproc-"/>
  <attr name="latency_monitoring" type="bool" val="1"/>
  <attr name="channel_map" type="string" val="PD2HDTPCChannelMap"/>


### PR DESCRIPTION
Issue marked [here](https://github.com/DUNE-DAQ/fdreadoutlibs/issues/260) made me add two new variables to appmodel. See PR [here](https://github.com/DUNE-DAQ/appmodel/pull/241).  Therefore, I updated the `daqsystemtest` accordingly, with the two parameters.

integration test bundle passed. 