### PR TITLE
Moving processor type definition in integration test configurations

### DIFF
--- a/config/daqsystemtest/integrationtest-objects.data.xml
+++ b/config/daqsystemtest/integrationtest-objects.data.xml
@@ -81,11 +81,6 @@
  <comment creation-time="20240909T081245" created-by="glehmann" created-on="np04-srv-024.cern.ch" author="glehmann" text=" "/>
 </comments>
 
-
-<obj class="AVXFrugalPedestalSubtractProcessor" id="tpg-pedsub-proc">
- <attr name="accum_limit" type="u8" val="10"/>
-</obj>
-
 <obj class="DFHWConf" id="dfhw-01">
  <rel name="uses">
   <ref class="StorageDevice" id="storage-01"/>

--- a/config/daqsystemtest/moduleconfs.data.xml
+++ b/config/daqsystemtest/moduleconfs.data.xml
@@ -89,12 +89,35 @@
  <comment creation-time="20250805T092423" created-by="dergonul" created-on="np04-srv-028.cern.ch" author="dergonul" text="Emu CRT configs"/>
 </comments>
 
-
 <obj class="AVXThresholdProcessor" id="tpg-threshold-proc">
  <attr name="metric_collect_time_sample_period" type="u64" val="256"/>
  <attr name="plane0" type="u16" val="100"/>
  <attr name="plane1" type="u16" val="100"/>
  <attr name="plane2" type="u16" val="100"/>
+</obj>
+
+<obj class="AVXAbsRunSumProcessor" id="tpg-absrs-proc">
+ <attr name="metric_collect_time_sample_period" type="u64" val="256"/>
+ <attr name="memory_factor_plane0" type="u8" val="8"/>
+ <attr name="memory_factor_plane1" type="u8" val="8"/>
+ <attr name="memory_factor_plane2" type="u8" val="8"/>
+ <attr name="scale_factor_plane0" type="u8" val="10"/>
+ <attr name="scale_factor_plane1" type="u8" val="10"/>
+ <attr name="scale_factor_plane2" type="u8" val="10"/>
+</obj>
+
+<obj class="AVXFrugalPedestalSubtractProcessor" id="tpg-pedsub-proc">
+ <attr name="accum_limit" type="u8" val="10"/>
+</obj>
+
+<obj class="AVXRunSumProcessor" id="tpg-rs-proc">
+ <attr name="metric_collect_time_sample_period" type="u64" val="256"/>
+ <attr name="memory_factor_plane0" type="u8" val="8"/>
+ <attr name="memory_factor_plane1" type="u8" val="8"/>
+ <attr name="memory_factor_plane2" type="u8" val="8"/>
+ <attr name="scale_factor_plane0" type="u8" val="10"/>
+ <attr name="scale_factor_plane1" type="u8" val="10"/>
+ <attr name="scale_factor_plane2" type="u8" val="10"/>
 </obj>
 
 <obj class="ActionPlan" id="crt-readout-start">

--- a/config/daqsystemtest/ru-segment.data.xml
+++ b/config/daqsystemtest/ru-segment.data.xml
@@ -105,32 +105,6 @@
  <comment creation-time="20250805T092423" created-by="dergonul" created-on="np04-srv-028.cern.ch" author="dergonul" text="Emu CRT configs"/>
 </comments>
 
-
-<obj class="AVXAbsRunSumProcessor" id="tpg-absrs-proc">
- <attr name="metric_collect_time_sample_period" type="u64" val="256"/>
- <attr name="memory_factor_plane0" type="u8" val="8"/>
- <attr name="memory_factor_plane1" type="u8" val="8"/>
- <attr name="memory_factor_plane2" type="u8" val="8"/>
- <attr name="scale_factor_plane0" type="u8" val="10"/>
- <attr name="scale_factor_plane1" type="u8" val="10"/>
- <attr name="scale_factor_plane2" type="u8" val="10"/>
-</obj>
-
-<obj class="AVXFrugalPedestalSubtractProcessor" id="tpg-pedsub-proc">
- <attr name="metric_collect_time_sample_period" type="u64" val="256"/>
- <attr name="accum_limit" type="u8" val="10"/>
-</obj>
-
-<obj class="AVXRunSumProcessor" id="tpg-rs-proc">
- <attr name="metric_collect_time_sample_period" type="u64" val="256"/>
- <attr name="memory_factor_plane0" type="u8" val="8"/>
- <attr name="memory_factor_plane1" type="u8" val="8"/>
- <attr name="memory_factor_plane2" type="u8" val="8"/>
- <attr name="scale_factor_plane0" type="u8" val="10"/>
- <attr name="scale_factor_plane1" type="u8" val="10"/>
- <attr name="scale_factor_plane2" type="u8" val="10"/>
-</obj>
-
 <obj class="CRTReaderApplication" id="crt-data-source-01">
  <attr name="application_name" type="string" val="daq_application"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>


### PR DESCRIPTION
# Current issue

## Test and observation

If I run the `tpstream_writing_test.py` with the current up to date `develop` branch, in `moduleconfs.data.xml`, we defined the following,

```
<obj class="TPCRawDataProcessor" id="def-wib-processor">
 <attr name="queue_sizes" type="u32" val="10000"/>
 <attr name="thread_names_prefix" type="string" val="postproc-"/>
 <attr name="latency_monitoring" type="bool" val="1"/>
 <attr name="channel_map" type="string" val="PD2HDTPCChannelMap"/>
 <attr name="metric_collect_opmon_rate" type="u32" val="1"/>
 <rel name="processing_steps">
  <ref class="AVXFrugalPedestalSubtractProcessor" id="tpg-pedsub-proc"/>
  <ref class="AVXThresholdProcessor" id="tpg-threshold-proc"/>
 </rel>
 <rel name="sot_minima" class="SamplesOverThresholdMinima" id="def-sot-minima"/>
</obj>
```

However, if we go to the resolved `integtest-session-resolved.data.xml`, we find the resolved configuration to be,

```
<obj class="TPCRawDataProcessor" id="def-wib-processor">
 <attr name="queue_sizes" type="u32" val="10000"/>
 <attr name="thread_names_prefix" type="string" val="postproc-"/>
 <attr name="latency_monitoring" type="bool" val="1"/>
 <attr name="channel_map" type="string" val="PD2HDTPCChannelMap"/>
 <attr name="metric_collect_opmon_rate" type="u32" val="1"/>
 <rel name="processing_steps">
  <ref class="AVXThresholdProcessor" id="tpg-threshold-proc"/>
 </rel>
 <rel name="sot_minima" class="SamplesOverThresholdMinima" id="def-sot-minima"/>
</obj>
```

`<ref class="AVXFrugalPedestalSubtractProcessor" id="tpg-pedsub-proc"/>` is missing from the resolved processing steps, giving us only one processor instead.

# Proposed solution

Appearing to be a configuration resolution issue, I have lifted the definitions of the processors from `ru-segment.data.xml` directly into `moduleconfs.data.xml`. In addition, I have also removed a redundant definition of the `AVXFrugalPedestalSubtractProcessor` from `integrationtest-objects.data.xml`.

# Tests

- [x] tpstream_writing_test
- [x] example_system_test
- [x] Full integration tests
