### PR TITLE
Updated the bundle script summary to show a red X icon for tests with errors…

### DIFF
--- a/scripts/dunedaq_integtest_bundle.sh
+++ b/scripts/dunedaq_integtest_bundle.sh
@@ -347,7 +347,7 @@ date                                                      | CaptureOutput ${ITGR
 echo "Log file is: ${ITGRUNNER_LOG_FILE}"                 | CaptureOutput ${ITGRUNNER_LOG_FILE}
 echo ""                                                   | CaptureOutput ${ITGRUNNER_LOG_FILE}
 summary_string="`egrep $'=====|\u2B95' ${ITGRUNNER_LOG_FILE} | egrep ' in |Running'`"
-colorized_summary_string="`echo \"${summary_string}\" | sed 's/passed/passed \\\\U2705/' | sed 's/failed/failed \\\\U274c/' | sed 's/\(errors\?\)/\1 \\\\U274c/' | sed 's/no tests ran/no tests ran \\\\U274c/' | sed 's/skipped/skipped \\\\U1f7e1/'`"
+colorized_summary_string="`echo \"${summary_string}\" | sed 's/passed/passed \\\\U2705/' | sed 's/failed/failed \\\\U274c/' | sed 's/\(errors\?\)/\1 \\\\U1F6A8/' | sed 's/no tests ran/no tests ran \\\\U1F6A8/' | sed 's/skipped/skipped \\\\U1f7e1/'`"
 echo -e "${colorized_summary_string}" | CaptureOutput ${ITGRUNNER_LOG_FILE}
 
 # check again if the numad daemon is running

--- a/scripts/dunedaq_integtest_bundle.sh
+++ b/scripts/dunedaq_integtest_bundle.sh
@@ -347,7 +347,7 @@ date                                                      | CaptureOutput ${ITGR
 echo "Log file is: ${ITGRUNNER_LOG_FILE}"                 | CaptureOutput ${ITGRUNNER_LOG_FILE}
 echo ""                                                   | CaptureOutput ${ITGRUNNER_LOG_FILE}
 summary_string="`egrep $'=====|\u2B95' ${ITGRUNNER_LOG_FILE} | egrep ' in |Running'`"
-colorized_summary_string="`echo \"${summary_string}\" | sed 's/passed/passed \\\\U2705/' | sed 's/failed/failed \\\\U274c/' | sed 's/errors/errors \\\\U274c/' | sed 's/error/error \\\\U274c/' | sed 's/no tests ran/no tests ran \\\\U274c/' | sed 's/skipped/skipped \\\\U1f7e1/'`"
+colorized_summary_string="`echo \"${summary_string}\" | sed 's/passed/passed \\\\U2705/' | sed 's/failed/failed \\\\U274c/' | sed 's/\(errors\?\)/\1 \\\\U274c/' | sed 's/no tests ran/no tests ran \\\\U274c/' | sed 's/skipped/skipped \\\\U1f7e1/'`"
 echo -e "${colorized_summary_string}" | CaptureOutput ${ITGRUNNER_LOG_FILE}
 
 # check again if the numad daemon is running

--- a/scripts/dunedaq_integtest_bundle.sh
+++ b/scripts/dunedaq_integtest_bundle.sh
@@ -347,7 +347,7 @@ date                                                      | CaptureOutput ${ITGR
 echo "Log file is: ${ITGRUNNER_LOG_FILE}"                 | CaptureOutput ${ITGRUNNER_LOG_FILE}
 echo ""                                                   | CaptureOutput ${ITGRUNNER_LOG_FILE}
 summary_string="`egrep $'=====|\u2B95' ${ITGRUNNER_LOG_FILE} | egrep ' in |Running'`"
-colorized_summary_string="`echo \"${summary_string}\" | sed 's/passed/passed \\\\U2705/' | sed 's/failed/failed \\\\U274c/' | sed 's/no tests ran/no tests ran \\\\U274c/' | sed 's/skipped/skipped \\\\U1f7e1/'`"
+colorized_summary_string="`echo \"${summary_string}\" | sed 's/passed/passed \\\\U2705/' | sed 's/failed/failed \\\\U274c/' | sed 's/error/error \\\\U274c/' | sed 's/no tests ran/no tests ran \\\\U274c/' | sed 's/skipped/skipped \\\\U1f7e1/'`"
 echo -e "${colorized_summary_string}" | CaptureOutput ${ITGRUNNER_LOG_FILE}
 
 # check again if the numad daemon is running

--- a/scripts/dunedaq_integtest_bundle.sh
+++ b/scripts/dunedaq_integtest_bundle.sh
@@ -347,7 +347,7 @@ date                                                      | CaptureOutput ${ITGR
 echo "Log file is: ${ITGRUNNER_LOG_FILE}"                 | CaptureOutput ${ITGRUNNER_LOG_FILE}
 echo ""                                                   | CaptureOutput ${ITGRUNNER_LOG_FILE}
 summary_string="`egrep $'=====|\u2B95' ${ITGRUNNER_LOG_FILE} | egrep ' in |Running'`"
-colorized_summary_string="`echo \"${summary_string}\" | sed 's/passed/passed \\\\U2705/' | sed 's/failed/failed \\\\U274c/' | sed 's/error/error \\\\U274c/' | sed 's/no tests ran/no tests ran \\\\U274c/' | sed 's/skipped/skipped \\\\U1f7e1/'`"
+colorized_summary_string="`echo \"${summary_string}\" | sed 's/passed/passed \\\\U2705/' | sed 's/failed/failed \\\\U274c/' | sed 's/errors/errors \\\\U274c/' | sed 's/error/error \\\\U274c/' | sed 's/no tests ran/no tests ran \\\\U274c/' | sed 's/skipped/skipped \\\\U1f7e1/'`"
 echo -e "${colorized_summary_string}" | CaptureOutput ${ITGRUNNER_LOG_FILE}
 
 # check again if the numad daemon is running


### PR DESCRIPTION
…as well as failed tests.

# Description

I noticed recently that integtests that reported an "error", versus a failed test, did not have a red icon in the bundle script summary printout to help users notice that there was a problem.  This change corrects that oversight.

Here are instructions for demonstrating the change:

```
DATE_PREFIX=`date '+%d%b'`
TIME_SUFFIX=`date '+%H%M'`

source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
setup_dbt latest
dbt-create -n NFD_DEV_260228_A9 ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}
cd ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}/sourcecode

git clone https://github.com/DUNE-DAQ/daqsystemtest.git -b develop
cd ..

dbt-workarea-env
dbt-build -j 12
dbt-workarea-env

dunedaq_integtest_bundle.sh -r dfmodules -k trmon

echo ""
echo -e "\U1F535 \U2705 Note that the trmon integtest failed, but the summary doesn't have any red icons to draw attention to that. \U2705 \U1F535"
echo ""
echo ""
sleep 3

cd sourcecode/daqsystemtest
git checkout kbiery/colorize_error_in_bundle_script
cd ../..

dbt-build -j 12
dbt-workarea-env

dunedaq_integtest_bundle.sh -r dfmodules -k trmon

echo ""
echo -e "\U1F535 \U2705 Note that the trmon integtest failed, and there now is a red icon in the summary. \U2705 \U1F535"
echo ""
echo ""
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing checklist

- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
