### PR TITLE
Updated and extended a few integtests to work with the ability to specify process manager types

### DIFF
--- a/integtest/3ru_3df_multirun_test.py
+++ b/integtest/3ru_3df_multirun_test.py
@@ -88,6 +88,33 @@ ignored_logfile_problems = {
     ],
 }
 
+# Introduction: the basic pattern used in the DUNE DAQ integration tests is to set up and
+# run one or more instances of the DAQ system ("DAQ sessions") and then verify that the
+# results of each test run (which often use emulated data sources) match what is expected,
+# given the configuration(s) of the DAQ system that the test writer provided.
+#
+# In all of this, the word "test" is a bit over-loaded.
+# * The pytest framework refers to the functions that are run to check the results of the
+#   data-taking as "tests". We tend to call those "validations" or "checks".  When we
+#   see the summary at the end of an integtest report that 'N tests were run', that
+#   means N validation functions were run by the pytest framework to check the results
+#   of the data taking in various ways.
+# * Distinct from that, we tend to use the word "test" to refer to one of our integtests.
+#   That is, the set of DAQ sessions and validation checks that are in one of these *_test.py
+#   files.
+#
+# In each of these integtest files, there are two categories of information that are required
+# to be provided to our integtest infrastructure and one optional type. These are used to
+# set up and loop through the desired DAQ sessions. The categories are the following:
+# 1. the configuration of the DAQ system (system topology, application parameters, etc.)
+# 2. the list of process managers that should be used [optional]
+# 3. the list of run control commands that should be executed
+# More information is provided about each of these below [coming soon!].
+#
+
+# 29-Dec-2025, KAB: The following comment about three variables is out-of-date.
+# It will be replaced soon, and the comment block above is a start on that.
+#
 # The next three variable declarations *must* be present as globals in the test
 # file. They're read by the "fixtures" in conftest.py to determine how
 # to run the config generation and nanorc
@@ -138,6 +165,13 @@ confgen_arguments = {
     "WIBEth_System": conf_dict,
     "Software_TPG_System": swtpg_conf,
 }
+
+# 29-Dec-2025, KAB: added sample process manager choices.
+process_manager_choices = {
+    "StandAloneSSH_PM" : {"pm_type": "ssh-standalone"},
+#   "ParamikoClient_PM" : {"pm_type": "ssh-standalone-paramiko-client"},
+}
+
 # The commands to run in nanorc, as a list
 nanorc_command_list = "boot conf".split()
 nanorc_command_list += (
@@ -162,7 +196,7 @@ nanorc_command_list += "scrap terminate".split()
 
 def test_nanorc_success(run_nanorc):
     current_test = os.environ.get("PYTEST_CURRENT_TEST")
-    match_obj = re.search(r".*\[(.+)\].*", current_test)
+    match_obj = re.search(r".*\[(.+)-run_nanorc0\].*", current_test)
     if match_obj:
         current_test = match_obj.group(1)
     banner_line = re.sub(".", "=", current_test)

--- a/integtest/tpreplay_test.py
+++ b/integtest/tpreplay_test.py
@@ -296,20 +296,21 @@ def test_data_files(run_nanorc):
     }
 
     # Match run to checks
-    match = re.search(r'\[(.+?)-run', current_test)
-    if match:
-        key = match.group(1)
-        if key in datafile_params:
+    # 29-Dec-2025, KAB: modified this block of code to work with the addition of
+    # the process-manager-choice fixture.
+    selected_params = {}
+    for key in datafile_params.keys():
+        if key in current_test:
             selected_params = datafile_params[key]
             print("Selected params for", key, ":", selected_params)
-        else:
-            print(f"Key '{key}' not found in datafile_params.")
-    else:
-        print("Could not extract key from current_test.")
+            break
+    if not selected_params:
+        print(f"\n*** ERROR: unable to determine the datafile_params for test {current_test}.")
 
     ### Run some tests on the output data file
     all_ok = True
 
+    all_ok &= len(run_nanorc.data_files) == selected_params["n_data_files"]
     if all_ok:
         print(f"\N{WHITE HEAVY CHECK MARK} The correct number of raw data files was found ({selected_params['n_data_files']})")
     else:

--- a/integtest/trigger_bitwords_test.py
+++ b/integtest/trigger_bitwords_test.py
@@ -302,16 +302,16 @@ def test_data_files(run_nanorc):
     }
 
     # Match run to checks
-    match = re.search(r'\[(.+?)-run', current_test)
-    if match:
-        key = match.group(1)
-        if key in datafile_params:
+    # 29-Dec-2025, KAB: modified this block of code to work with the addition of
+    # the process-manager-choice fixture.
+    selected_params = {}
+    for key in datafile_params.keys():
+        if key in current_test:
             selected_params = datafile_params[key]
             print("Selected params for", key, ":", selected_params)
-        else:
-            print(f"Key '{key}' not found in datafile_params.")
-    else:
-        print("Could not extract key from current_test.")
+            break
+    if not selected_params:
+        print(f"\n*** ERROR: unable to determine the datafile_params for test {current_test}.")
 
     ### Run some tests on the output data file
     all_ok = True


### PR DESCRIPTION
# Description

This PR is correlated with DUNE-DAQ/integrationtest#139.

In a discussion with Pawel and a few other people from the CCM WG, I learned that they are thinking about integration/regression tests that validate the behavior of different types of run control process managers. This led to the request for the ability to specify one or more process manager types in our integtest files.

The core changes to add this functionality were made in the `integrationtest` repo, and the changes in this repository were the following:

1. update a couple of tests to use a slightly different way of matching local substrings to the name of the current pytest 
2. provide a sample declaration of the desired process manager types (in the `3ru_3df_multirun_test`)
3. started adding comments to the `3ru_3df_multirun_test` to provide more (and updated) information about the variables that need to be defined in each integtest (to pass the necessary information to the integrationtest infrastructure).  I haven't finished that comment block because I want to discuss the current, slightly confusing, state of those variables with Eric and others and possibly make some changes to help reduce confusion.
4. I added a line to the `tpreplay_test` to check whether the number of raw data files produced by each data-taking run was correct.  It looked to me that this line had simply been missing.

Regarding the first change, there was logic in the `trigger_bitwords_test` and the `tpreplay_test` that used a regular expression to pull the "confgen" name out of the current pytest name and use that to look up the appropriate test parameters in a locally-defined dictionary.  With the addition of the process-manager-type fixture to our tests, the pytest names of our tests will now have three elements:  confgen name, process manager type, and index or name of the run control command list.  Instead of trying to update the regex to support this change, I simply modified the logic to check which confgen name appears in the pytest current test name.  This seems to work fine, and it seems a little more future-proof than the previous logic.

To test these changes, we can use the following steps:

```
DATE_PREFIX=`date '+%d%b'`
TIME_SUFFIX=`date '+%H%M'`

source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
setup_dbt latest
dbt-create -n NFD_DEV_251229_A9 ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}
cd ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}/sourcecode

git clone https://github.com/DUNE-DAQ/daqsystemtest.git -b kbiery/multiple_procmgr_support
cd ..

dbt-workarea-env

git clone https://github.com/DUNE-DAQ/integrationtest.git -b kbiery/multiple_procmgr_support
cd integrationtest; pip install -U . ; cd ..

dbt-build -j 12
dbt-workarea-env

dbt-build --integtest daqsystemtest
echo ""
echo -e "\U1F535 \U2705 Note that all regression tests passed. \U2705 \U1F535"
```

## Type of change

- [x] New feature or enhancement (non-breaking change which adds functionality)
- [x] Optimization (non-breaking change that improves code/performance)
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
