### PR TITLE
Added an ignored logfile warning about absl log messages to the example_system_test

### DIFF
--- a/integtest/example_system_test.py
+++ b/integtest/example_system_test.py
@@ -75,6 +75,8 @@ ignored_logfile_problems = {
     "local-connection-server": [
         "errorlog: -",
     ],
+    # 04-Mar-2026, KAB: added the absl::InitializeLog warning message to the ignored list for
+    # all DAQ processes, given that we currently don't have a way suppress it at its source.
     r".*": [
         r"WARNING: All log messages before absl::InitializeLog\(\) is called are written to STDERR"
     ]

--- a/integtest/example_system_test.py
+++ b/integtest/example_system_test.py
@@ -74,6 +74,9 @@ ignored_logfile_problems = {
     ],
     "local-connection-server": [
         "errorlog: -",
+    ],
+    r".*": [
+        r"WARNING: All log messages before absl::InitializeLog\(\) is called are written to STDERR"
     ]
 }
 


### PR DESCRIPTION
# Description

In recent regression testing at EHN1, I noticed that I would fairly consistently see problems reported in the `ENH1` part of the `example_system_test`.  

There would be warnings in the log file(s) like the following:

```
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
```

From information that various people posted in [a different PR](https://github.com/DUNE-DAQ/drunc/issues/754#issuecomment-3996453577), it seems that this error is hard to get rid of (if not impossible, at the moment).  So, I added this warning message to the list of `ignored` messages in the `example_system_test`.

Here are suggestions for testing the proposed change (on a computer at EHN1):

```
DATE_PREFIX=`date '+%d%b'`
TIME_SUFFIX=`date '+%H%M'`

source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
setup_dbt latest
dbt-create -n NFD_DEV_260304_A9 ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}
cd ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}/sourcecode

git clone https://github.com/DUNE-DAQ/daqsystemtest.git -b develop

cd ..

dbt-workarea-env
dbt-build -j 12
dbt-workarea-env

cd $DBT_AREA_ROOT/sourcecode/daqsystemtest/integtest
pytest -s -k EHN1 example_system_test.py

echo ""
echo -e "\U1F535 \U2705 Note that there are log file warnings that cause the test to fail. \U2705 \U1F535"
echo ""
echo ""
sleep 3

git checkout kbiery/ignore_absl_warning

pytest -s -k EHN1 example_system_test.py

echo ""
echo -e "\U1F535 \U2705 Note that there are *no* log file warnings with the proposed change. \U2705 \U1F535"
echo ""
echo ""
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing checklist

- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
