### PR TITLE
Removed the over-ride of the clock speed in fake_data_producer_test.py…

### DIFF
--- a/integtest/fake_data_producer_test.py
+++ b/integtest/fake_data_producer_test.py
@@ -67,14 +67,6 @@ conf_dict.config_substitutions.append(
     )
 )
 
-conf_dict.config_substitutions.append(
-    data_classes.attribute_substitution(
-        obj_id="dummy-detector",
-        obj_class="DetectorConfig",
-        updates={"clock_speed_hz": 1000000000}, # FakeDataProd uses nanoseconds as its timestamps
-    )
-)
-
 doublewindow_conf = copy.deepcopy(conf_dict)
 
 doublewindow_conf.config_substitutions.append(


### PR DESCRIPTION
…now that the FakeDataProducer module uses DTS ticks.

# Description

This change is a follow-up to DUNE-DAQ/dfmodules#469.

To test the results of both changes, one can look at the raw data files produced by the fake_data_producer_test with `HDF5LIBS_TestDumpRecord -t -n 1 <filename>`.
