### PR TITLE
NanoRC to DuneRC name change

### DIFF
--- a/integtest/3ru_1df_multirun_test.py
+++ b/integtest/3ru_1df_multirun_test.py
@@ -105,7 +105,7 @@ print(f"{resval_debug_string}")
 
 # The next three variable declarations *must* be present as globals in the test
 # file. They're read by the "fixtures" in conftest.py to determine how
-# to run the config generation and nanorc
+# to run the config generation and dunerc
 
 object_databases = ["config/daqsystemtest/integrationtest-objects.data.xml"]
 
@@ -159,28 +159,28 @@ confgen_arguments = {
     "Software_TPG_System": swtpg_conf,
 }
 
-# The commands to run in nanorc, as a list
-nanorc_command_list = "boot conf".split()
-nanorc_command_list += (
+# The commands to run in dunerc, as a list
+dunerc_command_list = "boot conf".split()
+dunerc_command_list += (
     "start --run-number 101 wait 5 enable-triggers wait ".split()
     + [str(run_duration)]
     + "disable-triggers wait 1 drain-dataflow wait 2 stop-trigger-sources wait 1 stop wait 2".split()
 )
-nanorc_command_list += (
+dunerc_command_list += (
     "start --run-number 102 wait 1 enable-triggers wait ".split()
     + [str(run_duration)]
     + "disable-triggers wait 1 drain-dataflow wait 2 stop-trigger-sources wait 1 stop wait 2".split()
 )
-nanorc_command_list += (
+dunerc_command_list += (
     "start --run-number 103 wait 1 enable-triggers wait ".split()
     + [str(run_duration)]
     + "disable-triggers wait 1 drain-dataflow wait 2 stop-trigger-sources wait 1 stop wait 2".split()
 )
-nanorc_command_list += "scrap terminate".split()
+dunerc_command_list += "scrap terminate".split()
 
 # The tests themselves
 
-def test_nanorc_success(run_nanorc):
+def test_dunerc_success(run_dunerc):
     # print the name of the current test
     current_test = os.environ.get("PYTEST_CURRENT_TEST")
     match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
@@ -191,23 +191,23 @@ def test_nanorc_success(run_nanorc):
     print(current_test)
     print(banner_line)
 
-    # Check that nanorc completed correctly
-    assert run_nanorc.completed_process.returncode == 0
+    # Check that dunerc completed correctly
+    assert run_dunerc.completed_process.returncode == 0
 
 
-def test_log_files(run_nanorc):
+def test_log_files(run_dunerc):
     if check_for_logfile_errors:
         # Check that there are no warnings or errors in the log files
         assert log_file_checks.logs_are_error_free(
-            run_nanorc.log_files, True, True, ignored_logfile_problems
+            run_dunerc.log_files, True, True, ignored_logfile_problems
         )
 
 
-def test_data_files(run_nanorc):
+def test_data_files(run_dunerc):
     local_expected_event_count = expected_event_count
     local_event_count_tolerance = expected_event_count_tolerance
     fragment_check_list = [triggercandidate_frag_params, hsi_frag_params, wibeth_frag_params]
-    if run_nanorc.confgen_config.tpg_enabled:
+    if run_dunerc.confgen_config.tpg_enabled:
         local_expected_event_count += (
             (6250 / ta_prescale)
             * number_of_data_producers
@@ -226,11 +226,11 @@ def test_data_files(run_nanorc):
         fragment_check_list.append(triggeractivity_frag_params)
 
     # Run some tests on the output data file
-    assert len(run_nanorc.data_files) == expected_number_of_data_files
+    assert len(run_dunerc.data_files) == expected_number_of_data_files
 
     all_ok = True
-    for idx in range(len(run_nanorc.data_files)):
-        data_file = data_file_checks.DataFile(run_nanorc.data_files[idx])
+    for idx in range(len(run_dunerc.data_files)):
+        data_file = data_file_checks.DataFile(run_dunerc.data_files[idx])
         all_ok &= data_file_checks.sanity_check(data_file)
         all_ok &= data_file_checks.check_file_attributes(data_file)
         all_ok &= data_file_checks.check_event_count(

--- a/integtest/3ru_3df_multirun_test.py
+++ b/integtest/3ru_3df_multirun_test.py
@@ -131,7 +131,7 @@ print(f"{resval_debug_string}")
 #
 # The next three variable declarations *must* be present as globals in the test
 # file. They're read by the "fixtures" in conftest.py to determine how
-# to run the config generation and nanorc
+# to run the config generation and dunerc
 
 object_databases = ["config/daqsystemtest/integrationtest-objects.data.xml"]
 
@@ -186,29 +186,29 @@ process_manager_choices = {
 #   "ParamikoClient_PM" : {"pm_type": "ssh-standalone-paramiko-client"},
 }
 
-# The commands to run in nanorc, as a list
-nanorc_command_list = "boot conf".split()
-nanorc_command_list += (
+# The commands to run in dunerc, as a list
+dunerc_command_list = "boot conf".split()
+dunerc_command_list += (
     "start --run-number 101 wait 5 enable-triggers wait ".split()
     + [str(run_duration)]
     + "disable-triggers wait 1 drain-dataflow wait 2 stop-trigger-sources wait 1 stop wait 2".split()
 )
-nanorc_command_list += (
+dunerc_command_list += (
     "start --run-number 102 wait 1 enable-triggers wait ".split()
     + [str(run_duration)]
     + "disable-triggers wait 1 drain-dataflow wait 2 stop-trigger-sources wait 1 stop wait 2".split()
 )
-nanorc_command_list += (
+dunerc_command_list += (
     "start --run-number 103 wait 1 enable-triggers wait ".split()
     + [str(run_duration)]
     + "disable-triggers wait 1 drain-dataflow wait 2 stop-trigger-sources wait 1 stop wait 2".split()
 )
-nanorc_command_list += "scrap terminate".split()
+dunerc_command_list += "scrap terminate".split()
 
 # The tests themselves
 
 
-def test_nanorc_success(run_nanorc):
+def test_dunerc_success(run_dunerc):
     # print the name of the current test
     current_test = os.environ.get("PYTEST_CURRENT_TEST")
     match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
@@ -219,25 +219,25 @@ def test_nanorc_success(run_nanorc):
     print(current_test)
     print(banner_line)
 
-    # Check that nanorc completed correctly
-    assert run_nanorc.completed_process.returncode == 0
+    # Check that dunerc completed correctly
+    assert run_dunerc.completed_process.returncode == 0
 
 
-def test_log_files(run_nanorc):
+def test_log_files(run_dunerc):
     if check_for_logfile_errors:
         # Check that there are no warnings or errors in the log files
         assert log_file_checks.logs_are_error_free(
-            run_nanorc.log_files, True, True, ignored_logfile_problems
+            run_dunerc.log_files, True, True, ignored_logfile_problems
         )
 
 
-def test_data_files(run_nanorc):
+def test_data_files(run_dunerc):
     local_expected_event_count = expected_event_count
     local_event_count_tolerance = expected_event_count_tolerance
     low_number_of_files = expected_number_of_data_files
     high_number_of_files = expected_number_of_data_files
     fragment_check_list = [triggercandidate_frag_params, hsi_frag_params, wibeth_frag_params]
-    if run_nanorc.confgen_config.tpg_enabled:
+    if run_dunerc.confgen_config.tpg_enabled:
         local_expected_event_count += (
             (6250 / ta_prescale)
             * number_of_data_producers
@@ -262,13 +262,13 @@ def test_data_files(run_nanorc):
 
     # Run some tests on the output data file
     assert (
-        len(run_nanorc.data_files) == high_number_of_files
-        or len(run_nanorc.data_files) == low_number_of_files
+        len(run_dunerc.data_files) == high_number_of_files
+        or len(run_dunerc.data_files) == low_number_of_files
     )
 
     all_ok = True
-    for idx in range(len(run_nanorc.data_files)):
-        data_file = data_file_checks.DataFile(run_nanorc.data_files[idx])
+    for idx in range(len(run_dunerc.data_files)):
+        data_file = data_file_checks.DataFile(run_dunerc.data_files[idx])
         all_ok &= data_file_checks.sanity_check(data_file)
         all_ok &= data_file_checks.check_file_attributes(data_file)
         all_ok &= data_file_checks.check_event_count(

--- a/integtest/README.md
+++ b/integtest/README.md
@@ -6,7 +6,7 @@
 Here is a sample command for invoking a test (feel free to keep or drop the options in brackets, as you prefer):
 
 ```
-pytest -s minimal_system_quick_test.py [--nanorc-option log-level debug]  # this nanorc option is still useful even when using drunc
+pytest -s minimal_system_quick_test.py [--dunerc-option log-level debug]  # this dunerc option is still useful even when using drunc
 ```
 
 The "-k" pytest option can be used ro selectively run a subset of the configurations in one of our integtest files.  For example:

--- a/integtest/example_system_test.py
+++ b/integtest/example_system_test.py
@@ -137,8 +137,8 @@ else:
         "Local 2x3 Conf": twobythree_local_conf,
     }
 
-# The commands to run in nanorc, as a list
-nanorc_command_list = (
+# The commands to run in dunerc, as a list
+dunerc_command_list = (
     "boot wait 2 conf start --run-number 101 wait 1 enable-triggers wait ".split()
     + [str(run_duration)]
     + "disable-triggers wait 2 drain-dataflow wait 2 stop-trigger-sources stop scrap terminate".split()
@@ -147,7 +147,7 @@ nanorc_command_list = (
 # The tests themselves
 
 
-def test_nanorc_success(run_nanorc):
+def test_dunerc_success(run_dunerc):
     # print the name of the current test
     current_test = os.environ.get("PYTEST_CURRENT_TEST")
     match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
@@ -163,45 +163,45 @@ def test_nanorc_success(run_nanorc):
             f"This computer ({hostname}) is not at EHN1, not running EHN1 sessions"
         )
 
-    # Check that nanorc completed correctly
-    assert run_nanorc.completed_process.returncode == 0
+    # Check that dunerc completed correctly
+    assert run_dunerc.completed_process.returncode == 0
 
 
-def test_log_files(run_nanorc):
+def test_log_files(run_dunerc):
     current_test = os.environ.get("PYTEST_CURRENT_TEST")
     if not host_is_at_ehn1(hostname) and "EHN1" in current_test:
         pytest.skip(
             f"This computer ({hostname}) is not at EHN1, not running EHN1 sessions"
         )
 
-    session_name = run_nanorc.session_name if run_nanorc.session_name is not None else run_nanorc.session
+    session_name = run_dunerc.session_name if run_dunerc.session_name is not None else run_dunerc.session
     if host_is_at_ehn1(hostname) and "EHN1" in current_test:
         log_dir = pathlib.Path("/log")
-        run_nanorc.log_files += list(log_dir.glob(f"log_*_{session_name}*.txt"))
+        run_dunerc.log_files += list(log_dir.glob(f"log_*_{session_name}*.txt"))
 
     # Check that at least some of the expected log files are present
     assert any(
         f"{session_name}_df-01" in str(logname)
-        for logname in run_nanorc.log_files
+        for logname in run_dunerc.log_files
     )
     assert any(
-        f"{session_name}_dfo" in str(logname) for logname in run_nanorc.log_files
+        f"{session_name}_dfo" in str(logname) for logname in run_dunerc.log_files
     )
     assert any(
-        f"{session_name}_mlt" in str(logname) for logname in run_nanorc.log_files
+        f"{session_name}_mlt" in str(logname) for logname in run_dunerc.log_files
     )
     assert any(
-        f"{session_name}_ru" in str(logname) for logname in run_nanorc.log_files
+        f"{session_name}_ru" in str(logname) for logname in run_dunerc.log_files
     )
 
     if check_for_logfile_errors:
         # Check that there are no warnings or errors in the log files
         assert log_file_checks.logs_are_error_free(
-            run_nanorc.log_files, True, True, ignored_logfile_problems
+            run_dunerc.log_files, True, True, ignored_logfile_problems
         )
 
 
-def test_data_files(run_nanorc):
+def test_data_files(run_dunerc):
     current_test = os.environ.get("PYTEST_CURRENT_TEST")
     if not host_is_at_ehn1(hostname) and "EHN1" in current_test:
         pytest.skip(
@@ -224,7 +224,7 @@ def test_data_files(run_nanorc):
     assert expected_file_count != 0,f"Unable to locate test parameters for {current_test}"
 
     # Run some tests on the output data file
-    assert len(run_nanorc.data_files) == expected_file_count, f"Unexpected file count: Actual: {len(run_nanorc.data_files)}, Expected: {expected_file_count}"
+    assert len(run_dunerc.data_files) == expected_file_count, f"Unexpected file count: Actual: {len(run_dunerc.data_files)}, Expected: {expected_file_count}"
 
     local_expected_fragment_count = expected_fragment_count
     wibeth_frag_params["expected_fragment_count"] = local_expected_fragment_count
@@ -254,8 +254,8 @@ def test_data_files(run_nanorc):
 
     all_ok = True
 
-    for idx in range(len(run_nanorc.data_files)):
-        data_file = data_file_checks.DataFile(run_nanorc.data_files[idx])
+    for idx in range(len(run_dunerc.data_files)):
+        data_file = data_file_checks.DataFile(run_dunerc.data_files[idx])
         all_ok &= data_file_checks.sanity_check(data_file)
         all_ok &= data_file_checks.check_file_attributes(data_file)
         all_ok &= data_file_checks.check_event_count(

--- a/integtest/fake_data_producer_test.py
+++ b/integtest/fake_data_producer_test.py
@@ -63,7 +63,7 @@ print(f"{resval_debug_string}")
 
 # The next three variable declarations *must* be present as globals in the test
 # file. They're read by the "fixtures" in conftest.py to determine how
-# to run the config generation and nanorc
+# to run the config generation and dunerc
 
 object_databases = ["config/daqsystemtest/integrationtest-objects.data.xml"]
 
@@ -101,29 +101,29 @@ confgen_arguments = {
     "Double_Window_Size": doublewindow_conf,
 }
 
-# The commands to run in nanorc, as a list
-nanorc_command_list = "boot conf".split()
-nanorc_command_list += (
+# The commands to run in dunerc, as a list
+dunerc_command_list = "boot conf".split()
+dunerc_command_list += (
     "start --run-number 101 wait 5 enable-triggers wait ".split()
     + [str(run_duration)]
     + "disable-triggers wait 1 drain-dataflow wait 2 stop-trigger-sources wait 1 stop wait 2".split()
 )
-nanorc_command_list += (
+dunerc_command_list += (
     "start --run-number 102 wait 1 enable-triggers wait ".split()
     + [str(run_duration)]
     + "disable-triggers wait 1 drain-dataflow wait 2 stop-trigger-sources wait 1 stop wait 2".split()
 )
-nanorc_command_list += (
+dunerc_command_list += (
     "start --run-number 103 wait 1 enable-triggers wait ".split()
     + [str(run_duration)]
     + "disable-triggers wait 1 drain-dataflow wait 2 stop-trigger-sources wait 1 stop wait 2".split()
 )
-nanorc_command_list += "scrap terminate".split()
+dunerc_command_list += "scrap terminate".split()
 
 
 # The tests themselves
 
-def test_nanorc_success(run_nanorc):
+def test_dunerc_success(run_dunerc):
     # print the name of the current test
     current_test = os.environ.get("PYTEST_CURRENT_TEST")
     match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
@@ -134,19 +134,19 @@ def test_nanorc_success(run_nanorc):
     print(current_test)
     print(banner_line)
 
-    # Check that nanorc completed correctly
-    assert run_nanorc.completed_process.returncode == 0
+    # Check that dunerc completed correctly
+    assert run_dunerc.completed_process.returncode == 0
 
 
-def test_log_files(run_nanorc):
+def test_log_files(run_dunerc):
     if check_for_logfile_errors:
         # Check that there are no warnings or errors in the log files
         assert log_file_checks.logs_are_error_free(
-            run_nanorc.log_files, True, True, ignored_logfile_problems
+            run_dunerc.log_files, True, True, ignored_logfile_problems
         )
 
 
-def test_data_files(run_nanorc):
+def test_data_files(run_dunerc):
     local_expected_event_count = expected_event_count
     local_event_count_tolerance = expected_event_count_tolerance
     frag_params = wibeth_frag_params
@@ -164,15 +164,15 @@ def test_data_files(run_nanorc):
 
     # Run some tests on the output data file
     all_ok = True
-    all_ok &= len(run_nanorc.data_files) == expected_number_of_data_files
+    all_ok &= len(run_dunerc.data_files) == expected_number_of_data_files
     print("") # Clear potential dot from pytest
     if all_ok:
         print(f"\N{WHITE HEAVY CHECK MARK} The correct number of raw data files was found ({expected_number_of_data_files})")
     else:
-        print(f"\N{POLICE CARS REVOLVING LIGHT} An incorrect number of raw data files was found, expected {expected_number_of_data_files}, found {len(run_nanorc.data_files)} \N{POLICE CARS REVOLVING LIGHT}")
+        print(f"\N{POLICE CARS REVOLVING LIGHT} An incorrect number of raw data files was found, expected {expected_number_of_data_files}, found {len(run_dunerc.data_files)} \N{POLICE CARS REVOLVING LIGHT}")
 
-    for idx in range(len(run_nanorc.data_files)):
-        data_file = data_file_checks.DataFile(run_nanorc.data_files[idx])
+    for idx in range(len(run_dunerc.data_files)):
+        data_file = data_file_checks.DataFile(run_dunerc.data_files[idx])
         all_ok &= data_file_checks.sanity_check(data_file)
         all_ok &= data_file_checks.check_file_attributes(data_file)
         all_ok &= data_file_checks.check_event_count(

--- a/integtest/long_window_readout_test.py
+++ b/integtest/long_window_readout_test.py
@@ -90,7 +90,7 @@ print(f"{resval_debug_string}")
 
 # The next three variable declarations *must* be present as globals in the test
 # file. They're read by the "fixtures" in conftest.py to determine how
-# to run the config generation and nanorc
+# to run the config generation and dunerc
 
 object_databases = ["config/daqsystemtest/integrationtest-objects.data.xml"]
 
@@ -172,28 +172,28 @@ confgen_arguments = {  # "No_TR_Splitting": conf_dict,
     "With_TR_Splitting": trsplit_conf,
 }
 
-# The commands to run in nanorc, as a list
-nanorc_command_list = "boot conf".split()
-nanorc_command_list += (
+# The commands to run in dunerc, as a list
+dunerc_command_list = "boot conf".split()
+dunerc_command_list += (
     "start --trigger-rate ".split()
     + [str(trigger_rate)]
     + "--run-number 101 wait 15 enable-triggers wait ".split()
     + [str(run_duration)]
     + "disable-triggers wait 2 drain-dataflow wait 2 stop-trigger-sources stop wait 2".split()
 )
-nanorc_command_list += (
+dunerc_command_list += (
     "start --trigger-rate ".split()
     + [str(trigger_rate)]
     + "--run-number 102 wait 15 enable-triggers wait ".split()
     + [str(run_duration)]
     + "disable-triggers wait 2 drain-dataflow wait 2 stop-trigger-sources stop wait 2".split()
 )
-nanorc_command_list += "scrap terminate".split()
+dunerc_command_list += "scrap terminate".split()
 
 # The tests themselves
 
 
-def test_nanorc_success(run_nanorc):
+def test_dunerc_success(run_dunerc):
     # print the name of the current test
     current_test = os.environ.get("PYTEST_CURRENT_TEST")
     match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
@@ -204,19 +204,19 @@ def test_nanorc_success(run_nanorc):
     print(current_test)
     print(banner_line)
 
-    # Check that nanorc completed correctly
-    assert run_nanorc.completed_process.returncode == 0
+    # Check that dunerc completed correctly
+    assert run_dunerc.completed_process.returncode == 0
 
 
-def test_log_files(run_nanorc):
+def test_log_files(run_dunerc):
     if check_for_logfile_errors:
         # Check that there are no warnings or errors in the log files
         assert log_file_checks.logs_are_error_free(
-            run_nanorc.log_files, True, True, ignored_logfile_problems
+            run_dunerc.log_files, True, True, ignored_logfile_problems
         )
 
 
-def test_data_files(run_nanorc):
+def test_data_files(run_dunerc):
     local_expected_event_count = expected_event_count
     local_event_count_tolerance = expected_event_count_tolerance
     fragment_check_list = [triggercandidate_frag_params]
@@ -224,15 +224,15 @@ def test_data_files(run_nanorc):
 
     all_ok = True
     # Run some tests on the output data file
-    all_ok &= len(run_nanorc.data_files) == expected_number_of_data_files
+    all_ok &= len(run_dunerc.data_files) == expected_number_of_data_files
     print("") # Clear potential dot from pytest
     if all_ok:
         print(f"\N{WHITE HEAVY CHECK MARK} The correct number of raw data files was found ({expected_number_of_data_files})")
     else:
-        print(f"\N{POLICE CARS REVOLVING LIGHT} An incorrect number of raw data files was found, expected {expected_number_of_data_files}, found {len(run_nanorc.data_files)} \N{POLICE CARS REVOLVING LIGHT}")
+        print(f"\N{POLICE CARS REVOLVING LIGHT} An incorrect number of raw data files was found, expected {expected_number_of_data_files}, found {len(run_dunerc.data_files)} \N{POLICE CARS REVOLVING LIGHT}")
 
-    for idx in range(len(run_nanorc.data_files)):
-        data_file = data_file_checks.DataFile(run_nanorc.data_files[idx])
+    for idx in range(len(run_dunerc.data_files)):
+        data_file = data_file_checks.DataFile(run_dunerc.data_files[idx])
         all_ok &= data_file_checks.sanity_check(data_file)
         all_ok &= data_file_checks.check_file_attributes(data_file)
         all_ok &= data_file_checks.check_event_count(
@@ -248,10 +248,10 @@ def test_data_files(run_nanorc):
     assert all_ok, "\N{POLICE CARS REVOLVING LIGHT} One or more data file checks failed! \N{POLICE CARS REVOLVING LIGHT}"
 
 
-def test_cleanup(run_nanorc):
+def test_cleanup(run_dunerc):
     pathlist_string = ""
     filelist_string = ""
-    for data_file in run_nanorc.data_files:
+    for data_file in run_dunerc.data_files:
         filelist_string += " " + str(data_file)
         if str(data_file.parent) not in pathlist_string:
             pathlist_string += " " + str(data_file.parent)
@@ -265,7 +265,7 @@ def test_cleanup(run_nanorc):
         print("--------------------")
         os.system(f"ls -alF {filelist_string}")
 
-        for data_file in run_nanorc.data_files:
+        for data_file in run_dunerc.data_files:
             data_file.unlink()
 
         print("--------------------")

--- a/integtest/minimal_system_quick_test.py
+++ b/integtest/minimal_system_quick_test.py
@@ -70,7 +70,7 @@ print(f"{resval_debug_string}")
 
 # The next three variable declarations *must* be present as globals in the test
 # file. They're read by the "fixtures" in conftest.py to determine how
-# to run the config generation and nanorc
+# to run the config generation and dunerc
 
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)
@@ -108,8 +108,8 @@ conf_dict.config_substitutions.append(substitution)
 
 
 confgen_arguments = {"MinimalSystem": conf_dict}
-# The commands to run in nanorc, as a list
-nanorc_command_list = (
+# The commands to run in dunerc, as a list
+dunerc_command_list = (
     "boot conf start --run-number 101 wait 1 enable-triggers wait ".split()
     + [str(run_duration)]
     + "disable-triggers wait 2 drain-dataflow wait 2 stop-trigger-sources stop scrap terminate".split()
@@ -118,7 +118,7 @@ nanorc_command_list = (
 # The tests themselves
 
 
-def test_nanorc_success(run_nanorc):
+def test_dunerc_success(run_dunerc):
     # print the name of the current test
     current_test = os.environ.get("PYTEST_CURRENT_TEST")
     match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
@@ -129,48 +129,48 @@ def test_nanorc_success(run_nanorc):
     print(current_test)
     print(banner_line)
 
-    # Check that nanorc completed correctly
-    assert run_nanorc.completed_process.returncode == 0
+    # Check that dunerc completed correctly
+    assert run_dunerc.completed_process.returncode == 0
 
 
-def test_log_files(run_nanorc):
+def test_log_files(run_dunerc):
     # Check that at least some of the expected log files are present
     assert any(
-        f"{run_nanorc.session}_df-01" in str(logname)
-        for logname in run_nanorc.log_files
+        f"{run_dunerc.session}_df-01" in str(logname)
+        for logname in run_dunerc.log_files
     )
     assert any(
-        f"{run_nanorc.session}_dfo" in str(logname) for logname in run_nanorc.log_files
+        f"{run_dunerc.session}_dfo" in str(logname) for logname in run_dunerc.log_files
     )
     assert any(
-        f"{run_nanorc.session}_mlt" in str(logname) for logname in run_nanorc.log_files
+        f"{run_dunerc.session}_mlt" in str(logname) for logname in run_dunerc.log_files
     )
     assert any(
-        f"{run_nanorc.session}_ru" in str(logname) for logname in run_nanorc.log_files
+        f"{run_dunerc.session}_ru" in str(logname) for logname in run_dunerc.log_files
     )
 
     if check_for_logfile_errors:
         # Check that there are no warnings or errors in the log files
         assert log_file_checks.logs_are_error_free(
-            run_nanorc.log_files, True, True, ignored_logfile_problems
+            run_dunerc.log_files, True, True, ignored_logfile_problems
         )
 
 
-def test_data_files(run_nanorc):
+def test_data_files(run_dunerc):
     # Run some tests on the output data file
-    all_ok = len(run_nanorc.data_files) == expected_number_of_data_files
+    all_ok = len(run_dunerc.data_files) == expected_number_of_data_files
     print("") # Clear potential dot from pytest
     if all_ok:
         print(f"\N{WHITE HEAVY CHECK MARK} The correct number of raw data files was found ({expected_number_of_data_files})")
     else:
-        print(f"\N{POLICE CARS REVOLVING LIGHT} An incorrect number of raw data files was found, expected {expected_number_of_data_files}, found {len(run_nanorc.data_files)} \N{POLICE CARS REVOLVING LIGHT}")
+        print(f"\N{POLICE CARS REVOLVING LIGHT} An incorrect number of raw data files was found, expected {expected_number_of_data_files}, found {len(run_dunerc.data_files)} \N{POLICE CARS REVOLVING LIGHT}")
 
     fragment_check_list = [triggercandidate_frag_params, hsi_frag_params]
     fragment_check_list.append(wibeth_frag_params)
     nontrig_fragment_check_list = [hsi_frag_params, wibeth_frag_params]
 
-    for idx in range(len(run_nanorc.data_files)):
-        data_file = data_file_checks.DataFile(run_nanorc.data_files[idx])
+    for idx in range(len(run_dunerc.data_files)):
+        data_file = data_file_checks.DataFile(run_dunerc.data_files[idx])
         all_ok &= data_file_checks.sanity_check(data_file)
         all_ok &= data_file_checks.check_file_attributes(data_file)
         all_ok &= data_file_checks.check_event_count(
@@ -190,7 +190,7 @@ def test_data_files(run_nanorc):
 
 
 # 26-Nov-2025, KAB: added some sample opmon metric checks, for demonstration purposes
-def test_metric_files(run_nanorc):
+def test_metric_files(run_dunerc):
     print("") # Clear potential dot from pytest
 
     # 10-Dec-2025, KAB: we have noticed that sometimes drunc transitions (or other parts of
@@ -216,17 +216,17 @@ def test_metric_files(run_nanorc):
     # We'll set the maximum allowed sample count slightly higher than the expected value.
     max_metric_sample_count = expected_metric_sample_count + 2
     try:
-        #print(f"\nDAQ session overall time: {run_nanorc.daq_session_overall_time} seconds")
-        if run_nanorc.daq_session_overall_time is not None:
-            extra_time_taken = run_nanorc.daq_session_overall_time - expected_daq_session_time
+        #print(f"\nDAQ session overall time: {run_dunerc.daq_session_overall_time} seconds")
+        if run_dunerc.daq_session_overall_time is not None:
+            extra_time_taken = run_dunerc.daq_session_overall_time - expected_daq_session_time
             if extra_time_taken > 10:
                 extra_sample_count_allowance = int(extra_time_taken / 10)
                 max_metric_sample_count += extra_sample_count_allowance
     except AttributeError:
         pass
 
-    session_name = run_nanorc.session_name if run_nanorc.session_name else run_nanorc.session
-    metric_data = opmon_metric_checks.collate_opmon_data_from_files(run_nanorc.opmon_files)
+    session_name = run_dunerc.session_name if run_dunerc.session_name else run_dunerc.session
+    metric_data = opmon_metric_checks.collate_opmon_data_from_files(run_dunerc.opmon_files)
 
     metric_key_list = [session_name, "df-01", "df-01-trb", "dfmodules.TRBInfo", "generated_trigger_records"]
     all_ok = True

--- a/integtest/readout_type_scan_test.py
+++ b/integtest/readout_type_scan_test.py
@@ -151,7 +151,7 @@ print(f"{resval_debug_string}")
 
 # The next three variable declarations *must* be present as globals in the test
 # file. They're read by the "fixtures" in conftest.py to determine how
-# to run the config generation and nanorc
+# to run the config generation and dunerc
 
 object_databases = ["config/daqsystemtest/integrationtest-objects.data.xml"]
 
@@ -300,8 +300,8 @@ confgen_arguments = {
     "GrenobleCRT_System": grenoble_crt_conf
 }
 
-# The commands to run in nanorc, as a list
-nanorc_command_list = (
+# The commands to run in dunerc, as a list
+dunerc_command_list = (
     "boot conf start --run-number 101 wait 2 enable-triggers wait ".split()
     + [str(run_duration)]
     + "disable-triggers wait 2 drain-dataflow stop-trigger-sources wait 2 stop scrap terminate".split()
@@ -311,7 +311,7 @@ nanorc_command_list = (
 
 # The tests themselves
 
-def test_nanorc_success(run_nanorc):
+def test_dunerc_success(run_dunerc):
     # print the name of the current test
     current_test = os.environ.get("PYTEST_CURRENT_TEST")
     match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
@@ -322,19 +322,19 @@ def test_nanorc_success(run_nanorc):
     print(current_test)
     print(banner_line)
 
-    # Check that nanorc completed correctly
-    assert run_nanorc.completed_process.returncode == 0
+    # Check that dunerc completed correctly
+    assert run_dunerc.completed_process.returncode == 0
 
 
-def test_log_files(run_nanorc):
+def test_log_files(run_dunerc):
     if check_for_logfile_errors:
         # Check that there are no warnings or errors in the log files
         assert log_file_checks.logs_are_error_free(
-            run_nanorc.log_files, True, True, ignored_logfile_problems
+            run_dunerc.log_files, True, True, ignored_logfile_problems
         )
 
 
-def test_data_files(run_nanorc):
+def test_data_files(run_dunerc):
     local_expected_event_count = expected_event_count
     local_event_count_tolerance = expected_event_count_tolerance
     fragment_check_list = [triggercandidate_frag_params]
@@ -351,7 +351,7 @@ def test_data_files(run_nanorc):
         fragment_check_list.append(bern_crt_frag_params)
     elif "GrenobleCRT" in current_test:
         fragment_check_list.append(grenoble_crt_frag_params)
-    if run_nanorc.confgen_config.tpg_enabled:
+    if run_dunerc.confgen_config.tpg_enabled:
         fragment_check_list.append(triggeractivity_frag_params)
         if "WIBEth" in current_test:
             fragment_check_list.append(wibeth_triggerprimitive_frag_params)
@@ -392,15 +392,15 @@ def test_data_files(run_nanorc):
 
     # Run some tests on the output data file
     all_ok = True
-    all_ok &= len(run_nanorc.data_files) == expected_number_of_data_files
+    all_ok &= len(run_dunerc.data_files) == expected_number_of_data_files
     print("") # Clear potential dot from pytest
     if all_ok:
         print(f"\N{WHITE HEAVY CHECK MARK} The correct number of raw data files was found ({expected_number_of_data_files})")
     else:
-        print(f"\N{POLICE CARS REVOLVING LIGHT} An incorrect number of raw data files was found, expected {expected_number_of_data_files}, found {len(run_nanorc.data_files)} \N{POLICE CARS REVOLVING LIGHT}")
+        print(f"\N{POLICE CARS REVOLVING LIGHT} An incorrect number of raw data files was found, expected {expected_number_of_data_files}, found {len(run_dunerc.data_files)} \N{POLICE CARS REVOLVING LIGHT}")
 
-    for idx in range(len(run_nanorc.data_files)):
-        data_file = data_file_checks.DataFile(run_nanorc.data_files[idx])
+    for idx in range(len(run_dunerc.data_files)):
+        data_file = data_file_checks.DataFile(run_dunerc.data_files[idx])
         all_ok &= data_file_checks.sanity_check(data_file)
         all_ok &= data_file_checks.check_file_attributes(data_file)
         all_ok &= data_file_checks.check_event_count(

--- a/integtest/sample_ehn1_multihost_test.py
+++ b/integtest/sample_ehn1_multihost_test.py
@@ -283,20 +283,20 @@ ehn1_multihost_1x1_conf.connsvc_port = 0  # random
 confgen_arguments = {"EHN1 MultiHost 1x1 Conf": ehn1_multihost_1x1_conf}
 
 
-# The commands to run in nanorc, as a list
+# The commands to run in dunerc, as a list
 if len(computers_that_are_unreachable) == 0 and pytest_tmpdir_looks_reasonable:
-    nanorc_command_list = (
+    dunerc_command_list = (
         "boot wait 2 conf start --run-number 101 wait 1 enable-triggers wait ".split()
         + [str(run_duration)]
         + "disable-triggers wait 2 drain-dataflow wait 2 stop-trigger-sources stop scrap terminate".split()
     )
 else:
-    nanorc_command_list = ["wait", "1"]
+    dunerc_command_list = ["wait", "1"]
 
 # The tests themselves
 
 
-def test_nanorc_success(run_nanorc, capsys):
+def test_dunerc_success(run_dunerc, capsys):
     if len(computers_that_are_unreachable) > 0:
         with capsys.disabled():
             print(f"\n\n\N{LARGE YELLOW CIRCLE} The following computers are needed for this test but are unreachable from this computer ({hostname}) via ssh:")
@@ -318,7 +318,7 @@ def test_nanorc_success(run_nanorc, capsys):
         print("*** WARNING: the cleanup of stale _gunicorn_ process on np04-srv-028 did not succeed...")
 
     current_test = os.environ.get("PYTEST_CURRENT_TEST")
-    match_obj = re.search(r".*\[(.+)-run_nanorc0\].*", current_test)
+    match_obj = re.search(r".*\[(.+)-run_dunerc0\].*", current_test)
     if match_obj:
         current_test = match_obj.group(1)
     banner_line = re.sub(".", "=", current_test)
@@ -326,40 +326,40 @@ def test_nanorc_success(run_nanorc, capsys):
     print(current_test)
     print(banner_line)
 
-    # Check that nanorc completed correctly
-    assert run_nanorc.completed_process.returncode == 0
+    # Check that dunerc completed correctly
+    assert run_dunerc.completed_process.returncode == 0
 
 
-def test_log_files(run_nanorc):
+def test_log_files(run_dunerc):
     if len(computers_that_are_unreachable) > 0:
         pytest.skip(f"One or more needed computers are unreachable ({computers_that_are_unreachable}).")
     if not pytest_tmpdir_looks_reasonable:
         pytest.skip("The PYTEST_DEBUG_TEMPROOT env var has not been set to point to a valid directory.")
 
     # Check that at least some of the expected log files are present
-    session_name = run_nanorc.session_name if run_nanorc.session_name is not None else run_nanorc.session
+    session_name = run_dunerc.session_name if run_dunerc.session_name is not None else run_dunerc.session
     assert any(
         f"{session_name}_df-01" in str(logname)
-        for logname in run_nanorc.log_files
+        for logname in run_dunerc.log_files
     )
     assert any(
-        f"{session_name}_dfo" in str(logname) for logname in run_nanorc.log_files
+        f"{session_name}_dfo" in str(logname) for logname in run_dunerc.log_files
     )
     assert any(
-        f"{session_name}_mlt" in str(logname) for logname in run_nanorc.log_files
+        f"{session_name}_mlt" in str(logname) for logname in run_dunerc.log_files
     )
     assert any(
-        f"{session_name}_ru" in str(logname) for logname in run_nanorc.log_files
+        f"{session_name}_ru" in str(logname) for logname in run_dunerc.log_files
     )
 
     if check_for_logfile_errors:
         # Check that there are no warnings or errors in the log files
         assert log_file_checks.logs_are_error_free(
-            run_nanorc.log_files, True, True, ignored_logfile_problems
+            run_dunerc.log_files, True, True, ignored_logfile_problems
         )
 
 
-def test_data_files(run_nanorc):
+def test_data_files(run_dunerc):
     if len(computers_that_are_unreachable) > 0:
         pytest.skip(f"One or more needed computers are unreachable ({computers_that_are_unreachable}).")
     if not pytest_tmpdir_looks_reasonable:
@@ -379,7 +379,7 @@ def test_data_files(run_nanorc):
     assert expected_file_count != 0,f"Unable to locate test parameters for {current_test}"
 
     # Run some tests on the output data file
-    assert len(run_nanorc.data_files) == expected_file_count, f"Unexpected file count: Actual: {len(run_nanorc.data_files)}, Expected: {expected_file_count}"
+    assert len(run_dunerc.data_files) == expected_file_count, f"Unexpected file count: Actual: {len(run_dunerc.data_files)}, Expected: {expected_file_count}"
 
     local_expected_fragment_count = expected_fragment_count
     wibeth_frag_params["expected_fragment_count"] = local_expected_fragment_count
@@ -409,8 +409,8 @@ def test_data_files(run_nanorc):
 
     all_ok = True
 
-    for idx in range(len(run_nanorc.data_files)):
-        data_file = data_file_checks.DataFile(run_nanorc.data_files[idx])
+    for idx in range(len(run_dunerc.data_files)):
+        data_file = data_file_checks.DataFile(run_dunerc.data_files[idx])
         all_ok &= data_file_checks.sanity_check(data_file)
         all_ok &= data_file_checks.check_file_attributes(data_file)
         all_ok &= data_file_checks.check_event_count(
@@ -427,13 +427,13 @@ def test_data_files(run_nanorc):
     assert all_ok
 
 
-def test_tpstream_files(run_nanorc):
+def test_tpstream_files(run_dunerc):
     if len(computers_that_are_unreachable) > 0:
         pytest.skip(f"One or more needed computers are unreachable ({computers_that_are_unreachable}).")
     if not pytest_tmpdir_looks_reasonable:
         pytest.skip("The PYTEST_DEBUG_TEMPROOT env var has not been set to point to a valid directory.")
 
-    tpstream_files = run_nanorc.tpset_files
+    tpstream_files = run_dunerc.tpset_files
     local_expected_event_count = (
         run_duration + 8
     )  # TPStreamWriterModule is currently configured to write at 1 Hz, addl TimeSlices expected because of wait times in drunc command list

--- a/integtest/small_footprint_quick_test.py
+++ b/integtest/small_footprint_quick_test.py
@@ -70,7 +70,7 @@ print(f"{resval_debug_string}")
 
 # The next three variable declarations *must* be present as globals in the test
 # file. They're read by the "fixtures" in conftest.py to determine how
-# to run the config generation and nanorc
+# to run the config generation and dunerc
 
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)
@@ -102,8 +102,8 @@ conf_dict.config_substitutions.append(
 )
 confgen_arguments = {"SmallFootprint": conf_dict}
 
-# The commands to run in nanorc, as a list
-nanorc_command_list = (
+# The commands to run in dunerc, as a list
+dunerc_command_list = (
     "boot conf start --run-number 101 wait 1 enable-triggers wait ".split()
     + [str(run_duration)]
     + "disable-triggers wait 2 drain-dataflow stop-trigger-sources stop wait 2 scrap terminate".split()
@@ -112,7 +112,7 @@ nanorc_command_list = (
 # The tests themselves
 
 
-def test_nanorc_success(run_nanorc):
+def test_dunerc_success(run_dunerc):
     # print the name of the current test
     current_test = os.environ.get("PYTEST_CURRENT_TEST")
     match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
@@ -123,28 +123,28 @@ def test_nanorc_success(run_nanorc):
     print(current_test)
     print(banner_line)
 
-    # Check that nanorc completed correctly
-    assert run_nanorc.completed_process.returncode == 0
+    # Check that dunerc completed correctly
+    assert run_dunerc.completed_process.returncode == 0
 
 
-def test_log_files(run_nanorc):
+def test_log_files(run_dunerc):
     if check_for_logfile_errors:
         # Check that there are no warnings or errors in the log files
         assert log_file_checks.logs_are_error_free(
-            run_nanorc.log_files, True, True, ignored_logfile_problems
+            run_dunerc.log_files, True, True, ignored_logfile_problems
         )
 
 
-def test_data_files(run_nanorc):
+def test_data_files(run_dunerc):
     # Run some tests on the output data file
-    assert len(run_nanorc.data_files) == expected_number_of_data_files
+    assert len(run_dunerc.data_files) == expected_number_of_data_files
 
     fragment_check_list = [triggercandidate_frag_params, hsi_frag_params]
     fragment_check_list.append(wibeth_frag_params)  # WIBEth
 
     all_ok = True
-    for idx in range(len(run_nanorc.data_files)):
-        data_file = data_file_checks.DataFile(run_nanorc.data_files[idx])
+    for idx in range(len(run_dunerc.data_files)):
+        data_file = data_file_checks.DataFile(run_dunerc.data_files[idx])
         all_ok &= data_file_checks.sanity_check(data_file)
         all_ok &= data_file_checks.check_file_attributes(data_file)
         all_ok &= data_file_checks.check_event_count(

--- a/integtest/tpg_state_collection_test.py
+++ b/integtest/tpg_state_collection_test.py
@@ -199,8 +199,8 @@ conf_dict.config_substitutions.append(
 
 confgen_arguments = {"Software_TPG_System": conf_dict}
 
-# The commands to run in nanorc, as a list
-nanorc_command_list = (
+# The commands to run in dunerc, as a list
+dunerc_command_list = (
     "boot conf wait 5".split()
     + "start --run-number 101 wait 1 enable-triggers wait ".split()
     + [str(run_duration)]
@@ -214,7 +214,7 @@ nanorc_command_list = (
 # The tests themselves
 
 
-def test_nanorc_success(run_nanorc):
+def test_dunerc_success(run_dunerc):
     # print the name of the current test
     current_test = os.environ.get("PYTEST_CURRENT_TEST")
     match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
@@ -225,19 +225,19 @@ def test_nanorc_success(run_nanorc):
     print(current_test)
     print(banner_line)
 
-    # Check that nanorc completed correctly
-    assert run_nanorc.completed_process.returncode == 0
+    # Check that dunerc completed correctly
+    assert run_dunerc.completed_process.returncode == 0
 
 
-def test_log_files(run_nanorc):
+def test_log_files(run_dunerc):
     if check_for_logfile_errors:
         # Check that there are no warnings or errors in the log files
         assert log_file_checks.logs_are_error_free(
-            run_nanorc.log_files, True, True, ignored_logfile_problems
+            run_dunerc.log_files, True, True, ignored_logfile_problems
         )
 
 
-def test_data_files(run_nanorc):
+def test_data_files(run_dunerc):
     local_expected_event_count = expected_event_count
     local_event_count_tolerance = expected_event_count_tolerance
     low_number_of_files = expected_number_of_data_files
@@ -263,13 +263,13 @@ def test_data_files(run_nanorc):
 
     # Run some tests on the output data file
     assert (
-        len(run_nanorc.data_files) == high_number_of_files
-        or len(run_nanorc.data_files) == low_number_of_files
+        len(run_dunerc.data_files) == high_number_of_files
+        or len(run_dunerc.data_files) == low_number_of_files
     )
 
     all_ok = True
-    for idx in range(len(run_nanorc.data_files)):
-        data_file = data_file_checks.DataFile(run_nanorc.data_files[idx])
+    for idx in range(len(run_dunerc.data_files)):
+        data_file = data_file_checks.DataFile(run_dunerc.data_files[idx])
         all_ok &= data_file_checks.sanity_check(data_file)
         all_ok &= data_file_checks.check_file_attributes(data_file)
         all_ok &= data_file_checks.check_event_count(
@@ -285,8 +285,8 @@ def test_data_files(run_nanorc):
     assert all_ok
 
 
-def test_tpstream_files(run_nanorc):
-    tpstream_files = run_nanorc.tpset_files
+def test_tpstream_files(run_dunerc):
+    tpstream_files = run_dunerc.tpset_files
     local_expected_event_count = (
         run_duration + 8
     )  # TPStreamWriterModule is currently configured to write at 1 Hz, addl TimeSlices expected because of wait times in drunc command list
@@ -315,11 +315,11 @@ def test_tpstream_files(run_nanorc):
 
 # 26-Nov-2025, KAB: added checking of opmon metrics to verify that the ones that are
 # specifically enabled in this test work as expected.
-def test_metric_files(run_nanorc):
+def test_metric_files(run_dunerc):
     print("") # Clear potential dot from pytest
 
-    session_name = run_nanorc.session_name if run_nanorc.session_name else run_nanorc.session
-    metric_data = opmon_metric_checks.collate_opmon_data_from_files(run_nanorc.opmon_files)
+    session_name = run_dunerc.session_name if run_dunerc.session_name else run_dunerc.session
+    metric_data = opmon_metric_checks.collate_opmon_data_from_files(run_dunerc.opmon_files)
 
     all_ok = True
 

--- a/integtest/tpreplay_test.py
+++ b/integtest/tpreplay_test.py
@@ -9,7 +9,7 @@ It does the following:
 1. Creates a temporary configuration DB file (via OKS) for each session.
 2. Populates the config DB with TPStream and SourceID objects.
 3. Customizes runtime configuration through deep config substitutions.
-4. Runs a pre-defined nanorc command sequence (boot → start → stop → terminate).
+4. Runs a pre-defined dunerc command sequence (boot → start → stop → terminate).
 5. Validates:
     - Nanorc command success
     - Presence and correctness of log files
@@ -241,21 +241,21 @@ confgen_arguments = {
   "np04-tpreplay": tpreplay_np04_conf
 }
 
-# The commands to run in nanorc, as a list
-nanorc_command_list = "boot conf wait 5".split()
-nanorc_command_list += (
+# The commands to run in dunerc, as a list
+dunerc_command_list = "boot conf wait 5".split()
+dunerc_command_list += (
     "start ".split()
     + "--run-number 101 enable-triggers wait ".split()
     + [str(run_duration)]
     + "disable-triggers drain-dataflow wait 2 stop-trigger-sources wait 2 stop wait 2".split()
 )
-nanorc_command_list += "scrap terminate".split()
+dunerc_command_list += "scrap terminate".split()
 
 atexit.register(_cleanup_tmpdir)
 
 ### Tests
 # Run control
-def test_nanorc_success(run_nanorc):
+def test_dunerc_success(run_dunerc):
     # print the name of the current test
     current_test = os.environ.get("PYTEST_CURRENT_TEST")
     match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
@@ -266,41 +266,41 @@ def test_nanorc_success(run_nanorc):
     print(current_test)
     print(banner_line)
 
-    # Check that nanorc completed correctly
-    assert run_nanorc.completed_process.returncode == 0
+    # Check that dunerc completed correctly
+    assert run_dunerc.completed_process.returncode == 0
 
 # Log files
-def test_log_files(run_nanorc):
-    session_name = run_nanorc.session_name if run_nanorc.session_name is not None else run_nanorc.session
+def test_log_files(run_dunerc):
+    session_name = run_dunerc.session_name if run_dunerc.session_name is not None else run_dunerc.session
 
     log_dir = pathlib.Path("/log")
-    run_nanorc.log_files += [
+    run_dunerc.log_files += [
         f for f in log_dir.glob(f"log_*_{session_name}*.txt") if f.exists()
     ]
 
     # Check that at least some of the expected log files are present
     assert any(
         f"{session_name}_df-01" in str(logname)
-        for logname in run_nanorc.log_files
+        for logname in run_dunerc.log_files
     )
     assert any(
-        f"{session_name}_dfo" in str(logname) for logname in run_nanorc.log_files
+        f"{session_name}_dfo" in str(logname) for logname in run_dunerc.log_files
     )
     assert any(
-        f"{session_name}_mlt" in str(logname) for logname in run_nanorc.log_files
+        f"{session_name}_mlt" in str(logname) for logname in run_dunerc.log_files
     )
     assert any(
-        f"{session_name}_tpreplay" in str(logname) for logname in run_nanorc.log_files
+        f"{session_name}_tpreplay" in str(logname) for logname in run_dunerc.log_files
     )
 
     if check_for_logfile_errors:
         # Check that there are no warnings or errors in the log files
         assert log_file_checks.logs_are_error_free(
-            run_nanorc.log_files, True, True, ignored_logfile_problems
-        ), f"Errors found in log files: {run_nanorc.log_files}"
+            run_dunerc.log_files, True, True, ignored_logfile_problems
+        ), f"Errors found in log files: {run_dunerc.log_files}"
 
 # Data files
-def test_data_files(run_nanorc):
+def test_data_files(run_dunerc):
     current_test = os.environ.get("PYTEST_CURRENT_TEST")
 
     datafile_params = {
@@ -323,15 +323,15 @@ def test_data_files(run_nanorc):
     ### Run some tests on the output data file
     all_ok = True
 
-    all_ok &= len(run_nanorc.data_files) == selected_params["n_data_files"]
+    all_ok &= len(run_dunerc.data_files) == selected_params["n_data_files"]
     if all_ok:
         print(f"\N{WHITE HEAVY CHECK MARK} The correct number of raw data files was found ({selected_params['n_data_files']})")
     else:
-        print(f"\N{POLICE CARS REVOLVING LIGHT} An incorrect number of raw data files was found, expected {selected_params['n_data_files']}, found {len(run_nanorc.data_files)} \N{POLICE CARS REVOLVING LIGHT}")
+        print(f"\N{POLICE CARS REVOLVING LIGHT} An incorrect number of raw data files was found, expected {selected_params['n_data_files']}, found {len(run_dunerc.data_files)} \N{POLICE CARS REVOLVING LIGHT}")
 
     ## Other test
     # number of SIDs
-    data_file = data_file_checks.DataFile(run_nanorc.data_files[0])
+    data_file = data_file_checks.DataFile(run_dunerc.data_files[0])
     all_ok &= data_file_checks.check_n_unique_sids(data_file, selected_params['n_sids_tp'], selected_params['n_sids_ta'], selected_params['n_sids_tc'] )
     if all_ok:
         print(f"\N{WHITE HEAVY CHECK MARK} The expected number of unique Source IDs was found ({selected_params['n_sids_tp'], selected_params['n_sids_ta'], selected_params['n_sids_tc']})")

--- a/integtest/tpreplay_test.py
+++ b/integtest/tpreplay_test.py
@@ -11,7 +11,7 @@ It does the following:
 3. Customizes runtime configuration through deep config substitutions.
 4. Runs a pre-defined dunerc command sequence (boot → start → stop → terminate).
 5. Validates:
-    - Nanorc command success
+    - DuneRC command success
     - Presence and correctness of log files
     - Data file contents (number of SIDs, file count)
 

--- a/integtest/tpstream_writing_test.py
+++ b/integtest/tpstream_writing_test.py
@@ -178,8 +178,8 @@ conf_dict.config_substitutions.append(
 
 confgen_arguments = {"Software_TPG_System": conf_dict}
 
-# The commands to run in nanorc, as a list
-nanorc_command_list = (
+# The commands to run in dunerc, as a list
+dunerc_command_list = (
     "boot conf wait 5".split()
     + "start --run-number 101 wait 1 enable-triggers wait ".split()
     + [str(run_duration)]
@@ -193,7 +193,7 @@ nanorc_command_list = (
 # The tests themselves
 
 
-def test_nanorc_success(run_nanorc):
+def test_dunerc_success(run_dunerc):
     # print the name of the current test
     current_test = os.environ.get("PYTEST_CURRENT_TEST")
     match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
@@ -204,19 +204,19 @@ def test_nanorc_success(run_nanorc):
     print(current_test)
     print(banner_line)
 
-    # Check that nanorc completed correctly
-    assert run_nanorc.completed_process.returncode == 0
+    # Check that dunerc completed correctly
+    assert run_dunerc.completed_process.returncode == 0
 
 
-def test_log_files(run_nanorc):
+def test_log_files(run_dunerc):
     if check_for_logfile_errors:
         # Check that there are no warnings or errors in the log files
         assert log_file_checks.logs_are_error_free(
-            run_nanorc.log_files, True, True, ignored_logfile_problems
+            run_dunerc.log_files, True, True, ignored_logfile_problems
         )
 
 
-def test_data_files(run_nanorc):
+def test_data_files(run_dunerc):
     local_expected_event_count = expected_event_count
     local_event_count_tolerance = expected_event_count_tolerance
     low_number_of_files = expected_number_of_data_files
@@ -242,13 +242,13 @@ def test_data_files(run_nanorc):
 
     # Run some tests on the output data file
     assert (
-        len(run_nanorc.data_files) == high_number_of_files
-        or len(run_nanorc.data_files) == low_number_of_files
+        len(run_dunerc.data_files) == high_number_of_files
+        or len(run_dunerc.data_files) == low_number_of_files
     )
 
     all_ok = True
-    for idx in range(len(run_nanorc.data_files)):
-        data_file = data_file_checks.DataFile(run_nanorc.data_files[idx])
+    for idx in range(len(run_dunerc.data_files)):
+        data_file = data_file_checks.DataFile(run_dunerc.data_files[idx])
         all_ok &= data_file_checks.sanity_check(data_file)
         all_ok &= data_file_checks.check_file_attributes(data_file)
         all_ok &= data_file_checks.check_event_count(
@@ -264,8 +264,8 @@ def test_data_files(run_nanorc):
     assert all_ok
 
 
-def test_tpstream_files(run_nanorc):
-    tpstream_files = run_nanorc.tpset_files
+def test_tpstream_files(run_dunerc):
+    tpstream_files = run_dunerc.tpset_files
     local_expected_event_count = (
         run_duration + 8
     )  # TPStreamWriterModule is currently configured to write at 1 Hz, addl TimeSlices expected because of wait times in drunc command list

--- a/integtest/trigger_bitwords_test.py
+++ b/integtest/trigger_bitwords_test.py
@@ -243,19 +243,19 @@ confgen_arguments = {
   "coincidence-bit": coincidence_bitword_conf
 }
 
-# The commands to run in nanorc, as a list
-nanorc_command_list = "boot conf".split()
-nanorc_command_list += (
+# The commands to run in dunerc, as a list
+dunerc_command_list = "boot conf".split()
+dunerc_command_list += (
     "start ".split()
     + "--run-number 101 enable-triggers wait ".split()
     + [str(run_duration)]
     + "disable-triggers drain-dataflow wait 2 stop-trigger-sources wait 2 stop wait 2".split()
 )
-nanorc_command_list += "scrap terminate".split()
+dunerc_command_list += "scrap terminate".split()
 
 ### Tests
 # Run control
-def test_nanorc_success(run_nanorc):
+def test_dunerc_success(run_dunerc):
     # print the name of the current test
     current_test = os.environ.get("PYTEST_CURRENT_TEST")
     match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
@@ -266,41 +266,41 @@ def test_nanorc_success(run_nanorc):
     print(current_test)
     print(banner_line)
 
-    # Check that nanorc completed correctly
-    assert run_nanorc.completed_process.returncode == 0
+    # Check that dunerc completed correctly
+    assert run_dunerc.completed_process.returncode == 0
 
 # Log files
-def test_log_files(run_nanorc):
-    session_name = run_nanorc.session_name if run_nanorc.session_name is not None else run_nanorc.session
+def test_log_files(run_dunerc):
+    session_name = run_dunerc.session_name if run_dunerc.session_name is not None else run_dunerc.session
 
     log_dir = pathlib.Path("/log")
-    run_nanorc.log_files += [
+    run_dunerc.log_files += [
         f for f in log_dir.glob(f"log_*_{session_name}*.txt") if f.exists()
     ]
 
     # Check that at least some of the expected log files are present
     assert any(
         f"{session_name}_df-01" in str(logname)
-        for logname in run_nanorc.log_files
+        for logname in run_dunerc.log_files
     )
     assert any(
-        f"{session_name}_dfo" in str(logname) for logname in run_nanorc.log_files
+        f"{session_name}_dfo" in str(logname) for logname in run_dunerc.log_files
     )
     assert any(
-        f"{session_name}_mlt" in str(logname) for logname in run_nanorc.log_files
+        f"{session_name}_mlt" in str(logname) for logname in run_dunerc.log_files
     )
     assert any(
-        f"{session_name}_ru" in str(logname) for logname in run_nanorc.log_files
+        f"{session_name}_ru" in str(logname) for logname in run_dunerc.log_files
     )
 
     if check_for_logfile_errors:
         # Check that there are no warnings or errors in the log files
         assert log_file_checks.logs_are_error_free(
-            run_nanorc.log_files, True, True, ignored_logfile_problems
-        ), f"Errors found in log files: {run_nanorc.log_files}"
+            run_dunerc.log_files, True, True, ignored_logfile_problems
+        ), f"Errors found in log files: {run_dunerc.log_files}"
 
 # Data files
-def test_data_files(run_nanorc):
+def test_data_files(run_dunerc):
     current_test = os.environ.get("PYTEST_CURRENT_TEST")
 
     # sanity checks
@@ -331,16 +331,16 @@ def test_data_files(run_nanorc):
     all_ok = True
 
     ## N of data files
-    all_ok &= len(run_nanorc.data_files) == selected_params["n_data_files"]
+    all_ok &= len(run_dunerc.data_files) == selected_params["n_data_files"]
 
     if all_ok:
         print(f"\N{WHITE HEAVY CHECK MARK} The correct number of raw data files was found ({selected_params['n_data_files']})")
     else:
-        print(f"\N{POLICE CARS REVOLVING LIGHT} An incorrect number of raw data files was found, expected {selected_params['n_data_files']}, found {len(run_nanorc.data_files)} \N{POLICE CARS REVOLVING LIGHT}")
+        print(f"\N{POLICE CARS REVOLVING LIGHT} An incorrect number of raw data files was found, expected {selected_params['n_data_files']}, found {len(run_dunerc.data_files)} \N{POLICE CARS REVOLVING LIGHT}")
 
     ## Other test
     if selected_params["n_data_files"] > 0:
-        data_file = data_file_checks.DataFile(run_nanorc.data_files[0])
+        data_file = data_file_checks.DataFile(run_dunerc.data_files[0])
         # TR types
         all_ok &= data_file_checks.check_tr_trigger_types(data_file, selected_params['expected_trigger_types'])
         if all_ok:

--- a/scripts/dunedaq_integtest_bundle.sh
+++ b/scripts/dunedaq_integtest_bundle.sh
@@ -24,7 +24,14 @@ Options:
     --concise-output : suppresses run control and DAQApp messages in order to focus on test results
     --tmpdir : specifies a root directory to use for test output, e.g. a directory instead of '/tmp'
     --list-only : list the tests that match the requested patterns without running them
-    --pytest-options : string with one or more command-line options to pass to Pytest (verbatim)
+    --pytest-options : string with one or more dunedaq-specific command-line options to pass to Pytest
+       - available options include the following:
+         --dunerc-path <path> : Path to DUNE run control. Default is to search in \$PATH
+         --skip-resource-checks : Whether to skip the node resource (CPU/Memory) checks for this test
+         --process-manager-type <type> : The run control process manager type to use for this test, e.g. ssh-standalone
+         --dunerc-option <option-name> <option-value> : Repeatable, run control arguments without leading dashes
+             for example, --dunerc-option log-level debug
+       - example: --pytest-options \"--skip-resource-checks --process-manager-type ssh-standalone --dunerc-option no-override-logs\"
 """
 }
 
@@ -129,7 +136,7 @@ while true; do
             shift 2
             ;;
         --pytest-options)
-            PYTEST_COMMAND="${PYTEST_COMMAND} $2"  # Add the specified options to the pytest command
+            PYTEST_COMMAND="${PYTEST_COMMAND} $2 --"  # Add the specified options to the pytest command
             shift 2
             ;;
         --list-only)


### PR DESCRIPTION
# Description

These changes follow along with the ones in DUNE-DAQ/integrationtest#147.  They convert the obsolete "nanorc" name in our integration tests to a more generic "dunerc" name.

An extra change that I made was to add information to the `dunedaq_integtest_bundle.sh` script "help" text.  That additional text describes the `--pytest-options` that are currently available.

Other than observing the new "dunerc" name in the integtest output, users should not notice a difference, and all integtests in this repo should continue to work

Here are suggestions for testing the changes:

```
DATE_PREFIX=`date '+%d%b'`
TIME_SUFFIX=`date '+%H%M'`

source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
setup_dbt latest
dbt-create -n NFD_DEV_260311_A9 ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}
cd ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}/sourcecode

git clone https://github.com/DUNE-DAQ/daqsystemtest.git -b kbiery/nanorc_to_dunerc_name_change
cd ..

dbt-workarea-env
dbt-build -j 12
dbt-workarea-env

dunedaq_integtest_bundle.sh -r daqsystemtest --concise

echo ""
echo -e "\U1F535 \U2705 Note that all of the modified integtests passed, modulo any problems with inserting TAs into latency buffers, which are unrelated. \U2705 \U1F535"
echo ""
echo ""
```

To see the new bundle script help text, we can just run `dunedaq_integtest_bundle.sh --help`.

## Type of change

- [x] Optimization (non-breaking change that improves code/performance)

## Testing checklist

- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
