### PR TITLE
Revert "RandomTCMaker conf updated"

### DIFF
--- a/config/daqsystemtest/moduleconfs.data.xml
+++ b/config/daqsystemtest/moduleconfs.data.xml
@@ -693,10 +693,7 @@
  <attr name="template_for" type="class" val="RandomTCMakerModule"/>
  <attr name="trigger_rate_hz" type="float" val="1"/>
  <attr name="time_distribution" type="enum" val="kUniform"/>
- <attr name="candidate_type_name" type="string" val="kRandom"/>
- <attr name="candidate_backshift_ts" type="s64" val="1000"/>
- <attr name="candidate_window_before_ts" type="u32" val="1000"/>
- <attr name="candidate_window_after_ts" type="u32" val="1001"/>
+ <rel name="tc_readout" class="TCReadoutMap" id="def-random-readout"/>
 </obj>
 
 <obj class="RequestHandler" id="def-data-request-handler">


### PR DESCRIPTION
Reverts DUNE-DAQ/daqsystemtest#265

Reverting due to issues on the configurations for integration tests and other places where configuration pieces may need updating. 