### PR TITLE
Added username to the drunc session name in EHN1 example_system_tests

### DIFF
--- a/config/daqsystemtest/ccm.data.xml
+++ b/config/daqsystemtest/ccm.data.xml
@@ -133,7 +133,7 @@
  <attr name="application_name" type="string" val="drunc-controller"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="exposes_service">
-  <ref class="Service" id="rccontroller_control_root"/>
+  <ref class="Service" id="root-rccontroller_control"/>
  </rel>
  <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
  <rel name="fsm" class="FSMconfiguration" id="fsmConf-test"/>
@@ -143,7 +143,7 @@
  <attr name="application_name" type="string" val="drunc-controller"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="exposes_service">
-  <ref class="Service" id="rccontroller_control"/>
+  <ref class="Service" id="root-rccontroller_control"/>
  </rel>
  <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
  <rel name="fsm" class="FSMconfiguration" id="fsmConf-test"/>
@@ -169,7 +169,7 @@
  <attr name="port" type="u16" val="0"/>
 </obj>
 
-<obj class="Service" id="rccontroller_control_root">
+<obj class="Service" id="root-rccontroller_control">
  <attr name="protocol" type="string" val="grpc"/>
  <attr name="port" type="u16" val="30006"/>
 </obj>

--- a/config/daqsystemtest/ccm.data.xml
+++ b/config/daqsystemtest/ccm.data.xml
@@ -87,7 +87,7 @@
  <attr name="commandline_parameters" type="string">
   <data val="Process PID $$;"/>
   <data val="trap &apos;pkill -INT -P $$&apos; EXIT;"/>
-  <data val="gunicorn -b 0.0.0.0:5000 --workers=1 --worker-class=gthread --threads=2 --timeout 5000000000 --log-level=info connectivityserver.connectionflask:app"/>
+  <data val="gunicorn -b 0.0.0.0:${CONNECTION_PORT} --workers=1 --worker-class=gthread --threads=2 --timeout 5000000000 --log-level=info connectivityserver.connectionflask:app"/>
  </attr>
  <attr name="threads" type="u16" val="1"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
@@ -133,7 +133,7 @@
  <attr name="application_name" type="string" val="drunc-controller"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="exposes_service">
-  <ref class="Service" id="rccontroller_control"/>
+  <ref class="Service" id="rccontroller_control_root"/>
  </rel>
  <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
  <rel name="fsm" class="FSMconfiguration" id="fsmConf-test"/>
@@ -161,12 +161,17 @@
 
 <obj class="Service" id="local-connectivity-service">
  <attr name="protocol" type="string" val="http"/>
- <attr name="port" type="u16" val="5000"/>
+ <attr name="port" type="u16" val="30005"/>
 </obj>
 
 <obj class="Service" id="rccontroller_control">
  <attr name="protocol" type="string" val="grpc"/>
  <attr name="port" type="u16" val="0"/>
+</obj>
+
+<obj class="Service" id="rccontroller_control_root">
+ <attr name="protocol" type="string" val="grpc"/>
+ <attr name="port" type="u16" val="30006"/>
 </obj>
 
 <obj class="Variable" id="ehn1-env-connectivity-port">
@@ -240,6 +245,11 @@
  <attr name="value" type="string" val="erstrace,throttle,lstdout"/>
 </obj>
 
+<obj class="Variable" id="local-env-connectivity-port">
+ <attr name="name" type="string" val="CONNECTION_PORT"/>
+ <attr name="value" type="string" val="30005"/>
+</obj>
+
 <obj class="VariableSet" id="ehn1-variables">
  <rel name="contains">
   <ref class="Variable" id="ehn1-env-ers-error"/>
@@ -248,6 +258,8 @@
   <ref class="Variable" id="ehn1-env-ers-stream-libs"/>
   <ref class="Variable" id="ehn1-env-ers-verb"/>
   <ref class="Variable" id="ehn1-env-ers-warning"/>
+  <ref class="Variable" id="ehn1-env-connectivity-port"/>
+  <ref class="Variable" id="ehn1-env-connectivity-server"/>
  </rel>
 </obj>
 
@@ -259,6 +271,7 @@
   <ref class="Variable" id="local-env-ers-verb"/>
   <ref class="Variable" id="local-env-ers-warning"/>
   <ref class="Variable" id="local-env-ers-debug-level"/>
+  <ref class="Variable" id="local-env-connectivity-port"/>
  </rel>
 </obj>
 

--- a/config/daqsystemtest/example-configs.data.xml
+++ b/config/daqsystemtest/example-configs.data.xml
@@ -63,7 +63,7 @@
 
 <oks-data>
 
-<info name="" type="" num-of-items="10" oks-format="data" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20231207T105549" last-modified-by="biery" last-modified-on="daq.fnal.gov" last-modification-time="20250903T173857"/>
+<info name="" type="" num-of-items="10" oks-format="data" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20231207T105549" last-modified-by="mrigan" last-modified-on="np04-srv-016.cern.ch" last-modification-time="20251003T122227"/>
 
 <include>
  <file path="schema/confmodel/dunedaq.schema.xml"/>
@@ -87,6 +87,7 @@
  <comment creation-time="20250522T092014" created-by="mrigan" created-on="np04-srv-016.cern.ch" author="mrigan" text="udpate replay"/>
  <comment creation-time="20250526T125621" created-by="dergonul" created-on="np04-srv-031.cern.ch" author="dergonul" text="Added new session for CRTBernFrame and CRTGrenobleFrame"/>
  <comment creation-time="20250805T092423" created-by="dergonul" created-on="np04-srv-028.cern.ch" author="dergonul" text="Emu CRT configs"/>
+ <comment creation-time="20251003T122227" created-by="mrigan" created-on="np04-srv-016.cern.ch" author="mrigan" text="actually using local vars variableset"/>
 </comments>
 
 
@@ -183,12 +184,7 @@
  </rel>
  <rel name="connectivity_service" class="ConnectivityService" id="local-connectivity-service-config"/>
  <rel name="environment">
-  <ref class="Variable" id="local-env-ers-verb"/>
-  <ref class="Variable" id="local-env-ers-info"/>
-  <ref class="Variable" id="local-env-ers-warning"/>
-  <ref class="Variable" id="local-env-ers-error"/>
-  <ref class="Variable" id="local-env-ers-fatal"/>
-  <ref class="Variable" id="local-env-ers-debug-level"/>
+  <ref class="VariableSet" id="local-variables"/>
  </rel>
  <rel name="segment" class="Segment" id="root-segment"/>
  <rel name="infrastructure_applications">
@@ -204,11 +200,7 @@
  <attr name="controller_log_level" type="enum" val="INFO"/>
  <rel name="connectivity_service" class="ConnectivityService" id="local-connectivity-service-config"/>
  <rel name="environment">
-  <ref class="Variable" id="local-env-ers-verb"/>
-  <ref class="Variable" id="local-env-ers-info"/>
-  <ref class="Variable" id="local-env-ers-warning"/>
-  <ref class="Variable" id="local-env-ers-error"/>
-  <ref class="Variable" id="local-env-ers-fatal"/>
+  <ref class="VariableSet" id="local-variables"/>
  </rel>
  <rel name="segment" class="Segment" id="root-segment"/>
  <rel name="infrastructure_applications">
@@ -230,12 +222,7 @@
  </rel>
  <rel name="connectivity_service" class="ConnectivityService" id="local-connectivity-service-config"/>
  <rel name="environment">
-  <ref class="Variable" id="local-env-ers-verb"/>
-  <ref class="Variable" id="local-env-ers-info"/>
-  <ref class="Variable" id="local-env-ers-warning"/>
-  <ref class="Variable" id="local-env-ers-error"/>
-  <ref class="Variable" id="local-env-ers-fatal"/>
-  <ref class="Variable" id="local-env-ers-debug-level"/>
+  <ref class="VariableSet" id="local-variables"/>
  </rel>
  <rel name="segment" class="Segment" id="socket-root-segment"/>
  <rel name="infrastructure_applications">
@@ -256,12 +243,7 @@
  </rel>
  <rel name="connectivity_service" class="ConnectivityService" id="local-connectivity-service-config"/>
  <rel name="environment">
-  <ref class="Variable" id="local-env-ers-verb"/>
-  <ref class="Variable" id="local-env-ers-info"/>
-  <ref class="Variable" id="local-env-ers-warning"/>
-  <ref class="Variable" id="local-env-ers-error"/>
-  <ref class="Variable" id="local-env-ers-fatal"/>
-  <ref class="Variable" id="local-env-ers-debug-level"/>
+  <ref class="VariableSet" id="local-variables"/>
  </rel>
  <rel name="segment" class="Segment" id="tpreplay-root-segment"/>
  <rel name="infrastructure_applications">

--- a/integtest/example_system_test.py
+++ b/integtest/example_system_test.py
@@ -88,14 +88,15 @@ onebyone_local_conf.session = "local-1x1-config"
 twobythree_local_conf = copy.deepcopy(common_config_obj)
 twobythree_local_conf.session = "local-2x3-config"
 
+username=os.environ.get("USER")
 onebyone_ehn1_conf = copy.deepcopy(common_config_obj)
 onebyone_ehn1_conf.session = "ehn1-local-1x1-config"
-onebyone_ehn1_conf.session_name = f"ehn1-local-1x1-config-{''.join(random.choices(string.ascii_letters, k=8))}"
+onebyone_ehn1_conf.session_name = f"ehn1-local-1x1-config-{username}-{''.join(random.choices(string.ascii_letters, k=4))}"
 onebyone_ehn1_conf.connsvc_port = None
 
 twobythree_ehn1_conf = copy.deepcopy(common_config_obj)
 twobythree_ehn1_conf.session = "ehn1-local-2x3-config"
-twobythree_ehn1_conf.session_name = f"ehn1-local-2x3-config-{''.join(random.choices(string.ascii_letters, k=8))}"
+twobythree_ehn1_conf.session_name = f"ehn1-local-2x3-config-{username}-{''.join(random.choices(string.ascii_letters, k=4))}"
 twobythree_ehn1_conf.connsvc_port = None
 
 


### PR DESCRIPTION
# Description

Recently, someone (Alessandro?) requested that we add the name of the user to the `drunc` session name for the EHN1 parts of the `example_system_test`.  With this, people looking at the Grafana displays at EHN1 can know which sessions are being run by which user.

This change does that.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [x] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

To test this, run the modified `example_system_test` at EHN1 and look at the available DAQ sessions on the Grafana OnMon display.

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.

