### PR TITLE
Modified the expected size range for TDEEth fragments in readout_type_scan_test.py…

### DIFF
--- a/integtest/readout_type_scan_test.py
+++ b/integtest/readout_type_scan_test.py
@@ -38,8 +38,8 @@ tde_frag_params = {
     "fragment_type_description": "TDEEth",
     "fragment_type": "TDEEth",
     "expected_fragment_count": number_of_data_producers,
-    "min_size_bytes": 7272,
-    "max_size_bytes": 14472,
+    "min_size_bytes": 14472,  # 19-Feb-2026, KAB: the time span of a TDEEth frame is 2000 ticks
+    "max_size_bytes": 21672,  # With a readout window of 2005 ticks, we'll get 2 or 3 frames
 }
 bern_crt_frag_params = {
     "fragment_type_description": "CRTBern",


### PR DESCRIPTION
…to correctly take into account the time span of TDEEth frames compared to the size of the readout window in this test.

# Description

I noticed that the `readout_type_scan_test` reported an error in the overnight running of the regression tests this morning ([link](https://github.com/DUNE-DAQ/daq-release/actions/runs/22171029750/job/64108757271)).  

I believe that recent changes in other places in the code uncovered a small misconfiguration in this test.  The allowed range in size of TDEEth fragments was between 7272 and 14472 bytes, but given the time span of TDEEth frames and the size of the readout window in this test, I believe that the allowed range should be 14472 to 21672 bytes.  

The reasoning behind this is that the time span of TDEEth frames is 2000 DTS (DUNE Timing System) ticks.  With a readout window of 2005 ticks, we would expect that most of the time, there will be two TDEEth frames in a TDEEth fragment.  But, there can be 3 occasionally.  

Since the size of a TDEEth frame is 7200 bytes, two frames would give a fragment size of 14472 (2 times 7200 plus 72 bytes for the Fragment header), and three frames would give a fragment size of 21672 bytes (3 times 7200 plus 72).

The way that I demonstrated the problem and verified the fix was to run the TDEEth parts of the `readout_type_scan_test` several times, with and without, the changes in this PR.  Without the changes, I saw occasional problems.  With the changes, I did not see any problems.

```
cd $DBT_AREA_ROOT/sourcecode/daqsystemtest/integtest
((dbt) ) [biery@daq integtest]$ pytest -s -k TDEEth readout_type_scan_test.py
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing checklist

- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
