### PR TITLE
Modified the bundle script to handle non-standard pytest output directories...

### DIFF
--- a/integtest/long_window_readout_test.py
+++ b/integtest/long_window_readout_test.py
@@ -8,6 +8,7 @@ import psutil
 import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
 import integrationtest.data_classes as data_classes
+from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
 
 pytest_plugins = "integrationtest.integrationtest_drunc"
 
@@ -69,7 +70,7 @@ ignored_logfile_problems = {
 sufficient_disk_space = True
 actual_output_path = output_path_parameter
 if output_path_parameter == ".":
-    actual_output_path = "/tmp"
+    actual_output_path = get_pytest_tmpdir()
 disk_space = shutil.disk_usage(actual_output_path)
 total_disk_space_gb = disk_space.total / (1024 * 1024 * 1024)
 free_disk_space_gb = disk_space.free / (1024 * 1024 * 1024)

--- a/scripts/daqsystemtest_integtest_bundle.sh
+++ b/scripts/daqsystemtest_integtest_bundle.sh
@@ -19,6 +19,7 @@ Options:
     -N <number of times to run the full set of selected tests, default=1>
     --stop-on-failure : causes the script to stop when one of the integtests reports a failure
     --concise-output : suppresses run control and DAQApp messages in order to focus on test results
+    --tmpdir : specifies a root directory to use for test output, e.g. a directory instead of '/tmp'
 """
     let counter=0
     echo "List of available tests:"
@@ -29,6 +30,25 @@ Options:
     echo ""
 }
 
+# 29-Dec-2025, KAB: Determine if a non-standard pytest tmpdir has been specified
+# in the linux shell environment in which this script is being run. We need to know
+# this value in order to direct functionality in this script to the right place.
+#
+# This logic checks to see if any of several possible env vars that specify the
+# pytest output directory have been set. If any of them have been set, the first
+# one that we find is used. If not, then we default to "/tmp".
+# The env vars in this list were found in the AI response to a Google search for
+# "how to tell pytest to use a different temporary directory". The precedence that
+# is represented in the ordering of the list was determined via local testing.
+#
+# In all cases, a user-specified command-line value for the tmpdir over-rides values
+# found in env vars. That assignment is handled in the script argument processing below.
+: "${tmpdir_root:=$PYTEST_DEBUG_TEMPROOT}"
+: "${tmpdir_root:=$TMPDIR}"
+: "${tmpdir_root:=$TEMP}"
+: "${tmpdir_root:=$TMP}"
+: "${tmpdir_root:=/tmp}"
+
 # Removes the ANSI characters associated with formatting, including color coding and font styling
 CaptureOutputNoANSI() {
     tee -a >(sed -u 's/\x1b\[[0-9;]*m//g' >> "$1")
@@ -38,8 +58,8 @@ CaptureOutput() {
     tee -a $1
 }
 
-TEMP=`getopt -o hs:f:l:k:n:N: --long help,stop-on-failure,concise-output -- "$@"`
-eval set -- "$TEMP"
+GETOPT_TEMP=`getopt -o hs:f:l:k:n:N: --long help,stop-on-failure,concise-output,tmpdir: -- "$@"`
+eval set -- "$GETOPT_TEMP"
 
 let first_test_index=0
 let individual_test_requested_iterations=1
@@ -83,6 +103,11 @@ while true; do
             PYTEST_COMMAND="`echo ${PYTEST_COMMAND} | sed 's/ -s//'`"  # remove the -s option to turn off messages from DAQ processes
             shift
             ;;
+        --tmpdir)
+            tmpdir_root=$2
+            export PYTEST_DEBUG_TEMPROOT=${tmpdir_root}
+            shift 2
+            ;;
         --)
             shift
             break
@@ -103,8 +128,8 @@ fi
 
 # other setup
 INITIAL_TIMESTAMP=`date '+%Y%m%d%H%M%S'`
-mkdir -p /tmp/pytest-of-${USER}
-ITGRUNNER_LOG_FILE="/tmp/pytest-of-${USER}/daqsystemtest_integtest_bundle_${INITIAL_TIMESTAMP}.log"
+mkdir -p ${tmpdir_root}/pytest-of-${USER}
+ITGRUNNER_LOG_FILE="${tmpdir_root}/pytest-of-${USER}/daqsystemtest_integtest_bundle_${INITIAL_TIMESTAMP}.log"
 CURRENT_PID=$$
 
 let number_of_individual_tests=0
@@ -167,7 +192,7 @@ while [[ ${full_set_loop_count} -lt ${full_set_requested_interations} ]]; do
                         # integrationtest infrastructure.
                         if [[ "`which jq 2>/dev/null`" != "" ]]; then
                             current_pytest_rundir=""
-                            mapfile -t bundle_info_files < <(find "/tmp/pytest-of-${USER}" -type f -name "bundle_script_info.json" -printf '%T@ %p\n' | grep -v 'failed-' | sort -nr | awk '{print $2}')
+                            mapfile -t bundle_info_files < <(find "${tmpdir_root}/pytest-of-${USER}" -type f -name "bundle_script_info.json" -printf '%T@ %p\n' | grep -v 'failed-' | sort -nr | awk '{print $2}')
                             for info_file in "${bundle_info_files[@]}"; do
                                 script_start_time=`jq -r .bundle_script_start_time ${info_file}`
                                 script_pid=`jq -r .bundle_script_process_id ${info_file}`
@@ -212,12 +237,12 @@ while [[ ${full_set_loop_count} -lt ${full_set_requested_interations} ]]; do
 
                         # remove stale and surplus directories from failed tests
                         test_dirs_to_remove=()
-                        mapfile -t all_failed_test_dirs < <(find /tmp/pytest-of-${USER} -maxdepth 1 -type d -printf '%T@ %p\n' | sort -nr | awk '{print $2}' | grep 'failed-')
+                        mapfile -t all_failed_test_dirs < <(find ${tmpdir_root}/pytest-of-${USER} -maxdepth 1 -type d -printf '%T@ %p\n' | sort -nr | awk '{print $2}' | grep 'failed-')
                         surplus_dirs=("${all_failed_test_dirs[@]:10}")
                         for test_dir in "${surplus_dirs[@]}"; do
                             test_dirs_to_remove+=(${test_dir})
                         done
-                        stale_failed_test_dirs=(`find /tmp/pytest-of-${USER} -maxdepth 1 -type d -name 'failed-*' -cmin +1560 -print`)
+                        stale_failed_test_dirs=(`find ${tmpdir_root}/pytest-of-${USER} -maxdepth 1 -type d -name 'failed-*' -cmin +1560 -print`)
                         for test_dir in "${stale_failed_test_dirs[@]}"; do
                             test_dirs_to_remove+=(${test_dir})
                         done

--- a/scripts/daqsystemtest_integtest_bundle.sh
+++ b/scripts/daqsystemtest_integtest_bundle.sh
@@ -115,8 +115,17 @@ fi
 
 # other setup
 INITIAL_TIMESTAMP=`date '+%Y%m%d%H%M%S'`
-mkdir -p ${tmpdir_root}/pytest-of-${USER}
-ITGRUNNER_LOG_FILE="${tmpdir_root}/pytest-of-${USER}/daqsystemtest_integtest_bundle_${INITIAL_TIMESTAMP}.log"
+pytest_user_dir=${tmpdir_root}/pytest-of-${USER}
+mkdir -p ${pytest_user_dir}
+if [[ ! -d ${pytest_user_dir} ]]; then
+    echo "*** ERROR: directory \"${pytest_user_dir}\" does not exist."
+    exit 1
+fi
+if [[ ! -w ${pytest_user_dir} ]]; then
+    echo "*** ERROR: directory \"${pytest_user_dir}\" is not writeable in the current environment."
+    exit 1
+fi
+ITGRUNNER_LOG_FILE="${pytest_user_dir}/daqsystemtest_integtest_bundle_${INITIAL_TIMESTAMP}.log"
 CURRENT_PID=$$
 
 let number_of_individual_tests=0
@@ -179,7 +188,7 @@ while [[ ${full_set_loop_count} -lt ${full_set_requested_interations} ]]; do
                         # integrationtest infrastructure.
                         if [[ "`which jq 2>/dev/null`" != "" ]]; then
                             current_pytest_rundir=""
-                            mapfile -t bundle_info_files < <(find "${tmpdir_root}/pytest-of-${USER}" -type f -name "bundle_script_info.json" -printf '%T@ %p\n' | grep -v 'failed-' | sort -nr | awk '{print $2}')
+                            mapfile -t bundle_info_files < <(find "${pytest_user_dir}" -type f -name "bundle_script_info.json" -printf '%T@ %p\n' | grep -v 'failed-' | sort -nr | awk '{print $2}')
                             for info_file in "${bundle_info_files[@]}"; do
                                 script_start_time=`jq -r .bundle_script_start_time ${info_file}`
                                 script_pid=`jq -r .bundle_script_process_id ${info_file}`
@@ -224,12 +233,12 @@ while [[ ${full_set_loop_count} -lt ${full_set_requested_interations} ]]; do
 
                         # remove stale and surplus directories from failed tests
                         test_dirs_to_remove=()
-                        mapfile -t all_failed_test_dirs < <(find ${tmpdir_root}/pytest-of-${USER} -maxdepth 1 -type d -printf '%T@ %p\n' | sort -nr | awk '{print $2}' | grep 'failed-')
+                        mapfile -t all_failed_test_dirs < <(find ${pytest_user_dir} -maxdepth 1 -type d -printf '%T@ %p\n' | sort -nr | awk '{print $2}' | grep 'failed-')
                         surplus_dirs=("${all_failed_test_dirs[@]:10}")
                         for test_dir in "${surplus_dirs[@]}"; do
                             test_dirs_to_remove+=(${test_dir})
                         done
-                        stale_failed_test_dirs=(`find ${tmpdir_root}/pytest-of-${USER} -maxdepth 1 -type d -name 'failed-*' -cmin +1560 -print`)
+                        stale_failed_test_dirs=(`find ${pytest_user_dir} -maxdepth 1 -type d -name 'failed-*' -cmin +1560 -print`)
                         for test_dir in "${stale_failed_test_dirs[@]}"; do
                             test_dirs_to_remove+=(${test_dir})
                         done

--- a/scripts/daqsystemtest_integtest_bundle.sh
+++ b/scripts/daqsystemtest_integtest_bundle.sh
@@ -115,16 +115,17 @@ fi
 
 # other setup
 INITIAL_TIMESTAMP=`date '+%Y%m%d%H%M%S'`
+# 30-Dec-2025, KAB: check that the specified tmpdir exists and is writeable
+if [[ ! -d ${tmpdir_root} ]]; then
+    echo "*** ERROR: directory \"${tmpdir_root}\" does not exist."
+    exit 1
+fi
+if [[ ! -w ${tmpdir_root} ]]; then
+    echo "*** ERROR: directory \"${tmpdir_root}\" is not writeable in the current environment."
+    exit 1
+fi
 pytest_user_dir=${tmpdir_root}/pytest-of-${USER}
 mkdir -p ${pytest_user_dir}
-if [[ ! -d ${pytest_user_dir} ]]; then
-    echo "*** ERROR: directory \"${pytest_user_dir}\" does not exist."
-    exit 1
-fi
-if [[ ! -w ${pytest_user_dir} ]]; then
-    echo "*** ERROR: directory \"${pytest_user_dir}\" is not writeable in the current environment."
-    exit 1
-fi
 ITGRUNNER_LOG_FILE="${pytest_user_dir}/daqsystemtest_integtest_bundle_${INITIAL_TIMESTAMP}.log"
 CURRENT_PID=$$
 

--- a/scripts/daqsystemtest_integtest_bundle.sh
+++ b/scripts/daqsystemtest_integtest_bundle.sh
@@ -33,21 +33,8 @@ Options:
 # 29-Dec-2025, KAB: Determine if a non-standard pytest tmpdir has been specified
 # in the linux shell environment in which this script is being run. We need to know
 # this value in order to direct functionality in this script to the right place.
-#
-# This logic checks to see if any of several possible env vars that specify the
-# pytest output directory have been set. If any of them have been set, the first
-# one that we find is used. If not, then we default to "/tmp".
-# The env vars in this list were found in the AI response to a Google search for
-# "how to tell pytest to use a different temporary directory". The precedence that
-# is represented in the ordering of the list was determined via local testing.
-#
-# In all cases, a user-specified command-line value for the tmpdir over-rides values
-# found in env vars. That assignment is handled in the script argument processing below.
-: "${tmpdir_root:=$PYTEST_DEBUG_TEMPROOT}"
-: "${tmpdir_root:=$TMPDIR}"
-: "${tmpdir_root:=$TEMP}"
-: "${tmpdir_root:=$TMP}"
-: "${tmpdir_root:=/tmp}"
+# A user-specified command-line value for the tmpdir over-rides the value determined here.
+tmpdir_root=`dst_get_pytest_tmpdir`
 
 # Removes the ANSI characters associated with formatting, including color coding and font styling
 CaptureOutputNoANSI() {

--- a/scripts/dst_get_pytest_tmpdir
+++ b/scripts/dst_get_pytest_tmpdir
@@ -1,0 +1,10 @@
+#!/bin/env python3
+from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
+
+def dst_get_pytest_tmpdir():
+  """Script to determine the current pytest tmpdir (the root of the current pytest output directory)."""
+  return get_pytest_tmpdir()
+
+if __name__ == '__main__':
+  tmpdir = dst_get_pytest_tmpdir()
+  print(tmpdir)


### PR DESCRIPTION
…, both ones that are specified in the environment and ones that are specified in command line arguments.

# Description

This PR is correlated with DUNE-DAQ/integrationtest#140.

The changes in this PR include ones that should have been included in the bundle script previously and ones that add new functionality.   In particular, 

- We should have been alert to the use of a non-standard pytest environment previously. That is remedied in this PR.
- It will likely be useful to occasionally specify a non-standard pytest output dir, and this PR includes changes to support a user-defined output directory as a command-line option to the bundle script.

The logic that is used to determine if a non-standard pytest output directory has been specified in the Linux shell environment has the following features.

- It checks to see if any of several possible env vars have been set. If any of them have been set, the first one that we find is used. If none are found, then we default to "/tmp".
    - The env vars in this list were found in the AI response to a Google search for "how to tell pytest to use a different temporary directory". The precedence that is represented in the ordering of the list was determined via local testing.
- In all cases, a user-specified command-line value for the tmpdir over-rides values found in env vars. 
- This functionality is implemented in a Python function in the `integrationtest` repo and a Python script in this repo.

Here is a screenshot of the Google search output:
<img width="614" height="560" alt="Screenshot 2025-12-29 at 4 54 04 PM" src="https://github.com/user-attachments/assets/2ba7c304-2879-4cf9-8d29-a5adc1f91344" />


To provide consistent behavior between the bundle script and the integtest that currently checks the amount of free space on the output disk (`long_window_readout_test.py`), the latter was modified to make use of the new `get_pytest_tmpdir` function from the `integtest` repo.

These changes can be tested by specifying a `--tmpdir` command-line option to the bundle script, or by setting some combination of the following environmental variables to an existing directory on the local computer:  `PYTEST_DEBUG_TEMPROOT`, `TMPDIR`, `TEMP`, `TMP`.

The following instructions may also be useful:

```
DATE_PREFIX=`date '+%d%b'`
TIME_SUFFIX=`date '+%H%M'`

source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
setup_dbt latest
dbt-create -n NFD_DEV_251230_A9 ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}
cd ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}/sourcecode

git clone https://github.com/DUNE-DAQ/daqsystemtest.git -b kbiery/bundlescript_nonstandard_pytest_outdir
cd ..

dbt-workarea-env

git clone https://github.com/DUNE-DAQ/integrationtest.git -b kbiery/get_pytest_tmpdir_function
cd integrationtest; pip install -U . ; cd ..

dbt-build -j 12
dbt-workarea-env

sed -i 's,"min_size_bytes": 7272,"min_size_bytes": 7273,' sourcecode/daqsystemtest/integtest/minimal_system_quick_test.py
sed -i 's,"max_size_bytes": 14472,"max_size_bytes": 14471,' sourcecode/daqsystemtest/integtest/minimal_system_quick_test.py

daqsystemtest_integtest_bundle.sh -l0

echo ""
echo -e "\U1F535 \U2705 Note that when the previous regression test failed, a copy of the pytest output directory was created in /tmp/pytest-of-${USER}. \U2705 \U1F535"
echo ""
echo ""

daqsystemtest_integtest_bundle.sh -l0 --tmpdir=/tmp/pytest-of-${USER}

echo ""
echo -e "\U1F535 \U2705 Note that when the previous regression test failed, a copy of the pytest output directory was created in /tmp/pytest-of-${USER}/pytest-of-${USER} (two levels down). \U2705 \U1F535"
echo ""
echo ""

daqsystemtest_integtest_bundle.sh -l0 --tmpdir=/tmp/pytest-of-dunedaq

echo ""
echo -e "\U1F535 \U2705 Note that the bundle script never really got started in this latest test because it couldn't write to the requested tmpdir. \U2705 \U1F535"
echo ""
```

## Type of change

- [x] New feature or enhancement (non-breaking change which adds functionality)
- [x] Optimization (non-breaking change that improves code/performance)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
