### PR TITLE
Removed the unnecessary and confusing second tc-map entry from the de…

### DIFF
--- a/config/daqsystemtest/moduleconfs.data.xml
+++ b/config/daqsystemtest/moduleconfs.data.xml
@@ -815,7 +815,6 @@
  <attr name="buffer_timeout" type="u32" val="1"/>
  <attr name="td_readout_limit" type="u32" val="1000000"/>
  <rel name="tc_readout_map">
-  <ref class="TCReadoutMap" id="def-tc-map"/>
   <ref class="TCReadoutMap" id="def-hsi-tc-map"/>
  </rel>
 </obj>

--- a/config/daqsystemtest/moduleconfs.data.xml
+++ b/config/daqsystemtest/moduleconfs.data.xml
@@ -841,12 +841,6 @@
  <attr name="time_after" type="u32" val="1001"/>
 </obj>
 
-<obj class="TCReadoutMap" id="def-tc-map">
- <attr name="tc_type_name" type="string" val="kTiming"/>
- <attr name="time_before" type="u32" val="3000"/>
- <attr name="time_after" type="u32" val="1001"/>
-</obj>
-
 <obj class="TCReadoutMap" id="prescale-tc-map-entry">
  <attr name="tc_type_name" type="string" val="kPrescale"/>
  <attr name="time_before" type="u32" val="2000"/>

--- a/integtest/trigger_bitwords_test.py
+++ b/integtest/trigger_bitwords_test.py
@@ -222,12 +222,6 @@ coincidence_bitword_conf.config_substitutions.append(
 )
 coincidence_bitword_conf.config_substitutions.append(
     data_classes.attribute_substitution(
-        obj_id="def-tc-map",
-        obj_class="TCReadoutMap",
-        updates={"time_before": 62500, "time_after": 62500},)
-)
-coincidence_bitword_conf.config_substitutions.append(
-    data_classes.attribute_substitution(
         obj_id="def-hsi-tc-map",
         obj_class="TCReadoutMap",
         updates={"time_before": 62500, "time_after": 62500},)


### PR DESCRIPTION
…f-tc-processor object in moduleconfs.data.xml.

# Description

This change is targeted to `fddaq-v5.7.0`...

It is very confusing and misleading to have two tc-map entries in a TCDataProcessor object that both specify the kTiming TC type.  Please see the snippets from `moduleconfs.data.xml` here:

```
<obj class="TCDataProcessor" id="def-tc-processor">
 <attr name="queue_sizes" type="u32" val="10000"/>
 <attr name="thread_names_prefix" type="string" val="mlt_"/>
 <attr name="latency_monitoring" type="bool" val="1"/>
 <attr name="merge_overlapping_tcs" type="bool" val="1"/>
 <attr name="ignore_overlapping_tcs" type="bool" val="0"/>
 <attr name="td_out_of_timeout" type="bool" val="1"/>
 <attr name="buffer_timeout" type="u32" val="1"/>
 <attr name="td_readout_limit" type="u32" val="1000000"/>
 <rel name="tc_readout_map">
  <ref class="TCReadoutMap" id="def-tc-map"/>
  <ref class="TCReadoutMap" id="def-hsi-tc-map"/>
 </rel>
</obj>

<obj class="TCReadoutMap" id="def-hsi-tc-map">
 <attr name="tc_type_name" type="string" val="kTiming"/>
 <attr name="time_before" type="u32" val="3000"/>
 <attr name="time_after" type="u32" val="1001"/>
</obj>

<obj class="TCReadoutMap" id="def-tc-map">
 <attr name="tc_type_name" type="string" val="kTiming"/>
 <attr name="time_before" type="u32" val="3000"/>
 <attr name="time_after" type="u32" val="1001"/>
</obj>
```

I propose to remove one of them.  In this PR, I have removed the `def-tc-map` entry and kept the `def-hsi-tc-map` entry, but I'll be glad to reverse that choice if the opposite choice makes more sense.

I have run the full set of `daqsystemtest` and `dfmodules` integtests with this change and seen no problems related to the change.

I found this duplication when I attempted to modify the readout window in an integtest (using the configuration-substitution functionality) and it wasn't clear which entry to change.  (And changing the first one in the list had no effect!)

## Type of change

- [x] Optimization (non-breaking change that improves code/performance)

## Testing checklist

- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
