### PR TITLE
Added the appropriate configuration substitution to make use of the readout_window_time_before & after times…

### DIFF
--- a/integtest/minimal_system_quick_test.py
+++ b/integtest/minimal_system_quick_test.py
@@ -77,6 +77,16 @@ substitution = data_classes.attribute_substitution(
     obj_class="RandomTCMakerConf",
     updates={"trigger_rate_hz": 1},
 )
+conf_dict.config_substitutions.append(
+    data_classes.attribute_substitution(
+        obj_class="TCReadoutMap",
+        obj_id = "def-random-readout",
+        updates={
+            "time_before": readout_window_time_before,
+            "time_after": readout_window_time_after,
+        },
+    )
+)
 conf_dict.config_substitutions.append(substitution)
 
 


### PR DESCRIPTION
… that are specified at the top of the file in minimal_system_quick_test.py.

# Description

Fixing an oversight...

To test this change, one can modify the before or after time and see that it has an effect on the test results...

## Type of change

- [x] Optimization (non-breaking change that improves code/performance)
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing checklist

- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)

