### PR TITLE
Modified the daqsystemtest_integtest_bundle.sh script to stop more quickly when a failure happens

### DIFF
--- a/scripts/daqsystemtest_integtest_bundle.sh
+++ b/scripts/daqsystemtest_integtest_bundle.sh
@@ -36,6 +36,7 @@ let individual_test_requested_iterations=1
 let full_set_requested_interations=1
 let stop_on_failure=0
 requested_test_names=
+PYTEST_COMMAND="pytest -s"  # our core pytest command, with print statements being displayed on the console
 
 while true; do
     case "$1" in
@@ -65,6 +66,7 @@ while true; do
             ;;
         --stop-on-failure)
             let stop_on_failure=1
+            PYTEST_COMMAND="${PYTEST_COMMAND} -x"  # add the -x option to our pytest command to have it exit on first error
             shift
             ;;
         --)
@@ -120,15 +122,15 @@ while [[ ${full_set_loop_count} -lt ${full_set_requested_interations} ]]; do
 
                     echo -e "\u2B95 \033[0;1mRunning ${TEST_NAME}\033[0m \u2B05" | tee -a ${ITGRUNNER_LOG_FILE}
                     if [[ -e "./${TEST_NAME}" ]]; then
-                        pytest -s ./${TEST_NAME} | tee -a ${ITGRUNNER_LOG_FILE}
+                        ${PYTEST_COMMAND} ./${TEST_NAME} | tee -a ${ITGRUNNER_LOG_FILE}
                     elif [[ -e "${DBT_AREA_ROOT}/sourcecode/daqsystemtest/integtest/${TEST_NAME}" ]]; then
                         if [[ -w "${DBT_AREA_ROOT}" ]]; then
-                            pytest -s ${DBT_AREA_ROOT}/sourcecode/daqsystemtest/integtest/${TEST_NAME} | tee -a ${ITGRUNNER_LOG_FILE}
+                            ${PYTEST_COMMAND} ${DBT_AREA_ROOT}/sourcecode/daqsystemtest/integtest/${TEST_NAME} | tee -a ${ITGRUNNER_LOG_FILE}
                         else
-                            pytest -s -p no:cacheprovider ${DBT_AREA_ROOT}/sourcecode/daqsystemtest/integtest/${TEST_NAME} | tee -a ${ITGRUNNER_LOG_FILE}
+                            ${PYTEST_COMMAND} -p no:cacheprovider ${DBT_AREA_ROOT}/sourcecode/daqsystemtest/integtest/${TEST_NAME} | tee -a ${ITGRUNNER_LOG_FILE}
                         fi
                     else
-                        pytest -s -p no:cacheprovider ${DAQSYSTEMTEST_SHARE}/integtest/${TEST_NAME} | tee -a ${ITGRUNNER_LOG_FILE}
+                        ${PYTEST_COMMAND} -p no:cacheprovider ${DAQSYSTEMTEST_SHARE}/integtest/${TEST_NAME} | tee -a ${ITGRUNNER_LOG_FILE}
                     fi
                     let pytest_return_code=${PIPESTATUS[0]}
 


### PR DESCRIPTION
# Description

I have modified the `daqsystemtest_integtest_bundle.sh` script so that testing will stop earlier when there is a failure and the user has specified `--stop-on-failure`. This functionality uses the `-x` option to the `pytest` command to get it to exit on the first error inside an individual test.

To test this change, we can run the modified bundle script and verify that existing tests continue to work as before.  We can also locally modify one of the existing regression tests (e.g. `readout_type_scan_test`) to generate an error (e.g. change the lower bound of the expected WIB fragment size to a larger value [here](https://github.com/DUNE-DAQ/daqsystemtest/blob/38b00c51a99ec6bc48241981e3ccafae4f69b288/integtest/readout_type_scan_test.py#L31)), run the bundle script with `--stop-on-fail` specified (e.g. `daqsystemtest_integtest_bundle.sh -k scan --stop-on-fail`), and see that testing stops sooner than before.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [x] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.

