### PR TITLE
Removed comments in integtests that referred to stale asset files

### DIFF
--- a/integtest/minimal_system_quick_test.py
+++ b/integtest/minimal_system_quick_test.py
@@ -78,17 +78,6 @@ substitution = data_classes.attribute_substitution(
 )
 conf_dict.config_substitutions.append(substitution)
 
-# conf_dict["daq_common"]["data_rate_slowdown_factor"] = data_rate_slowdown_factor
-# conf_dict["readout"]["use_fake_cards"] = True
-# conf_dict["trigger"]["ttcm_input_map"] = [{'signal': 1, 'tc_type_name': 'kTiming',
-#                                           'time_before': readout_window_time_before,
-#                                           'time_after': readout_window_time_after}]
-
-# conf_dict["readout"]["data_files"] = []
-# datafile_conf = {}
-# datafile_conf["data_file"] = "asset://?checksum=e96fd6efd3f98a9a3bfaba32975b476e" # WIBEth
-# datafile_conf["detector_id"] = 3
-# conf_dict["readout"]["data_files"].append(datafile_conf)
 
 confgen_arguments = {"MinimalSystem": conf_dict}
 # The commands to run in nanorc, as a list

--- a/integtest/readout_type_scan_test.py
+++ b/integtest/readout_type_scan_test.py
@@ -172,13 +172,11 @@ wib_tpg_conf.config_substitutions.append(
 )
 
 wibeth_conf = copy.deepcopy(conf_dict)
-# wibeth_conf.frame_file = "asset://?label=WIBEth&subsystem=readout"
 wibeth_conf.frame_file = "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798"
 
 tde_conf = copy.deepcopy(conf_dict)
 tde_conf.dro_map_config.det_id = 11
 tde_conf.frame_file = "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798" # WIBEth All Zeros
-#tde_conf.frame_file = "asset://?checksum=759e5351436bead208cf4963932d6327"
 
 daphne_stream_conf = copy.deepcopy(conf_dict)
 daphne_stream_conf.dro_map_config.det_id = 2  # det_id = 2 for HD_PDS

--- a/integtest/readout_type_scan_test.py
+++ b/integtest/readout_type_scan_test.py
@@ -211,7 +211,6 @@ tde_tpg_conf.config_substitutions.append(
         updates={"prescale": 50},
     )
 )
->>>>>>> origin/develop
 
 daphne_stream_conf = copy.deepcopy(conf_dict)
 daphne_stream_conf.dro_map_config.det_id = 2  # det_id = 2 for HD_PDS

--- a/integtest/readout_type_scan_test.py
+++ b/integtest/readout_type_scan_test.py
@@ -172,7 +172,7 @@ wib_tpg_conf.config_substitutions.append(
 )
 
 wibeth_conf = copy.deepcopy(conf_dict)
-wibeth_conf.frame_file = "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798"
+wibeth_conf.frame_file = "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798" # WIBEth All Zeros
 
 tde_conf = copy.deepcopy(conf_dict)
 tde_conf.dro_map_config.det_id = 11
@@ -195,7 +195,7 @@ daphne_stream_conf.config_substitutions.append(
 
 daphne_conf = copy.deepcopy(conf_dict)
 daphne_conf.dro_map_config.det_id = 2  # det_id = 2 for HD_PDS
-daphne_conf.frame_file = "asset://?checksum=a8990a9eb3a505d4ded62dfdfa9e2681"
+daphne_conf.frame_file = "asset://?checksum=a8990a9eb3a505d4ded62dfdfa9e2681" # np02vd_run036012_sample_membrane_pds
 daphne_conf.config_substitutions.append(
     data_classes.attribute_substitution(
         obj_class="TCReadoutMap",


### PR DESCRIPTION
## Description

DUNE-DAQ/daqsystemtest#245 requests that we update our regression tests, etc. to use recent data-replay files from the _assets_ system.

In this repo, that translated to removing comments in `integtests` that referred to stale files.

## Testing Suggestions

There are suggestions in DUNE-DAQ/daqsystemtest#245 for testing all of the asset-file-update changes together.
