### PR TITLE
Added opmon metric checking in tpg_state_collection_test.py and minimal_system_quick_test.py

### DIFF
--- a/integtest/minimal_system_quick_test.py
+++ b/integtest/minimal_system_quick_test.py
@@ -4,6 +4,7 @@ import urllib.request
 import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
 import integrationtest.data_classes as data_classes
+import integrationtest.opmon_metric_checks as opmon_metric_checks
 
 pytest_plugins = "integrationtest.integrationtest_drunc"
 
@@ -149,4 +150,17 @@ def test_data_files(run_nanorc):
         for kdx in range(len(nontrig_fragment_check_list)):
             all_ok &= data_file_checks.check_fragment_error_flags( data_file, nontrig_fragment_check_list[kdx])
 
+    assert all_ok
+
+
+def test_metric_files(run_nanorc):
+    print("") # Clear potential dot from pytest
+
+    session_name = run_nanorc.session_name if run_nanorc.session_name else run_nanorc.session
+    metric_data = opmon_metric_checks.collate_opmon_data_from_files(run_nanorc.opmon_files)
+
+    metric_key_list = [session_name, "df-01", "df-01-trb", "dfmodules.TRBInfo", "generated_trigger_records"]
+    all_ok = True
+    all_ok &= opmon_metric_checks.check_metric_sample_count(metric_data, metric_key_list, 1, 5)
+    all_ok &= opmon_metric_checks.check_metric_value_sum(metric_data, metric_key_list, 17, 23)
     assert all_ok

--- a/integtest/minimal_system_quick_test.py
+++ b/integtest/minimal_system_quick_test.py
@@ -164,8 +164,8 @@ def test_metric_files(run_nanorc):
     all_ok = True
     # a 20-second run will likely result in 3 metric samples (at 10-second intervals), so a range
     # of 1..5 should always succeed
-    all_ok &= opmon_metric_checks.check_metric_sample_count(metric_data, metric_key_list, 1, 5)
+    all_ok &= opmon_metric_checks.check_metric_sample_count(metric_data, metric_key_list, min_count=1, max_count=5)
     # the number of triggers expected in this test is ~20, so a test that checks for the reported
     # number of generated trigger records between 17 and 23 shoudl always succeed
-    all_ok &= opmon_metric_checks.check_metric_value_sum(metric_data, metric_key_list, 17, 23)
+    all_ok &= opmon_metric_checks.check_metric_value_sum(metric_data, metric_key_list, min_value_sum=17, max_value_sum=23)
     assert all_ok

--- a/integtest/minimal_system_quick_test.py
+++ b/integtest/minimal_system_quick_test.py
@@ -153,6 +153,7 @@ def test_data_files(run_nanorc):
     assert all_ok
 
 
+# 26-Nov-2025, KAB: added some sample opmon metric checks, for demonstration purposes
 def test_metric_files(run_nanorc):
     print("") # Clear potential dot from pytest
 
@@ -161,6 +162,10 @@ def test_metric_files(run_nanorc):
 
     metric_key_list = [session_name, "df-01", "df-01-trb", "dfmodules.TRBInfo", "generated_trigger_records"]
     all_ok = True
+    # a 20-second run will likely result in 3 metric samples (at 10-second intervals), so a range
+    # of 1..5 should always succeed
     all_ok &= opmon_metric_checks.check_metric_sample_count(metric_data, metric_key_list, 1, 5)
+    # the number of triggers expected in this test is ~20, so a test that checks for the reported
+    # number of generated trigger records between 17 and 23 shoudl always succeed
     all_ok &= opmon_metric_checks.check_metric_value_sum(metric_data, metric_key_list, 17, 23)
     assert all_ok

--- a/integtest/tpg_state_collection_test.py
+++ b/integtest/tpg_state_collection_test.py
@@ -314,6 +314,15 @@ def test_metric_files(run_nanorc):
     all_ok &= opmon_metric_checks.check_metric_value_sum(metric_data, metric_key_list, min_value_sum=1)
 
     # DLH-0, 'pedestal' metrics
+    # (In this test, the calculation of the pedestal for each WIB channel [used in TP
+    # generation] starts with a non-zero initial value, but the calculated value
+    # quickly becomes zero because this test uses the WIBEth All Zeroes binary file from the
+    # asset system.  As the name implies, the ADC values for the WIBs in that file are all zero.
+    # The fake-data-replay code randomly modifies a small fraction of the ADC values to be non-zero
+    # to provide fake "signals" that the trigger-primitive-generation code sees, but in this test,
+    # the rate of such fake non-zero signals is not large enough to affect the calculated pedestal.
+    # Because of all of that, the pedestal value check in this section can verify that the metric
+    # reporting system sees a pedestal value of zero.)
     metric_key_list = [session_name, "ru-det-conn-0", "DLH-0", "WIBEthFrameProcessor", "def-wib-processor", "datahandlinglibs.TPGProcessorInfo", "*", "pedestal"]
     all_ok &= opmon_metric_checks.check_metric_sample_count(metric_data, metric_key_list, min_count=1)
     all_ok &= opmon_metric_checks.check_metric_value_sum(metric_data, metric_key_list, min_value_sum=0, max_value_sum=0)
@@ -324,6 +333,15 @@ def test_metric_files(run_nanorc):
     all_ok &= opmon_metric_checks.check_metric_value_sum(metric_data, metric_key_list, min_value_sum=1)
 
     # DLH-1, 'pedestal' metrics
+    # (In this test, the calculation of the pedestal for each WIB channel [used in TP
+    # generation] starts with a non-zero initial value, but the calculated value
+    # quickly becomes zero because this test uses the WIBEth All Zeroes binary file from the
+    # asset system.  As the name implies, the ADC values for the WIBs in that file are all zero.
+    # The fake-data-replay code randomly modifies a small fraction of the ADC values to be non-zero
+    # to provide fake "signals" that the trigger-primitive-generation code sees, but in this test,
+    # the rate of such fake non-zero signals is not large enough to affect the calculated pedestal.
+    # Because of all of that, the pedestal value check in this section can verify that the metric
+    # reporting system sees a pedestal value of zero.)
     metric_key_list = [session_name, "ru-det-conn-0", "DLH-1", "WIBEthFrameProcessor", "def-wib-processor", "datahandlinglibs.TPGProcessorInfo", "*", "pedestal"]
     all_ok &= opmon_metric_checks.check_metric_sample_count(metric_data, metric_key_list, min_count=1)
     all_ok &= opmon_metric_checks.check_metric_value_sum(metric_data, metric_key_list, min_value_sum=0, max_value_sum=0)

--- a/integtest/tpg_state_collection_test.py
+++ b/integtest/tpg_state_collection_test.py
@@ -310,22 +310,22 @@ def test_metric_files(run_nanorc):
     # *** Check that the pedestal subtraction processor metrics are being produced as expected.
     # DLH-0, 'accum' metrics
     metric_key_list = [session_name, "ru-det-conn-0", "DLH-0", "WIBEthFrameProcessor", "def-wib-processor", "datahandlinglibs.TPGProcessorInfo", "*", "accum"]
-    all_ok &= opmon_metric_checks.check_metric_sample_count(metric_data, metric_key_list, 1)
-    all_ok &= opmon_metric_checks.check_metric_value_sum(metric_data, metric_key_list, 1)
+    all_ok &= opmon_metric_checks.check_metric_sample_count(metric_data, metric_key_list, min_count=1)
+    all_ok &= opmon_metric_checks.check_metric_value_sum(metric_data, metric_key_list, min_value_sum=1)
 
     # DLH-0, 'pedestal' metrics
     metric_key_list = [session_name, "ru-det-conn-0", "DLH-0", "WIBEthFrameProcessor", "def-wib-processor", "datahandlinglibs.TPGProcessorInfo", "*", "pedestal"]
-    all_ok &= opmon_metric_checks.check_metric_sample_count(metric_data, metric_key_list, 1)
-    all_ok &= opmon_metric_checks.check_metric_value_sum(metric_data, metric_key_list, 0, 0)
+    all_ok &= opmon_metric_checks.check_metric_sample_count(metric_data, metric_key_list, min_count=1)
+    all_ok &= opmon_metric_checks.check_metric_value_sum(metric_data, metric_key_list, min_value_sum=0, max_value_sum=0)
 
     # DLH-1, 'accum' metrics
     metric_key_list = [session_name, "ru-det-conn-0", "DLH-1", "WIBEthFrameProcessor", "def-wib-processor", "datahandlinglibs.TPGProcessorInfo", "*", "accum"]
-    all_ok &= opmon_metric_checks.check_metric_sample_count(metric_data, metric_key_list, 1)
-    all_ok &= opmon_metric_checks.check_metric_value_sum(metric_data, metric_key_list, 1)
+    all_ok &= opmon_metric_checks.check_metric_sample_count(metric_data, metric_key_list, min_count=1)
+    all_ok &= opmon_metric_checks.check_metric_value_sum(metric_data, metric_key_list, min_value_sum=1)
 
     # DLH-1, 'pedestal' metrics
     metric_key_list = [session_name, "ru-det-conn-0", "DLH-1", "WIBEthFrameProcessor", "def-wib-processor", "datahandlinglibs.TPGProcessorInfo", "*", "pedestal"]
-    all_ok &= opmon_metric_checks.check_metric_sample_count(metric_data, metric_key_list, 1)
-    all_ok &= opmon_metric_checks.check_metric_value_sum(metric_data, metric_key_list, 0, 0)
+    all_ok &= opmon_metric_checks.check_metric_sample_count(metric_data, metric_key_list, min_count=1)
+    all_ok &= opmon_metric_checks.check_metric_value_sum(metric_data, metric_key_list, min_value_sum=0, max_value_sum=0)
 
     assert all_ok

--- a/integtest/tpg_state_collection_test.py
+++ b/integtest/tpg_state_collection_test.py
@@ -297,6 +297,8 @@ def test_tpstream_files(run_nanorc):
     assert all_ok
 
 
+# 26-Nov-2025, KAB: added checking of opmon metrics to verify that the ones that are
+# specifically enabled in this test work as expected.
 def test_metric_files(run_nanorc):
     print("") # Clear potential dot from pytest
 

--- a/integtest/tpg_state_collection_test.py
+++ b/integtest/tpg_state_collection_test.py
@@ -7,6 +7,7 @@ import urllib.request
 import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
 import integrationtest.data_classes as data_classes
+import integrationtest.opmon_metric_checks as opmon_metric_checks
 
 pytest_plugins = "integrationtest.integrationtest_drunc"
 
@@ -293,4 +294,36 @@ def test_tpstream_files(run_nanorc):
             all_ok &= data_file_checks.check_fragment_sizes(
                 data_file, fragment_check_list[jdx]
             )
+    assert all_ok
+
+
+def test_metric_files(run_nanorc):
+    print("") # Clear potential dot from pytest
+
+    session_name = run_nanorc.session_name if run_nanorc.session_name else run_nanorc.session
+    metric_data = opmon_metric_checks.collate_opmon_data_from_files(run_nanorc.opmon_files)
+
+    all_ok = True
+
+    # *** Check that the pedestal subtraction processor metrics are being produced as expected.
+    # DLH-0, 'accum' metrics
+    metric_key_list = [session_name, "ru-det-conn-0", "DLH-0", "WIBEthFrameProcessor", "def-wib-processor", "datahandlinglibs.TPGProcessorInfo", "*", "accum"]
+    all_ok &= opmon_metric_checks.check_metric_sample_count(metric_data, metric_key_list, 1)
+    all_ok &= opmon_metric_checks.check_metric_value_sum(metric_data, metric_key_list, 1)
+
+    # DLH-0, 'pedestal' metrics
+    metric_key_list = [session_name, "ru-det-conn-0", "DLH-0", "WIBEthFrameProcessor", "def-wib-processor", "datahandlinglibs.TPGProcessorInfo", "*", "pedestal"]
+    all_ok &= opmon_metric_checks.check_metric_sample_count(metric_data, metric_key_list, 1)
+    all_ok &= opmon_metric_checks.check_metric_value_sum(metric_data, metric_key_list, 0, 0)
+
+    # DLH-1, 'accum' metrics
+    metric_key_list = [session_name, "ru-det-conn-0", "DLH-1", "WIBEthFrameProcessor", "def-wib-processor", "datahandlinglibs.TPGProcessorInfo", "*", "accum"]
+    all_ok &= opmon_metric_checks.check_metric_sample_count(metric_data, metric_key_list, 1)
+    all_ok &= opmon_metric_checks.check_metric_value_sum(metric_data, metric_key_list, 1)
+
+    # DLH-1, 'pedestal' metrics
+    metric_key_list = [session_name, "ru-det-conn-0", "DLH-1", "WIBEthFrameProcessor", "def-wib-processor", "datahandlinglibs.TPGProcessorInfo", "*", "pedestal"]
+    all_ok &= opmon_metric_checks.check_metric_sample_count(metric_data, metric_key_list, 1)
+    all_ok &= opmon_metric_checks.check_metric_value_sum(metric_data, metric_key_list, 0, 0)
+
     assert all_ok


### PR DESCRIPTION
# Description

These changes are for `fddaq-v5.6.0`... 

This PR is part of DUNE-DAQ/daq-deliverables#202 which describes the addition of opmon metric checking to integration tests.  The tests that were modified were `tpg_state_collection_test.py` and `minimal_system_quick_test.py`.

These changes build on ones in the `opmonlib` and `integrationtest` repos.

To test these changes one would include the modified repositories in a local software area and run the modified tests.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.

