### PR TITLE
[CCM] detach local connectivity gunicorn from tty

### DIFF
--- a/config/daqsystemtest/ccm.data.xml
+++ b/config/daqsystemtest/ccm.data.xml
@@ -86,8 +86,8 @@
  <attr name="application_name" type="string" val="echo"/>
  <attr name="commandline_parameters" type="string">
   <data val="Process PID $$;"/>
-  <data val="trap &apos;pkill -INT -P $$&apos; EXIT;"/>
-  <data val="gunicorn -b 0.0.0.0:5000 --workers=1 --worker-class=gthread --threads=2 --timeout 5000000000 --log-level=info connectivityserver.connectionflask:app"/>
+  <data val="trap &apos;pkill -QUIT -P $$&apos; EXIT;"/>
+  <data val="setsid gunicorn -b 0.0.0.0:5000 --workers=1 --worker-class=gthread --threads=2 --timeout 5000000000 --log-level=info connectivityserver.connectionflask:app"/>
  </attr>
  <attr name="threads" type="u16" val="1"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>

--- a/config/daqsystemtest/ccm.data.xml
+++ b/config/daqsystemtest/ccm.data.xml
@@ -87,7 +87,7 @@
  <attr name="commandline_parameters" type="string">
   <data val="Process PID $$;"/>
   <data val="trap &apos;pkill -QUIT -P $$&apos; EXIT;"/>
-  <data val="setsid gunicorn -b 0.0.0.0:CONNECTION_PORT --workers=1 --worker-class=gthread --threads=2 --timeout 5000000000 --log-level=info connectivityserver.connectionflask:app"/>
+  <data val="setsid gunicorn -b 0.0.0.0:${CONNECTION_PORT} --workers=1 --worker-class=gthread --threads=2 --timeout 5000000000 --log-level=info connectivityserver.connectionflask:app"/>
  </attr>
  <attr name="threads" type="u16" val="1"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>

--- a/integtest/3ru_1df_multirun_test.py
+++ b/integtest/3ru_1df_multirun_test.py
@@ -84,11 +84,9 @@ ignored_logfile_problems = {
     "-controller": [
         "Worker with pid \\d+ was terminated due to signal 1",
         "Connection '.*' not found on the application registry",
-        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 31-Oct, KAB/PP/JCF
     ],
     "connectivity-service": [
         "errorlog: -",
-        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 31-Oct, KAB/PP/JCF
     ],
 }
 

--- a/integtest/3ru_3df_multirun_test.py
+++ b/integtest/3ru_3df_multirun_test.py
@@ -82,11 +82,9 @@ ignored_logfile_problems = {
     "-controller": [
         "Worker with pid \\d+ was terminated due to signal 1",
         "Connection '.*' not found on the application registry",
-        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 31-Oct, KAB/PP/JCF
     ],
     "connectivity-service": [
         "errorlog: -",
-        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 31-Oct, KAB/PP/JCF
     ],
 }
 

--- a/integtest/example_system_test.py
+++ b/integtest/example_system_test.py
@@ -65,11 +65,9 @@ hsi_frag_params = {
 }
 ignored_logfile_problems = {
     "-controller": [
-        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 31-Oct, KAB/PP/JCF
     ],
     "local-connection-server": [
         "errorlog: -",
-        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 31-Oct, KAB/PP/JCF
     ]
 }
 

--- a/integtest/fake_data_producer_test.py
+++ b/integtest/fake_data_producer_test.py
@@ -40,11 +40,9 @@ ignored_logfile_problems = {
     "-controller": [
         "Worker with pid \\d+ was terminated due to signal",
         "Connection '.*' not found on the application registry",
-        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 31-Oct, KAB/PP/JCF
     ],
     "connectivity-service": [
         "errorlog: -",
-        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 31-Oct, KAB/PP/JCF
     ],
 }
 

--- a/integtest/long_window_readout_test.py
+++ b/integtest/long_window_readout_test.py
@@ -59,11 +59,9 @@ ignored_logfile_problems = {
     "-controller": [
         "Worker with pid \\d+ was terminated due to signal 1",
         "Connection '.*' not found on the application registry",
-        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 31-Oct, KAB/PP/JCF
     ],
     "connectivity-service": [
         "errorlog: -",
-        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 31-Oct, KAB/PP/JCF
     ],
 }
 

--- a/integtest/minimal_system_quick_test.py
+++ b/integtest/minimal_system_quick_test.py
@@ -44,11 +44,9 @@ ignored_logfile_problems = {
     "-controller": [
         "Worker with pid \\d+ was terminated due to signal",
         "Connection '.*' not found on the application registry",
-        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 31-Oct, KAB/PP/JCF
     ],
     "connectivity-service": [
         "errorlog: -",
-        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 31-Oct, KAB/PP/JCF
     ],
 }
 

--- a/integtest/readout_type_scan_test.py
+++ b/integtest/readout_type_scan_test.py
@@ -131,11 +131,9 @@ ignored_logfile_problems = {
     "-controller": [
         "Worker with pid \\d+ was terminated due to signal 1",
         "Connection '.*' not found on the application registry",
-        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 31-Oct, KAB/PP/JCF
     ],
     "connectivity-service": [
         "errorlog: -",
-        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 31-Oct, KAB/PP/JCF
     ],
 }
 

--- a/integtest/small_footprint_quick_test.py
+++ b/integtest/small_footprint_quick_test.py
@@ -45,11 +45,9 @@ ignored_logfile_problems = {
     "-controller": [
         "Worker with pid \\d+ was terminated due to signal 1",
         "Connection '.*' not found on the application registry",
-        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 31-Oct, KAB/PP/JCF
     ],
     "connectivity-service": [
         "errorlog: -",
-        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 31-Oct, KAB/PP/JCF
     ],
 }
 

--- a/integtest/tpg_state_collection_test.py
+++ b/integtest/tpg_state_collection_test.py
@@ -96,11 +96,9 @@ ignored_logfile_problems = {
     "-controller": [
         "Worker with pid \\d+ was terminated due to signal 1",
         "Connection '.*' not found on the application registry",
-        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 31-Oct, KAB/PP/JCF
     ],
     "connectivity-service": [
         "errorlog: -",
-        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 31-Oct, KAB/PP/JCF
     ],
 }
 

--- a/integtest/tpreplay_test.py
+++ b/integtest/tpreplay_test.py
@@ -53,7 +53,6 @@ check_for_logfile_errors = True
 ignored_logfile_problems = {
     "local-connection-server": [
         "errorlog: -",
-        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 31-Oct, KAB/PP/JCF
     ],
     "config_mlt": [
         "Trigger is inhibited",
@@ -67,7 +66,6 @@ ignored_logfile_problems = {
         "Postprocessing has too much backlog"
     ],
     "-controller": [
-        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 31-Oct, KAB/PP/JCF
     ]
 }
 

--- a/integtest/tpstream_writing_test.py
+++ b/integtest/tpstream_writing_test.py
@@ -96,11 +96,9 @@ ignored_logfile_problems = {
     "-controller": [
         "Worker with pid \\d+ was terminated due to signal 1",
         "Connection '.*' not found on the application registry",
-        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 31-Oct, KAB/PP/JCF
     ],
     "connectivity-service": [
         "errorlog: -",
-        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 31-Oct, KAB/PP/JCF
     ],
 }
 

--- a/integtest/trigger_bitwords_test.py
+++ b/integtest/trigger_bitwords_test.py
@@ -44,7 +44,6 @@ check_for_logfile_errors = True
 ignored_logfile_problems = {
     "local-connection-server": [
         "errorlog: -",
-        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 31-Oct, KAB/PP/JCF
     ],
     "config_mlt": [
         "Trigger is inhibited"
@@ -53,7 +52,6 @@ ignored_logfile_problems = {
         "that was busy with"
     ],
     "-controller": [
-        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 31-Oct, KAB/PP/JCF
     ]
 }
 


### PR DESCRIPTION
# Description

Fixes https://github.com/DUNE-DAQ/drunc/issues/649
Fixes https://github.com/DUNE-DAQ/drunc/issues/638

add setsid for local connectivity server gunicorn, preventing sighup sent by the kernel.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [x] Optimization (non-breaking change that improves code/performance)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

