### PR TITLE
Added a --concise-output option to the daqsystemtest_integtest_bundle script...

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -10,4 +10,4 @@ tmp_path_retention_count = 10
 # --tb=short        Just shows vanilla traceback: very useful, but file names are incomplete and relative
 # --tb=native       Slightly more info than short: still works very well. The full paths may be useful for CI
 
-addopts = --tb=no
+addopts = --tb=short

--- a/scripts/daqsystemtest_integtest_bundle.sh
+++ b/scripts/daqsystemtest_integtest_bundle.sh
@@ -18,6 +18,7 @@ Options:
     -n <number of times to run each individual test, default=1>
     -N <number of times to run the full set of selected tests, default=1>
     --stop-on-failure : causes the script to stop when one of the integtests reports a failure
+    --concise-output : suppresses run control and DAQApp messages in order to focus on test results
 """
     let counter=0
     echo "List of available tests:"
@@ -28,7 +29,7 @@ Options:
     echo ""
 }
 
-TEMP=`getopt -o hs:f:l:k:n:N: --long help,stop-on-failure -- "$@"`
+TEMP=`getopt -o hs:f:l:k:n:N: --long help,stop-on-failure,concise-output -- "$@"`
 eval set -- "$TEMP"
 
 let first_test_index=0
@@ -36,7 +37,7 @@ let individual_test_requested_iterations=1
 let full_set_requested_interations=1
 let stop_on_failure=0
 requested_test_names=
-PYTEST_COMMAND="pytest -s"  # our core pytest command, with print statements being displayed on the console
+PYTEST_COMMAND="pytest -s --tb=short"  # our core pytest command, with DAQ printout included and short pytest traceback
 
 while true; do
     case "$1" in
@@ -67,6 +68,10 @@ while true; do
         --stop-on-failure)
             let stop_on_failure=1
             PYTEST_COMMAND="${PYTEST_COMMAND} -x"  # add the -x option to our pytest command to have it exit on first error
+            shift
+            ;;
+        --concise-output)
+            PYTEST_COMMAND="`echo ${PYTEST_COMMAND} | sed 's/ -s//'`"  # remove the -s option to turn off messages from DAQ processes
             shift
             ;;
         --)


### PR DESCRIPTION
….to help make it easier to notice problems.

# Description

In a recent meeting, Pawel mentioned that dropping the `-s` option from our `pytest` calls will suppress the print statements from our control and data-movement applications, and this can be useful in reducing the clutter in the console when we are running regression tests.

I used that information as part of adding a `--concise-output` flag to the `daqsystemtest_integtest_bundle.py` script.  When one uses that option, the console output is less cluttered.

While making this change, I noticed that our choice of using the `--tb=no` option for `pytest` was preventing useful information from being printed to the console.  In response to that, I made two changes:  I changed the default setting for `--tb` in the `pytest.ini` file in this repo to be "short", and I added `--tb=short` to the running of `pytest` in the bundle script.  With these changes, I believe that we get sufficient information about problems when they occur (including typos in our pytest driver files, aka integtests).  

To test these changes, I recommend starting with the 04-Dec nightly build, adding in this branch, rebuilding the software area, and then running `daqsystemtest_integtest_bundle.sh` script with the `--help` option and various combinations of the `--stop-on-failure` and `--concise-output` options.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
