### PR TITLE
Provide additional ability to specify the run control process manager type for integration tests

### DIFF
--- a/integtest/3ru_3df_multirun_test.py
+++ b/integtest/3ru_3df_multirun_test.py
@@ -182,8 +182,8 @@ confgen_arguments = {
 
 # 29-Dec-2025, KAB: added sample process manager choices.
 process_manager_choices = {
-    "StandAloneSSH_PM" : {"pm_type": "ssh-standalone"},
-#   "ParamikoClient_PM" : {"pm_type": "ssh-standalone-paramiko-client"},
+    "StandAloneSSH_PM" : "ssh-standalone",
+#   "ParamikoClient_PM" : "ssh-standalone-paramiko-client",
 }
 
 # The commands to run in nanorc, as a list


### PR DESCRIPTION
# Description

Please Note:  This PR needs to be tested and merged in conjunction with DUNE-DAQ/integrationtest#148.

In response to a request from our run control colleagues, we have provided the ability to specify the process manager type that is used by integration tests from the command line.

With the changes included in this PR and the corresponding one in `integrationtest`, users can do this in the following ways:

```
pytest -s --process-manager-type ssh-standalone minimal_system_quick_test.py

dunedaq_integtest_bundle.sh -k min --pytest-options "--process-manager-type ssh-standalone"
```

Here are sample steps for testing these changes:

```
DATE_PREFIX=`date '+%d%b'`
TIME_SUFFIX=`date '+%H%M'`

source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
setup_dbt latest
dbt-create -n NFD_DEV_260305_A9 ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}
cd ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}/sourcecode

git clone https://github.com/DUNE-DAQ/daqsystemtest.git -b kbiery/pmtype_from_commandline
cd ..

cd pythoncode
git clone https://github.com/DUNE-DAQ/integrationtest.git -b kbiery/pmtype_from_commandline
cd ..

dbt-workarea-env
dbt-build -j 12
dbt-workarea-env

dunedaq_integtest_bundle.sh -k min --pytest-options "--process-manager-type ssh-standalone"
```

## Type of change

- [x] New feature or enhancement (non-breaking change which adds functionality)

## Testing checklist

- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
