### PR TITLE
Removed the setting of the frame_file_required directive in RTST and FDPT…

### DIFF
--- a/integtest/fake_data_producer_test.py
+++ b/integtest/fake_data_producer_test.py
@@ -103,8 +103,6 @@ nanorc_command_list += (
     )
 nanorc_command_list += "scrap terminate".split()
 
-# Don't require the --frame-file option since we don't need it
-frame_file_required = False
 
 # The tests themselves
 

--- a/integtest/readout_type_scan_test.py
+++ b/integtest/readout_type_scan_test.py
@@ -10,9 +10,6 @@ import integrationtest.data_classes as data_classes
 
 pytest_plugins = "integrationtest.integrationtest_drunc"
 
-# Don't require frames file
-frame_file_required = False
-
 # Values that help determine the running conditions
 number_of_data_producers = 2
 run_duration = 20  # seconds


### PR DESCRIPTION
… since it is no longer needed.

# Description

The `frame_file_required` integtest configuration parameter has been obsolete for a while.  These changes remove it from a couple of integtests that still had it defined.

I tested that the integtests in question continue to work after this change.

## Type of change

- [x] Optimization (non-breaking change that improves code/performance)

## Testing checklist

- [x] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
