### PR TITLE
Added text to the 'skipped' message in the sample_ehn1_multihost_test…

### DIFF
--- a/integtest/sample_ehn1_multihost_test.py
+++ b/integtest/sample_ehn1_multihost_test.py
@@ -305,6 +305,10 @@ def test_dunerc_success(run_dunerc, capsys):
     if not pytest_tmpdir_looks_reasonable:
         with capsys.disabled():
             print("\n\n\N{LARGE YELLOW CIRCLE} The PYTEST_DEBUG_TEMPROOT env var has not been set to point to a valid directory.")
+            print("\N{LARGE YELLOW CIRCLE} This is needed for this integtest to run.")
+            print("\N{LARGE YELLOW CIRCLE} Suggested steps: 'mkdir -p $HOME/dunedaq/scratch; export PYTEST_DEBUG_TEMPROOT=$HOME/dunedaq/scratch'")
+            print("\N{LARGE YELLOW CIRCLE} And you may want to consider 'unset PYTEST_DEBUG_TEMPROOT' after running the test.")
+            print("\N{LARGE YELLOW CIRCLE} Please see the comments at the top of this integtest for more information.")
         pytest.skip("The PYTEST_DEBUG_TEMPROOT env var has not been set to point to a valid directory.")
 
     with capsys.disabled():


### PR DESCRIPTION
….py to help the user know how to set the PYTEST_DEBUG_TEMPROOT env var.

# Description

Users may not know how to deal with the situation in which the `sample_ehn1_multihost_test` is run at EHN1 (so it *should* work), but it still needs the `PYTEST_DEBUG_TEMPROOT` env var to be set.  The changes in this PR provide some additional text that is written to the console that may be helpful.

This change is targeted to v5.7.0...

To test this change, one can run `sample_ehn1_multihost_test.py` with and without having the `PYTEST_DEBUG_TEMPROOT` env var set.
