### PR TITLE
Added an exclusion for SIGHUP messages to integtest to avoid spurious problems

### DIFF
--- a/integtest/3ru_1df_multirun_test.py
+++ b/integtest/3ru_1df_multirun_test.py
@@ -87,6 +87,7 @@ ignored_logfile_problems = {
     ],
     "connectivity-service": [
         "errorlog: -",
+        r"Worker \(pid:\d+\) was sent SIGHUP"
     ],
 }
 

--- a/integtest/3ru_1df_multirun_test.py
+++ b/integtest/3ru_1df_multirun_test.py
@@ -84,6 +84,7 @@ ignored_logfile_problems = {
     "-controller": [
         "Worker with pid \\d+ was terminated due to signal 1",
         "Connection '.*' not found on the application registry",
+        r"Worker \(pid:\d+\) was sent SIGHUP"
     ],
     "connectivity-service": [
         "errorlog: -",

--- a/integtest/3ru_1df_multirun_test.py
+++ b/integtest/3ru_1df_multirun_test.py
@@ -84,11 +84,11 @@ ignored_logfile_problems = {
     "-controller": [
         "Worker with pid \\d+ was terminated due to signal 1",
         "Connection '.*' not found on the application registry",
-        r"Worker \(pid:\d+\) was sent SIGHUP"
+        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 31-Oct, KAB/PP/JCF
     ],
     "connectivity-service": [
         "errorlog: -",
-        r"Worker \(pid:\d+\) was sent SIGHUP"
+        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 31-Oct, KAB/PP/JCF
     ],
 }
 

--- a/integtest/3ru_3df_multirun_test.py
+++ b/integtest/3ru_3df_multirun_test.py
@@ -82,11 +82,11 @@ ignored_logfile_problems = {
     "-controller": [
         "Worker with pid \\d+ was terminated due to signal 1",
         "Connection '.*' not found on the application registry",
-        r"Worker \(pid:\d+\) was sent SIGHUP"
+        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 31-Oct, KAB/PP/JCF
     ],
     "connectivity-service": [
         "errorlog: -",
-        r"Worker \(pid:\d+\) was sent SIGHUP"
+        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 31-Oct, KAB/PP/JCF
     ],
 }
 

--- a/integtest/3ru_3df_multirun_test.py
+++ b/integtest/3ru_3df_multirun_test.py
@@ -85,6 +85,7 @@ ignored_logfile_problems = {
     ],
     "connectivity-service": [
         "errorlog: -",
+        r"Worker \(pid:\d+\) was sent SIGHUP"
     ],
 }
 

--- a/integtest/3ru_3df_multirun_test.py
+++ b/integtest/3ru_3df_multirun_test.py
@@ -82,6 +82,7 @@ ignored_logfile_problems = {
     "-controller": [
         "Worker with pid \\d+ was terminated due to signal 1",
         "Connection '.*' not found on the application registry",
+        r"Worker \(pid:\d+\) was sent SIGHUP"
     ],
     "connectivity-service": [
         "errorlog: -",

--- a/integtest/example_system_test.py
+++ b/integtest/example_system_test.py
@@ -64,6 +64,9 @@ hsi_frag_params = {
                               "default": {"min_size_bytes":  72, "max_size_bytes": 100} }
 }
 ignored_logfile_problems = {
+    "-controller": [
+        r"Worker \(pid:\d+\) was sent SIGHUP"
+    ],
     "local-connection-server": [
         "errorlog: -",
         r"Worker \(pid:\d+\) was sent SIGHUP"

--- a/integtest/example_system_test.py
+++ b/integtest/example_system_test.py
@@ -65,11 +65,11 @@ hsi_frag_params = {
 }
 ignored_logfile_problems = {
     "-controller": [
-        r"Worker \(pid:\d+\) was sent SIGHUP"
+        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 31-Oct, KAB/PP/JCF
     ],
     "local-connection-server": [
         "errorlog: -",
-        r"Worker \(pid:\d+\) was sent SIGHUP"
+        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 31-Oct, KAB/PP/JCF
     ]
 }
 

--- a/integtest/fake_data_producer_test.py
+++ b/integtest/fake_data_producer_test.py
@@ -40,6 +40,7 @@ ignored_logfile_problems = {
     "-controller": [
         "Worker with pid \\d+ was terminated due to signal",
         "Connection '.*' not found on the application registry",
+        r"Worker \(pid:\d+\) was sent SIGHUP"
     ],
     "connectivity-service": [
         "errorlog: -",

--- a/integtest/fake_data_producer_test.py
+++ b/integtest/fake_data_producer_test.py
@@ -43,6 +43,7 @@ ignored_logfile_problems = {
     ],
     "connectivity-service": [
         "errorlog: -",
+        r"Worker \(pid:\d+\) was sent SIGHUP"
     ],
 }
 

--- a/integtest/fake_data_producer_test.py
+++ b/integtest/fake_data_producer_test.py
@@ -40,11 +40,11 @@ ignored_logfile_problems = {
     "-controller": [
         "Worker with pid \\d+ was terminated due to signal",
         "Connection '.*' not found on the application registry",
-        r"Worker \(pid:\d+\) was sent SIGHUP"
+        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 31-Oct, KAB/PP/JCF
     ],
     "connectivity-service": [
         "errorlog: -",
-        r"Worker \(pid:\d+\) was sent SIGHUP"
+        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 31-Oct, KAB/PP/JCF
     ],
 }
 

--- a/integtest/long_window_readout_test.py
+++ b/integtest/long_window_readout_test.py
@@ -62,6 +62,7 @@ ignored_logfile_problems = {
     ],
     "connectivity-service": [
         "errorlog: -",
+        r"Worker \(pid:\d+\) was sent SIGHUP"
     ],
 }
 

--- a/integtest/long_window_readout_test.py
+++ b/integtest/long_window_readout_test.py
@@ -59,6 +59,7 @@ ignored_logfile_problems = {
     "-controller": [
         "Worker with pid \\d+ was terminated due to signal 1",
         "Connection '.*' not found on the application registry",
+        r"Worker \(pid:\d+\) was sent SIGHUP"
     ],
     "connectivity-service": [
         "errorlog: -",

--- a/integtest/long_window_readout_test.py
+++ b/integtest/long_window_readout_test.py
@@ -59,11 +59,11 @@ ignored_logfile_problems = {
     "-controller": [
         "Worker with pid \\d+ was terminated due to signal 1",
         "Connection '.*' not found on the application registry",
-        r"Worker \(pid:\d+\) was sent SIGHUP"
+        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 31-Oct, KAB/PP/JCF
     ],
     "connectivity-service": [
         "errorlog: -",
-        r"Worker \(pid:\d+\) was sent SIGHUP"
+        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 31-Oct, KAB/PP/JCF
     ],
 }
 

--- a/integtest/minimal_system_quick_test.py
+++ b/integtest/minimal_system_quick_test.py
@@ -47,6 +47,7 @@ ignored_logfile_problems = {
     ],
     "connectivity-service": [
         "errorlog: -",
+        r"Worker \(pid:\d+\) was sent SIGHUP"
     ],
 }
 

--- a/integtest/minimal_system_quick_test.py
+++ b/integtest/minimal_system_quick_test.py
@@ -44,6 +44,7 @@ ignored_logfile_problems = {
     "-controller": [
         "Worker with pid \\d+ was terminated due to signal",
         "Connection '.*' not found on the application registry",
+        r"Worker \(pid:\d+\) was sent SIGHUP"
     ],
     "connectivity-service": [
         "errorlog: -",

--- a/integtest/minimal_system_quick_test.py
+++ b/integtest/minimal_system_quick_test.py
@@ -44,11 +44,11 @@ ignored_logfile_problems = {
     "-controller": [
         "Worker with pid \\d+ was terminated due to signal",
         "Connection '.*' not found on the application registry",
-        r"Worker \(pid:\d+\) was sent SIGHUP"
+        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 31-Oct, KAB/PP/JCF
     ],
     "connectivity-service": [
         "errorlog: -",
-        r"Worker \(pid:\d+\) was sent SIGHUP"
+        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 31-Oct, KAB/PP/JCF
     ],
 }
 

--- a/integtest/readout_type_scan_test.py
+++ b/integtest/readout_type_scan_test.py
@@ -131,11 +131,11 @@ ignored_logfile_problems = {
     "-controller": [
         "Worker with pid \\d+ was terminated due to signal 1",
         "Connection '.*' not found on the application registry",
-        r"Worker \(pid:\d+\) was sent SIGHUP"
+        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 31-Oct, KAB/PP/JCF
     ],
     "connectivity-service": [
         "errorlog: -",
-        r"Worker \(pid:\d+\) was sent SIGHUP"
+        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 31-Oct, KAB/PP/JCF
     ],
 }
 

--- a/integtest/readout_type_scan_test.py
+++ b/integtest/readout_type_scan_test.py
@@ -131,6 +131,7 @@ ignored_logfile_problems = {
     "-controller": [
         "Worker with pid \\d+ was terminated due to signal 1",
         "Connection '.*' not found on the application registry",
+        r"Worker \(pid:\d+\) was sent SIGHUP"
     ],
     "connectivity-service": [
         "errorlog: -",

--- a/integtest/readout_type_scan_test.py
+++ b/integtest/readout_type_scan_test.py
@@ -134,6 +134,7 @@ ignored_logfile_problems = {
     ],
     "connectivity-service": [
         "errorlog: -",
+        r"Worker \(pid:\d+\) was sent SIGHUP"
     ],
 }
 

--- a/integtest/small_footprint_quick_test.py
+++ b/integtest/small_footprint_quick_test.py
@@ -45,6 +45,7 @@ ignored_logfile_problems = {
     "-controller": [
         "Worker with pid \\d+ was terminated due to signal 1",
         "Connection '.*' not found on the application registry",
+        r"Worker \(pid:\d+\) was sent SIGHUP"
     ],
     "connectivity-service": [
         "errorlog: -",

--- a/integtest/small_footprint_quick_test.py
+++ b/integtest/small_footprint_quick_test.py
@@ -48,6 +48,7 @@ ignored_logfile_problems = {
     ],
     "connectivity-service": [
         "errorlog: -",
+        r"Worker \(pid:\d+\) was sent SIGHUP"
     ],
 }
 

--- a/integtest/small_footprint_quick_test.py
+++ b/integtest/small_footprint_quick_test.py
@@ -45,11 +45,11 @@ ignored_logfile_problems = {
     "-controller": [
         "Worker with pid \\d+ was terminated due to signal 1",
         "Connection '.*' not found on the application registry",
-        r"Worker \(pid:\d+\) was sent SIGHUP"
+        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 31-Oct, KAB/PP/JCF
     ],
     "connectivity-service": [
         "errorlog: -",
-        r"Worker \(pid:\d+\) was sent SIGHUP"
+        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 31-Oct, KAB/PP/JCF
     ],
 }
 

--- a/integtest/tpg_state_collection_test.py
+++ b/integtest/tpg_state_collection_test.py
@@ -96,11 +96,11 @@ ignored_logfile_problems = {
     "-controller": [
         "Worker with pid \\d+ was terminated due to signal 1",
         "Connection '.*' not found on the application registry",
-        r"Worker \(pid:\d+\) was sent SIGHUP"
+        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 31-Oct, KAB/PP/JCF
     ],
     "connectivity-service": [
         "errorlog: -",
-        r"Worker \(pid:\d+\) was sent SIGHUP"
+        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 31-Oct, KAB/PP/JCF
     ],
 }
 

--- a/integtest/tpg_state_collection_test.py
+++ b/integtest/tpg_state_collection_test.py
@@ -99,6 +99,7 @@ ignored_logfile_problems = {
     ],
     "connectivity-service": [
         "errorlog: -",
+        r"Worker \(pid:\d+\) was sent SIGHUP"
     ],
 }
 

--- a/integtest/tpg_state_collection_test.py
+++ b/integtest/tpg_state_collection_test.py
@@ -96,6 +96,7 @@ ignored_logfile_problems = {
     "-controller": [
         "Worker with pid \\d+ was terminated due to signal 1",
         "Connection '.*' not found on the application registry",
+        r"Worker \(pid:\d+\) was sent SIGHUP"
     ],
     "connectivity-service": [
         "errorlog: -",

--- a/integtest/tpreplay_test.py
+++ b/integtest/tpreplay_test.py
@@ -53,7 +53,7 @@ check_for_logfile_errors = True
 ignored_logfile_problems = {
     "local-connection-server": [
         "errorlog: -",
-        r"Worker \(pid:\d+\) was sent SIGHUP"
+        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 31-Oct, KAB/PP/JCF
     ],
     "config_mlt": [
         "Trigger is inhibited",
@@ -67,7 +67,7 @@ ignored_logfile_problems = {
         "Postprocessing has too much backlog"
     ],
     "-controller": [
-        r"Worker \(pid:\d+\) was sent SIGHUP"
+        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 31-Oct, KAB/PP/JCF
     ]
 }
 

--- a/integtest/tpreplay_test.py
+++ b/integtest/tpreplay_test.py
@@ -65,6 +65,9 @@ ignored_logfile_problems = {
     "config_tpreplay": [
         "Request on empty buffer",
         "Postprocessing has too much backlog"
+    ],
+    "-controller": [
+        r"Worker \(pid:\d+\) was sent SIGHUP"
     ]
 }
 

--- a/integtest/tpstream_writing_test.py
+++ b/integtest/tpstream_writing_test.py
@@ -96,11 +96,11 @@ ignored_logfile_problems = {
     "-controller": [
         "Worker with pid \\d+ was terminated due to signal 1",
         "Connection '.*' not found on the application registry",
-        r"Worker \(pid:\d+\) was sent SIGHUP"
+        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 31-Oct, KAB/PP/JCF
     ],
     "connectivity-service": [
         "errorlog: -",
-        r"Worker \(pid:\d+\) was sent SIGHUP"
+        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 31-Oct, KAB/PP/JCF
     ],
 }
 

--- a/integtest/tpstream_writing_test.py
+++ b/integtest/tpstream_writing_test.py
@@ -99,6 +99,7 @@ ignored_logfile_problems = {
     ],
     "connectivity-service": [
         "errorlog: -",
+        r"Worker \(pid:\d+\) was sent SIGHUP"
     ],
 }
 

--- a/integtest/tpstream_writing_test.py
+++ b/integtest/tpstream_writing_test.py
@@ -96,6 +96,7 @@ ignored_logfile_problems = {
     "-controller": [
         "Worker with pid \\d+ was terminated due to signal 1",
         "Connection '.*' not found on the application registry",
+        r"Worker \(pid:\d+\) was sent SIGHUP"
     ],
     "connectivity-service": [
         "errorlog: -",

--- a/integtest/trigger_bitwords_test.py
+++ b/integtest/trigger_bitwords_test.py
@@ -51,6 +51,9 @@ ignored_logfile_problems = {
     ],
     "config_dfo": [
         "that was busy with"
+    ],
+    "-controller": [
+        r"Worker \(pid:\d+\) was sent SIGHUP"
     ]
 }
 

--- a/integtest/trigger_bitwords_test.py
+++ b/integtest/trigger_bitwords_test.py
@@ -44,7 +44,7 @@ check_for_logfile_errors = True
 ignored_logfile_problems = {
     "local-connection-server": [
         "errorlog: -",
-        r"Worker \(pid:\d+\) was sent SIGHUP"
+        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 31-Oct, KAB/PP/JCF
     ],
     "config_mlt": [
         "Trigger is inhibited"
@@ -53,7 +53,7 @@ ignored_logfile_problems = {
         "that was busy with"
     ],
     "-controller": [
-        r"Worker \(pid:\d+\) was sent SIGHUP"
+        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 31-Oct, KAB/PP/JCF
     ]
 }
 


### PR DESCRIPTION
# Description

Recently, Pawel and John noticed that we occasionally see messages like the following in regression tests:

```
[ERROR] Worker (pid:3925714) was sent SIGHUP!
```

Some of the existing regression tests exclude messages like this when searching log files for errors and warnings, while others don't.

Pawel investigated the source of these messages and made some progress, but his preference is to defer a full investigation until after `fddaq-v5.5.0`.  Given that, we believe that it is prudent to add messages of this type to the ignored message lists in all regression tests.  This PR does that for the `daqsystemtest` repo.

These changes are independent of all other changes.

To test this in the short term, we should verify that the regression tests run without problems.  In the medium term (after this PR is approved and merged), we should watch that we don't see instances of the SIGHUP in regression tests.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [x] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

I have confirmed that existing tests run fine for me.

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.

