### PR TITLE
Add script which runs generate_modules_test on all Applications in the daqsystemtest example configs

### DIFF
--- a/scripts/check_daqsystemtest_applications.sh
+++ b/scripts/check_daqsystemtest_applications.sh
@@ -38,6 +38,12 @@ function echo_failure() {
 
 function check_config() {
     config_file=$1
+
+    get_apps "$config_file"  &>/dev/null || oks_dump -f "$config_file" | grep -vE '^\s*'
+    if [ $? -ne 0 ];then
+        echo "         Failed to parse config file '$config_file'"
+        return 1
+    fi
     
     get_apps "$config_file" | while IFS= read -r LINE; do
 

--- a/scripts/check_daqsystemtest_applications.sh
+++ b/scripts/check_daqsystemtest_applications.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+BOOTUP=color
+RES_COL=0
+MOVE_TO_COL="echo -en \\033[${RES_COL}G"
+SETCOLOR_SUCCESS="echo -en \\033[1;32m"
+SETCOLOR_FAILURE="echo -en \\033[1;31m"
+SETCOLOR_NORMAL="echo -en \\033[0;39m"
+if [ "$CONSOLETYPE" = "serial" ]; then
+    BOOTUP=serial
+    MOVE_TO_COL=
+    SETCOLOR_SUCCESS=
+    SETCOLOR_FAILURE=
+    SETCOLOR_NORMAL=
+fi
+
+function echo_success() {
+    [ "$BOOTUP" = "color" ] && $MOVE_TO_COL
+    echo -n "["
+    [ "$BOOTUP" = "color" ] && $SETCOLOR_SUCCESS
+    echo -n $"  OK  "
+    [ "$BOOTUP" = "color" ] && $SETCOLOR_NORMAL
+    echo -n "]"
+    echo -ne "\r"
+    return 0
+}
+
+function echo_failure() {
+  [ "$BOOTUP" = "color" ] && $MOVE_TO_COL
+  echo -n "["
+  [ "$BOOTUP" = "color" ] && $SETCOLOR_FAILURE
+  echo -n $"FAILED"
+  [ "$BOOTUP" = "color" ] && $SETCOLOR_NORMAL
+  echo -n "]"
+  echo -ne "\r"
+  return 1
+}
+
+function check_config() {
+    config_file=$1
+    
+    get_apps "$config_file" | while IFS= read -r LINE; do
+
+        session_name=$(echo "$LINE" | grep -oE 'in session [^:]*:' | awk '{print $3}' | tr -d ':')
+        app_list_string=$(echo "$LINE" | awk -F "[" '{print $2}' | sed "s/'//g; s/ //g; s/\]//g")
+
+        IFS=',' read -ra app_list <<< "$app_list_string"
+
+        # Print header for the current session
+        echo -e "\n--- Processing SESSION: $session_name (${#app_list[@]} apps) ---"
+
+        for app in "${app_list[@]}"; do
+            echo -n "         Running generate_modules_test for app '$app' in session '$session_name'"
+            if generate_modules_test "$session_name" "$app" "$config_file" &>/dev/null; then
+                echo_success
+            else
+                echo_failure
+            fi
+            echo
+        done
+    done
+}
+
+echo "Checking config/daqsystemtest/example-configs.data.xml Sessions and Applications"
+check_config "config/daqsystemtest/example-configs.data.xml"
+echo 
+
+echo "Checking config/daqsystemtest/example-hsi-configs.data.xml Sessions and Applications"
+check_config "config/daqsystemtest/example-hsi-configs.data.xml"
+echo

--- a/scripts/check_daqsystemtest_applications.sh
+++ b/scripts/check_daqsystemtest_applications.sh
@@ -41,7 +41,9 @@ function check_config() {
 
     get_apps "$config_file"  &>/dev/null || oks_dump -f "$config_file" | grep -vE '^\s*'
     if [ $? -ne 0 ];then
-        echo "         Failed to parse config file '$config_file'"
+        echo -n "         Failed to parse config file '$config_file'"
+        echo_failure
+        echo
         return 1
     fi
     


### PR DESCRIPTION
# Description

This PR adds a script which runs the `generate_modules_test` executable on each application within each Session defined in example-configs.data.xml and example-hsi-configs.data.xml. This can be used as an early-warning test to detect issues with SmartDaqApplication module generation during development.


## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

N/A

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

