### PR TITLE
In MSQT, increased the upper bound on the expected number of metric samples when the test runs long

### DIFF
--- a/integtest/minimal_system_quick_test.py
+++ b/integtest/minimal_system_quick_test.py
@@ -164,10 +164,23 @@ def test_metric_files(run_nanorc):
     # (metric samples are produced every 10 seconds, by default).
     # I've tried to make this code backward compatible by handling cases in which the
     # daq_session_overall_time is not available (e.g. the try/catch).
-    max_metric_sample_count = 5  # under normal conditions, the sample count is 3, so 5 allows for some variation
+    #
+    # The expected DAQ session time is the sum of the time spent in the "running" state
+    # (specified in the run control commands above [run_duration]) plus the "wait" times in
+    # the RC commands plus the time spent in RC transitions.  With a run duration of 20 sec,
+    # the session time has been measured to be ~40 seconds, so we take the extra 20 seconds
+    # into account.
+    expected_daq_session_time = run_duration + 20
+    #
+    # To calculate the expected number of metric samples, we subtract a small-ish amount of
+    # time that the DAQ session spends in state(s) that don't produce metrics (say 3 seconds)
+    # and divide by 10, where 10 seconds is the interval between each reporting of metrics.
+    expected_metric_sample_count = int((expected_daq_session_time - 3) / 10)
+    #
+    # We'll set the maximum allowed sample count slightly higher than the expected value.
+    max_metric_sample_count = expected_metric_sample_count + 2
     try:
-        #print(f"DAQ session overall time: {run_nanorc.daq_session_overall_time} seconds")
-        expected_daq_session_time = 40  # this was determined by looking at the overall time from a normal run
+        #print(f"\nDAQ session overall time: {run_nanorc.daq_session_overall_time} seconds")
         if run_nanorc.daq_session_overall_time is not None:
             extra_time_taken = run_nanorc.daq_session_overall_time - expected_daq_session_time
             if extra_time_taken > 10:
@@ -175,7 +188,6 @@ def test_metric_files(run_nanorc):
                 max_metric_sample_count += extra_sample_count_allowance
     except AttributeError:
         pass
-    #print(f"max_metric_sample_count: {max_metric_sample_count}")
 
     session_name = run_nanorc.session_name if run_nanorc.session_name else run_nanorc.session
     metric_data = opmon_metric_checks.collate_opmon_data_from_files(run_nanorc.opmon_files)
@@ -186,7 +198,9 @@ def test_metric_files(run_nanorc):
     # of 1..5 should always succeed
     all_ok &= opmon_metric_checks.check_metric_sample_count(metric_data, metric_key_list, min_count=1,
                                                             max_count=max_metric_sample_count)
-    # the number of triggers expected in this test is ~20, so a test that checks for the reported
-    # number of generated trigger records between 17 and 23 shoudl always succeed
-    all_ok &= opmon_metric_checks.check_metric_value_sum(metric_data, metric_key_list, min_value_sum=17, max_value_sum=23)
+    # the number of triggers expected in this test is based on the run duration, so we check for
+    # a reported number of generated trigger records between slightly above/below that
+    all_ok &= opmon_metric_checks.check_metric_value_sum(metric_data, metric_key_list,
+                                                         min_value_sum=run_duration-3,
+                                                         max_value_sum=run_duration+3)
     assert all_ok

--- a/integtest/minimal_system_quick_test.py
+++ b/integtest/minimal_system_quick_test.py
@@ -157,6 +157,26 @@ def test_data_files(run_nanorc):
 def test_metric_files(run_nanorc):
     print("") # Clear potential dot from pytest
 
+    # 10-Dec-2025, KAB: we have noticed that sometimes drunc transitions (or other parts of
+    # a run control session) take a little longer than expected.  This can cause extra metric
+    # samples to be created.  This section of code takes that into account by increasing
+    # the max allowed sample count by the amount of extra time taken, divided by 10
+    # (metric samples are produced every 10 seconds, by default).
+    # I've tried to make this code backward compatible by handling cases in which the
+    # daq_session_overall_time is not available (e.g. the try/catch).
+    max_metric_sample_count = 5  # under normal conditions, the sample count is 3, so 5 allows for some variation
+    try:
+        #print(f"DAQ session overall time: {run_nanorc.daq_session_overall_time} seconds")
+        expected_daq_session_time = 40  # this was determined by looking at the overall time from a normal run
+        if run_nanorc.daq_session_overall_time is not None:
+            extra_time_taken = run_nanorc.daq_session_overall_time - expected_daq_session_time
+            if extra_time_taken > 10:
+                extra_sample_count_allowance = int(extra_time_taken / 10)
+                max_metric_sample_count += extra_sample_count_allowance
+    except AttributeError:
+        pass
+    #print(f"max_metric_sample_count: {max_metric_sample_count}")
+
     session_name = run_nanorc.session_name if run_nanorc.session_name else run_nanorc.session
     metric_data = opmon_metric_checks.collate_opmon_data_from_files(run_nanorc.opmon_files)
 
@@ -164,7 +184,8 @@ def test_metric_files(run_nanorc):
     all_ok = True
     # a 20-second run will likely result in 3 metric samples (at 10-second intervals), so a range
     # of 1..5 should always succeed
-    all_ok &= opmon_metric_checks.check_metric_sample_count(metric_data, metric_key_list, min_count=1, max_count=5)
+    all_ok &= opmon_metric_checks.check_metric_sample_count(metric_data, metric_key_list, min_count=1,
+                                                            max_count=max_metric_sample_count)
     # the number of triggers expected in this test is ~20, so a test that checks for the reported
     # number of generated trigger records between 17 and 23 shoudl always succeed
     all_ok &= opmon_metric_checks.check_metric_value_sum(metric_data, metric_key_list, min_value_sum=17, max_value_sum=23)


### PR DESCRIPTION
# Description

This PR is correlated with DUNE-DAQ/integrationtest#137.

Recently, there was a failure in the running of the `minimal_system_quick_test.py` in the overnight regression test run.  The failure was that the number of samples for the generated_trigger_records metric was larger than expected.  

This was caused by a longer-than-expected run time of the DAQ session.  (not sure what caused that)

This change, plus the correlated one in the `integrationtest` repo addresses this possiblity by increasing the upper bound in the expected number of metric samples when the test runs long.

Here are instructions for testing these changes along with the ones in the `integrationtest` repo:
```
DATE_PREFIX=`date '+%d%b'`
TIME_SUFFIX=`date '+%H%M'`

source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
setup_dbt latest
dbt-create -n NFD_DEV_251211_A9 ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}
cd ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}/sourcecode

git clone https://github.com/DUNE-DAQ/daqsystemtest.git -b kbiery/handle_extra_metric_samples
cd ..

dbt-workarea-env

git clone https://github.com/DUNE-DAQ/integrationtest.git -b kbiery/session_time_bundle_info
cd integrationtest; pip install -U . ; cd ..

dbt-build -j 12
dbt-workarea-env

daqsystemtest_integtest_bundle.sh -k minimal
echo ""
echo -e "\U1F535 \U2705 Note that the previous regression test succeeded. \U2705 \U1F535"
echo -e "\U1F535 \U2705 In particular, the metric sample check was successful. \U2705 \U1F535"
echo ""

sed -i 's,boot conf start,boot conf wait 35 start,' sourcecode/daqsystemtest/integtest/minimal_system_quick_test.py

daqsystemtest_integtest_bundle.sh -k minimal
echo ""
echo -e "\U1F535 \U2705 Note that the previous regression test succeeded, even though \U2705 \U1F535"
echo -e "\U1F535 \U2705 the number of metric samples fluctuation upward from 3 to 6. \U2705 \U1F535"
```

## Type of change

- [x] Optimization (non-breaking change that improves code/performance)

## Testing checklist

- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
