### PR TITLE
Add Configurable RunSum Divisor

### DIFF
--- a/config/daqsystemtest/moduleconfs.data.xml
+++ b/config/daqsystemtest/moduleconfs.data.xml
@@ -104,6 +104,12 @@
  <attr name="scale_factor_plane0" type="u8" val="10"/>
  <attr name="scale_factor_plane1" type="u8" val="10"/>
  <attr name="scale_factor_plane2" type="u8" val="10"/>
+ <attr name="memory_divisor_plane0" type="u8" val="10"/>
+ <attr name="memory_divisor_plane1" type="u8" val="10"/>
+ <attr name="memory_divisor_plane2" type="u8" val="10"/>
+ <attr name="scale_divisor_plane0" type="u8" val="10"/>
+ <attr name="scale_divisor_plane1" type="u8" val="10"/>
+ <attr name="scale_divisor_plane2" type="u8" val="10"/>
 </obj>
 
 <obj class="AVXFrugalPedestalSubtractProcessor" id="tpg-pedsub-proc">
@@ -118,6 +124,12 @@
  <attr name="scale_factor_plane0" type="u8" val="10"/>
  <attr name="scale_factor_plane1" type="u8" val="10"/>
  <attr name="scale_factor_plane2" type="u8" val="10"/>
+ <attr name="memory_divisor_plane0" type="u8" val="10"/>
+ <attr name="memory_divisor_plane1" type="u8" val="10"/>
+ <attr name="memory_divisor_plane2" type="u8" val="10"/>
+ <attr name="scale_divisor_plane0" type="u8" val="10"/>
+ <attr name="scale_divisor_plane1" type="u8" val="10"/>
+ <attr name="scale_divisor_plane2" type="u8" val="10"/>
 </obj>
 
 <obj class="ActionPlan" id="crt-readout-start">


### PR DESCRIPTION
# Description
TPG running sum processors now include a configurable divisor value. While the changes in https://github.com/DUNE-DAQ/appmodel/pull/254 have default values, the changes in this PR are to make these changes explicit here. The values set are the same as before the divisor was configurable. Though, the TPG processors affected by this change are not used in the existing integration test for their complexity.


## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

Testing was done through a local run that used either of `AVXRunSumProcessor` or `AVXAbsRunSumProcessor` and checking that the local run configured without error. The check on TP quality and TPG functionality was completed for https://github.com/DUNE-DAQ/tpglibs/pull/34.

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

