### PR TITLE
Fixes for the TDEEth_TPG part of the readout_type_scan_test

### DIFF
--- a/integtest/readout_type_scan_test.py
+++ b/integtest/readout_type_scan_test.py
@@ -206,9 +206,23 @@ tde_tpg_conf.config_substitutions.append(
 )
 tde_tpg_conf.config_substitutions.append(
     data_classes.attribute_substitution(
+        obj_class="AVXThresholdProcessor",
+        obj_id="tpg-threshold-proc",
+        updates={"plane0": 500, "plane1": 500, "plane2": 500},
+    )
+)
+tde_tpg_conf.config_substitutions.append(
+    data_classes.attribute_substitution(
         obj_class="TAMakerPrescaleAlgorithm",
         obj_id="dummy-ta-maker",
-        updates={"prescale": 50},
+        updates={"prescale": 100},
+    )
+)
+tde_tpg_conf.config_substitutions.append(
+    data_classes.attribute_substitution(
+        obj_class="GeoId",
+        obj_id="geioId-1",
+        updates={"slot_id": 4, "stream_id": 0},
     )
 )
 
@@ -267,7 +281,7 @@ confgen_arguments = {
     "DAPHNE_System": daphne_conf,
     "DAPHNE_TPG_System": daphne_tpg_conf,
     "TDEEth_System": tde_conf,
-#    "TDEEth_TPG_System": tde_tpg_conf,
+    "TDEEth_TPG_System": tde_tpg_conf,
     "BernCRT_System": bern_crt_conf,
     "GrenobleCRT_System": grenoble_crt_conf
 }


### PR DESCRIPTION
## Description

We noticed that the recent addition of a TDEEth_TPG section to the `readout_type_scan_test` started to fail when it was run with recent changes in `fdreadoutlibs` (creation of `TPCEthFrameProcessor`).

Alejandro found that this was because of several reasons:

1. Kurt had used an invalid GeoID (crate/slot/stream == 5/3/1) for one of the data sources in the integtest.  Alejandro fixed this problem by using 5/4/0 instead of 5/3/1.
2. The sample TDE data had several noisy time periods in its data sample, and this caused the rate of TPs to be higher than expected.  This was fixed by tuning the TP threshold and TAMaker prescale.  

## Testing Suggestions

These changes can be tested by checking out this branch in a local software area and verifying that the `readout_type_scan_test` now runs cleanly.
