### PR TITLE
Disabled the merging of overlapping TCs in the example_system_test to…

### DIFF
--- a/integtest/example_system_test.py
+++ b/integtest/example_system_test.py
@@ -84,21 +84,52 @@ common_config_obj.config_db = (
 
 onebyone_local_conf = copy.deepcopy(common_config_obj)
 onebyone_local_conf.session = "local-1x1-config"
+onebyone_local_conf.config_substitutions.append(
+    data_classes.attribute_substitution(
+        obj_class="TCDataProcessor",
+        obj_id="def-tc-processor",
+        updates={
+            "merge_overlapping_tcs": False
+        },)
+)
 
 twobythree_local_conf = copy.deepcopy(common_config_obj)
 twobythree_local_conf.session = "local-2x3-config"
+twobythree_local_conf.config_substitutions.append(
+    data_classes.attribute_substitution(
+        obj_class="TCDataProcessor",
+        obj_id="def-tc-processor",
+        updates={
+            "merge_overlapping_tcs": False
+        },)
+)
 
 username=os.environ.get("USER")
 onebyone_ehn1_conf = copy.deepcopy(common_config_obj)
 onebyone_ehn1_conf.session = "ehn1-local-1x1-config"
 onebyone_ehn1_conf.session_name = f"ehn1-local-1x1-config-{username}-{''.join(random.choices(string.ascii_letters, k=4))}"
 onebyone_ehn1_conf.connsvc_port = None
+onebyone_ehn1_conf.config_substitutions.append(
+    data_classes.attribute_substitution(
+        obj_class="TCDataProcessor",
+        obj_id="def-tc-processor",
+        updates={
+            "merge_overlapping_tcs": False
+        },)
+)
 
 twobythree_ehn1_conf = copy.deepcopy(common_config_obj)
 twobythree_ehn1_conf.session = "ehn1-local-2x3-config"
 twobythree_ehn1_conf.session_name = f"ehn1-local-2x3-config-{username}-{''.join(random.choices(string.ascii_letters, k=4))}"
 twobythree_ehn1_conf.connsvc_port = None
-
+twobythree_ehn1_conf.config_substitutions.append(
+    data_classes.attribute_substitution(
+        obj_class="TCDataProcessor",
+        obj_id="def-tc-processor",
+        updates={
+            "merge_overlapping_tcs": False
+        },)
+)
 
 def host_is_at_ehn1(hostname):
     return re.match(r"^(np02|np04)-srv-\d{3}$", hostname) or re.match(r"^(np02|np04)-srv-\d{3}.cern.ch$", hostname)
@@ -120,7 +151,7 @@ else:
 
 # The commands to run in nanorc, as a list
 nanorc_command_list = (
-    "boot wait 5 conf start --run-number 101 wait 1 enable-triggers wait ".split()
+    "boot wait 2 conf start --run-number 101 wait 1 enable-triggers wait ".split()
     + [str(run_duration)]
     + "disable-triggers wait 2 drain-dataflow wait 2 stop-trigger-sources stop scrap terminate".split()
 )

--- a/integtest/example_system_test.py
+++ b/integtest/example_system_test.py
@@ -86,9 +86,9 @@ onebyone_local_conf = copy.deepcopy(common_config_obj)
 onebyone_local_conf.session = "local-1x1-config"
 onebyone_local_conf.config_substitutions.append(
     data_classes.attribute_substitution(
-        obj_class="TCDataProcessor",
-        obj_id="def-tc-processor",
-        updates={
+        obj_class="TCDataProcessor",     # 12-Nov-2025, KAB: turned off the merging of
+        obj_id="def-tc-processor",       # overlapping TCs so that we get more consistent
+        updates={                        # numbers of TriggerRecords in the output files.
             "merge_overlapping_tcs": False
         },)
 )
@@ -97,9 +97,9 @@ twobythree_local_conf = copy.deepcopy(common_config_obj)
 twobythree_local_conf.session = "local-2x3-config"
 twobythree_local_conf.config_substitutions.append(
     data_classes.attribute_substitution(
-        obj_class="TCDataProcessor",
-        obj_id="def-tc-processor",
-        updates={
+        obj_class="TCDataProcessor",     # 12-Nov-2025, KAB: turned off the merging of
+        obj_id="def-tc-processor",       # overlapping TCs so that we get more consistent
+        updates={                        # numbers of TriggerRecords in the output files.
             "merge_overlapping_tcs": False
         },)
 )
@@ -111,9 +111,9 @@ onebyone_ehn1_conf.session_name = f"ehn1-local-1x1-config-{username}-{''.join(ra
 onebyone_ehn1_conf.connsvc_port = None
 onebyone_ehn1_conf.config_substitutions.append(
     data_classes.attribute_substitution(
-        obj_class="TCDataProcessor",
-        obj_id="def-tc-processor",
-        updates={
+        obj_class="TCDataProcessor",     # 12-Nov-2025, KAB: turned off the merging of
+        obj_id="def-tc-processor",       # overlapping TCs so that we get more consistent
+        updates={                        # numbers of TriggerRecords in the output files.
             "merge_overlapping_tcs": False
         },)
 )
@@ -124,9 +124,9 @@ twobythree_ehn1_conf.session_name = f"ehn1-local-2x3-config-{username}-{''.join(
 twobythree_ehn1_conf.connsvc_port = None
 twobythree_ehn1_conf.config_substitutions.append(
     data_classes.attribute_substitution(
-        obj_class="TCDataProcessor",
-        obj_id="def-tc-processor",
-        updates={
+        obj_class="TCDataProcessor",     # 12-Nov-2025, KAB: turned off the merging of
+        obj_id="def-tc-processor",       # overlapping TCs so that we get more consistent
+        updates={                        # numbers of TriggerRecords in the output files.
             "merge_overlapping_tcs": False
         },)
 )


### PR DESCRIPTION
… help avoid fluctuations in the number of TriggerRecords.

This change is targeted to `fddaq-v5.6.0`...

# Description

We occasionally notice the number of TriggerRecords produced by one of the runs in the `example_system_test` fluctuate too low, and that causes the `data_file_checks` that are part of the test to complain.

I recently saw this several times when running this test at EHN1, where a couple more configurations (sub-tests) are run (to test monitoring infrastructure) compared to tests on computers outside of EHN1.

Recall that the system configurations that are used in the `example_system_test` include three types of triggers: kTiming, kRandom, and kPrescale (derived from TPs).  

I believe that what happens when the number of TRs fluctuates low is that there are overlapping triggers (actually TriggerCandidates) that get merged together, and this reduces the overall number of TriggerRecords in the HDF5 files.

To change this behavior, I have added configuration over-rides to turn off the merging of overlapping TCs.  This is already done in other regression tests to help achieve more consistent behavior, but this has not been done in `example_system_test` until now.

When I have run many instances of the `example_system_test` with these changes, I have not seen the number of TRs fluctuate too low, so my sense is that these changes are helping.

However, I *have* seen instances in which the size of HSI fragments is too low.  That is a related problem, and it will be the subject of a separate PR in the `integrationtest` repo (not tied to this PR).

To test these changes, we should run the `example_system_test` many times and verify that we don't see instances of the number of TRs fluctuating low.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [x] Optimization (non-breaking change that improves code/performance)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.

