### PR TITLE
Properly set TC readout window sizes for daqsystemtest after updates in config

### DIFF
--- a/config/daqsystemtest/moduleconfs.data.xml
+++ b/config/daqsystemtest/moduleconfs.data.xml
@@ -693,10 +693,7 @@
  <attr name="template_for" type="class" val="RandomTCMakerModule"/>
  <attr name="trigger_rate_hz" type="float" val="1"/>
  <attr name="time_distribution" type="enum" val="kUniform"/>
- <attr name="candidate_type_name" type="string" val="kRandom"/>
- <attr name="candidate_backshift_ts" type="s64" val="1000"/>
- <attr name="candidate_window_before_ts" type="u32" val="1000"/>
- <attr name="candidate_window_after_ts" type="u32" val="1001"/>
+ <rel name="tc_readout" class="TCReadoutMap" id="def-random-readout"/>
 </obj>
 
 <obj class="RequestHandler" id="def-data-request-handler">

--- a/config/daqsystemtest/moduleconfs.data.xml
+++ b/config/daqsystemtest/moduleconfs.data.xml
@@ -658,7 +658,7 @@
  <attr name="trigger_rate_hz" type="float" val="1"/>
  <attr name="time_distribution" type="enum" val="kUniform"/>
  <attr name="candidate_type_name" type="string" val="kRandom"/>
- <attr name="candidate_backshift_ts" type="s32" val="1000"/>
+ <attr name="candidate_backshift_ts" type="s64" val="1000"/>
  <attr name="candidate_window_before_ts" type="u32" val="1000"/>
  <attr name="candidate_window_after_ts" type="u32" val="1001"/>
 </obj>

--- a/config/daqsystemtest/moduleconfs.data.xml
+++ b/config/daqsystemtest/moduleconfs.data.xml
@@ -658,7 +658,7 @@
  <attr name="trigger_rate_hz" type="float" val="1"/>
  <attr name="time_distribution" type="enum" val="kUniform"/>
  <attr name="candidate_type_name" type="string" val="kRandom"/>
- <attr name="candidate_offset_ts" type="s32" val="1000"/>
+ <attr name="candidate_backshift_ts" type="s32" val="1000"/>
  <attr name="candidate_window_before_ts" type="u32" val="1000"/>
  <attr name="candidate_window_after_ts" type="u32" val="1001"/>
 </obj>

--- a/config/daqsystemtest/moduleconfs.data.xml
+++ b/config/daqsystemtest/moduleconfs.data.xml
@@ -657,7 +657,10 @@
  <attr name="template_for" type="class" val="RandomTCMakerModule"/>
  <attr name="trigger_rate_hz" type="float" val="1"/>
  <attr name="time_distribution" type="enum" val="kUniform"/>
- <rel name="tc_readout" class="TCReadoutMap" id="def-random-readout"/>
+ <attr name="candidate_type_name" type="string" val="kRandom"/>
+ <attr name="candidate_offset_ts" type="s32" val="1000"/>
+ <attr name="candidate_window_before_ts" type="u32" val="1000"/>
+ <attr name="candidate_window_after_ts" type="u32" val="1001"/>
 </obj>
 
 <obj class="RequestHandler" id="def-data-request-handler">
@@ -794,12 +797,6 @@
 <obj class="TCReadoutMap" id="def-hsi-tc-map">
  <attr name="tc_type_name" type="string" val="kTiming"/>
  <attr name="time_before" type="u32" val="3000"/>
- <attr name="time_after" type="u32" val="1001"/>
-</obj>
-
-<obj class="TCReadoutMap" id="def-random-readout">
- <attr name="tc_type_name" type="string" val="kRandom"/>
- <attr name="time_before" type="u32" val="1000"/>
  <attr name="time_after" type="u32" val="1001"/>
 </obj>
 

--- a/config/daqsystemtest/moduleconfs.data.xml
+++ b/config/daqsystemtest/moduleconfs.data.xml
@@ -694,9 +694,9 @@
  <attr name="trigger_rate_hz" type="float" val="1"/>
  <attr name="time_distribution" type="enum" val="kUniform"/>
  <attr name="candidate_type_name" type="string" val="kRandom"/>
- <attr name="candidate_backshift_ts" type="s64" val="1000"/>
- <attr name="candidate_window_before_ts" type="u32" val="1000"/>
- <attr name="candidate_window_after_ts" type="u32" val="1001"/>
+ <attr name="candidate_backshift_ts" type="s64" val="0"/>
+ <attr name="candidate_window_before_ts" type="u32" val="2000"/>
+ <attr name="candidate_window_after_ts" type="u32" val="5"/>
 </obj>
 
 <obj class="RequestHandler" id="def-data-request-handler">

--- a/config/daqsystemtest/moduleconfs.data.xml
+++ b/config/daqsystemtest/moduleconfs.data.xml
@@ -800,6 +800,12 @@
  <attr name="time_after" type="u32" val="1001"/>
 </obj>
 
+<obj class="TCReadoutMap" id="def-random-readout">
+ <attr name="tc_type_name" type="string" val="kRandom"/>
+ <attr name="time_before" type="u32" val="1000"/>
+ <attr name="time_after" type="u32" val="1001"/>
+</obj>
+
 <obj class="TCReadoutMap" id="def-tc-map">
  <attr name="tc_type_name" type="string" val="kTiming"/>
  <attr name="time_before" type="u32" val="3000"/>

--- a/config/daqsystemtest/moduleconfs.data.xml
+++ b/config/daqsystemtest/moduleconfs.data.xml
@@ -693,7 +693,10 @@
  <attr name="template_for" type="class" val="RandomTCMakerModule"/>
  <attr name="trigger_rate_hz" type="float" val="1"/>
  <attr name="time_distribution" type="enum" val="kUniform"/>
- <rel name="tc_readout" class="TCReadoutMap" id="def-random-readout"/>
+ <attr name="candidate_type_name" type="string" val="kRandom"/>
+ <attr name="candidate_backshift_ts" type="s64" val="1000"/>
+ <attr name="candidate_window_before_ts" type="u32" val="1000"/>
+ <attr name="candidate_window_after_ts" type="u32" val="1001"/>
 </obj>
 
 <obj class="RequestHandler" id="def-data-request-handler">

--- a/integtest/fake_data_producer_test.py
+++ b/integtest/fake_data_producer_test.py
@@ -79,11 +79,12 @@ doublewindow_conf = copy.deepcopy(conf_dict)
 
 doublewindow_conf.config_substitutions.append(
     data_classes.attribute_substitution(
-        obj_class="TCReadoutMap",
-        obj_id = "def-random-readout",
+        obj_class="RandomTCMakerConf",
+        obj_id = "random-tc-generator",
         updates={
-            "time_before": 2000,
-            "time_after": 2001,
+            "candidate_backshift_ts": 0,
+            "candidate_window_before_ts": 2000,
+            "candidate_window_after_ts": 2001,
         },
     )
 )

--- a/integtest/long_window_readout_test.py
+++ b/integtest/long_window_readout_test.py
@@ -130,11 +130,12 @@ conf_dict.config_substitutions.append(
 )
 conf_dict.config_substitutions.append(
     data_classes.attribute_substitution(
-        obj_class="TCReadoutMap",
-        obj_id = "def-random-readout",
+        obj_class="RandomTCMakerConf",
+        obj_id = "random-tc-generator",
         updates={
-            "time_before": readout_window_time_before,
-            "time_after": readout_window_time_after,
+            "candidate_backshift_ts": 0,
+            "candidate_window_before_ts": readout_window_time_before,
+            "candidate_window_after_ts": readout_window_time_after,
         },
     )
 )

--- a/integtest/readout_type_scan_test.py
+++ b/integtest/readout_type_scan_test.py
@@ -232,11 +232,12 @@ daphne_stream_conf.frame_file = "asset://?label=DAPHNEStream&subsystem=readout"
 
 daphne_stream_conf.config_substitutions.append(
     data_classes.attribute_substitution(
-        obj_class="TCReadoutMap",
-        obj_id = "def-random-readout",
+        obj_class="RandomTCMakerConf",
+        obj_id = "random-tc-generator",
         updates={
-            "time_before": 62000,
-            "time_after": 500,
+            "candidate_backshift_ts": 0,
+            "candidate_window_before_ts": 62000,
+            "candidate_window_after_ts": 500,
         },
     )
 )
@@ -246,11 +247,12 @@ daphne_conf.dro_map_config.det_id = 2  # det_id = 2 for HD_PDS
 daphne_conf.frame_file = "asset://?checksum=a8990a9eb3a505d4ded62dfdfa9e2681" # np02vd_run036012_sample_membrane_pds
 daphne_conf.config_substitutions.append(
     data_classes.attribute_substitution(
-        obj_class="TCReadoutMap",
-        obj_id = "def-random-readout",
+        obj_class="RandomTCMakerConf",
+        obj_id = "random-tc-generator",
         updates={
-            "time_before": 62000,
-            "time_after": 500,
+            "candidate_backshift_ts": 0,
+            "candidate_window_before_ts": 62000,
+            "candidate_window_after_ts": 500,
         },
     )
 )

--- a/integtest/trigger_bitwords_test.py
+++ b/integtest/trigger_bitwords_test.py
@@ -191,7 +191,7 @@ coincidence_bitword_conf.config_substitutions.append(
     data_classes.attribute_substitution(
         obj_id="random-tc-generator",
         obj_class="RandomTCMakerConf",
-        updates={"trigger_rate_hz": 40},)
+        updates={"trigger_rate_hz": 40, "candidate_backshift_ts": 0, "candidate_window_before_ts": 62500, "candidate_window_after_ts": 62500},)
 )
 coincidence_bitword_conf.config_substitutions.append(
     data_classes.attribute_substitution(


### PR DESCRIPTION
# Description

Some integtests in daqsystemtest were failing with the new RandomTriggerCandidateMaker updates (see [here](https://github.com/DUNE-DAQ/trigger/pull/425), including examples of tests that were failing). This PR tries to set the configuration for readout windows back to as it was before, so that the tests should all pass.

Should be testable by running through integtests and seeing they pass...

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)


## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

