### PR TITLE
Changes to support integration test verbosity levels

### DIFF
--- a/integtest/3ru_1df_multirun_test.py
+++ b/integtest/3ru_1df_multirun_test.py
@@ -1,22 +1,20 @@
 import pytest
-import os
-import re
 import copy
 import math
 import urllib.request
 
 import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
+import integrationtest.basic_checks as basic_checks
 import integrationtest.data_classes as data_classes
 import integrationtest.resource_validation as resource_validation
 from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
 from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
-pytest_plugins = "integrationtest.integrationtest_drunc"
-
-# tweak the print() statement default behavior so that it always flushes the output.
 import functools
-print = functools.partial(print, flush=True)
+print = functools.partial(print, flush=True)  # always flush print() output
+
+pytest_plugins = "integrationtest.integrationtest_drunc"
 
 # Values that help determine the running conditions
 number_of_data_producers = 3
@@ -154,7 +152,7 @@ swtpg_conf.config_substitutions.append(
 
 confgen_arguments = {
     "WIBEth_System": conf_dict,
-    "Software_TPG_System": swtpg_conf,
+    "WIBEth_TPG_System": swtpg_conf,
 }
 
 # The commands to run in dunerc, as a list
@@ -178,27 +176,17 @@ dunerc_command_list += "scrap terminate".split()
 
 # The tests themselves
 
-def test_dunerc_success(run_dunerc):
-    if run_dunerc.verbosity_helper.compare_level(IntegtestVerbosityLevels.drunc_transitions):
-        # print the name of the current test
-        current_test = os.environ.get("PYTEST_CURRENT_TEST")
-        match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
-        if match_obj:
-            current_test = match_obj.group(1)
-        banner_line = re.sub(".", "=", current_test)
-        print(banner_line)
-        print(current_test)
-        print(banner_line)
-
-    # Check that dunerc completed correctly
-    assert run_dunerc.completed_process.returncode == 0
+def test_dunerc_success(run_dunerc, caplog):
+    # checks for run control success, problems during pytest setup, etc.
+    basic_checks.basic_checks(run_dunerc, caplog, print_test_name=True)
 
 
 def test_log_files(run_dunerc):
     if check_for_logfile_errors:
         # Check that there are no warnings or errors in the log files
         assert log_file_checks.logs_are_error_free(
-            run_dunerc.log_files, True, True, ignored_logfile_problems
+            run_dunerc.log_files, True, True, ignored_logfile_problems,
+            verbosity_helper=run_dunerc.verbosity_helper
         )
 
 

--- a/integtest/3ru_1df_multirun_test.py
+++ b/integtest/3ru_1df_multirun_test.py
@@ -2,7 +2,6 @@ import pytest
 import os
 import re
 import copy
-import psutil
 import math
 import urllib.request
 
@@ -11,6 +10,7 @@ import integrationtest.log_file_checks as log_file_checks
 import integrationtest.data_classes as data_classes
 import integrationtest.resource_validation as resource_validation
 from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
+from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
 pytest_plugins = "integrationtest.integrationtest_drunc"
 
@@ -100,8 +100,6 @@ resource_validator.cpu_count_needs(30, 60)  # 3 for each data source (incl TPG) 
 resource_validator.free_memory_needs(20, 32)  # 25% more than what we observe being used ('free -h')
 actual_output_path = get_pytest_tmpdir()
 resource_validator.free_disk_space_needs(actual_output_path, 1)  # more than what we observe
-resval_debug_string = resource_validator.get_debug_string()
-print(f"{resval_debug_string}")
 
 # The next three variable declarations *must* be present as globals in the test
 # file. They're read by the "fixtures" in conftest.py to determine how
@@ -181,15 +179,16 @@ dunerc_command_list += "scrap terminate".split()
 # The tests themselves
 
 def test_dunerc_success(run_dunerc):
-    # print the name of the current test
-    current_test = os.environ.get("PYTEST_CURRENT_TEST")
-    match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
-    if match_obj:
-        current_test = match_obj.group(1)
-    banner_line = re.sub(".", "=", current_test)
-    print(banner_line)
-    print(current_test)
-    print(banner_line)
+    if run_dunerc.verbosity_helper.compare_level(IntegtestVerbosityLevels.drunc_transitions):
+        # print the name of the current test
+        current_test = os.environ.get("PYTEST_CURRENT_TEST")
+        match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
+        if match_obj:
+            current_test = match_obj.group(1)
+        banner_line = re.sub(".", "=", current_test)
+        print(banner_line)
+        print(current_test)
+        print(banner_line)
 
     # Check that dunerc completed correctly
     assert run_dunerc.completed_process.returncode == 0
@@ -226,11 +225,15 @@ def test_data_files(run_dunerc):
         fragment_check_list.append(triggeractivity_frag_params)
 
     # Run some tests on the output data file
-    assert len(run_dunerc.data_files) == expected_number_of_data_files
+    all_ok = len(run_dunerc.data_files) == expected_number_of_data_files
+    if all_ok:
+        if run_dunerc.verbosity_helper.compare_level(IntegtestVerbosityLevels.drunc_transitions):
+            print(f"\n\N{WHITE HEAVY CHECK MARK} The correct number of raw data files was found ({expected_number_of_data_files})")
+    else:
+        print(f"\n\N{POLICE CARS REVOLVING LIGHT} An incorrect number of raw data files was found, expected {expected_number_of_data_files}, found {len(run_dunerc.data_files)} \N{POLICE CARS REVOLVING LIGHT}")
 
-    all_ok = True
     for idx in range(len(run_dunerc.data_files)):
-        data_file = data_file_checks.DataFile(run_dunerc.data_files[idx])
+        data_file = data_file_checks.DataFile(run_dunerc.data_files[idx], run_dunerc.verbosity_helper)
         all_ok &= data_file_checks.sanity_check(data_file)
         all_ok &= data_file_checks.check_file_attributes(data_file)
         all_ok &= data_file_checks.check_event_count(

--- a/integtest/3ru_3df_multirun_test.py
+++ b/integtest/3ru_3df_multirun_test.py
@@ -9,6 +9,7 @@ import integrationtest.log_file_checks as log_file_checks
 import integrationtest.data_classes as data_classes
 import integrationtest.resource_validation as resource_validation
 from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
+from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
 pytest_plugins = "integrationtest.integrationtest_drunc"
 
@@ -123,8 +124,6 @@ resource_validator.cpu_count_needs(22, 44)  # 3 for each data source (incl TPG) 
 resource_validator.free_memory_needs(15, 24)  # 25% more than what we observe being used ('free -h')
 actual_output_path = get_pytest_tmpdir()
 resource_validator.free_disk_space_needs(actual_output_path, 1)  # more than what we observe
-resval_debug_string = resource_validator.get_debug_string()
-print(f"{resval_debug_string}")
 
 # 29-Dec-2025, KAB: The following comment about three variables is out-of-date.
 # It will be replaced soon, and the comment block above is a start on that.
@@ -209,15 +208,16 @@ dunerc_command_list += "scrap terminate".split()
 
 
 def test_dunerc_success(run_dunerc):
-    # print the name of the current test
-    current_test = os.environ.get("PYTEST_CURRENT_TEST")
-    match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
-    if match_obj:
-        current_test = match_obj.group(1)
-    banner_line = re.sub(".", "=", current_test)
-    print(banner_line)
-    print(current_test)
-    print(banner_line)
+    if run_dunerc.verbosity_helper.compare_level(IntegtestVerbosityLevels.drunc_transitions):
+        # print the name of the current test
+        current_test = os.environ.get("PYTEST_CURRENT_TEST")
+        match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
+        if match_obj:
+            current_test = match_obj.group(1)
+        banner_line = re.sub(".", "=", current_test)
+        print(banner_line)
+        print(current_test)
+        print(banner_line)
 
     # Check that dunerc completed correctly
     assert run_dunerc.completed_process.returncode == 0
@@ -268,7 +268,7 @@ def test_data_files(run_dunerc):
 
     all_ok = True
     for idx in range(len(run_dunerc.data_files)):
-        data_file = data_file_checks.DataFile(run_dunerc.data_files[idx])
+        data_file = data_file_checks.DataFile(run_dunerc.data_files[idx], run_dunerc.verbosity_helper)
         all_ok &= data_file_checks.sanity_check(data_file)
         all_ok &= data_file_checks.check_file_attributes(data_file)
         all_ok &= data_file_checks.check_event_count(

--- a/integtest/3ru_3df_multirun_test.py
+++ b/integtest/3ru_3df_multirun_test.py
@@ -1,21 +1,19 @@
 import pytest
-import os
-import re
 import copy
 import urllib.request
 
 import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
+import integrationtest.basic_checks as basic_checks
 import integrationtest.data_classes as data_classes
 import integrationtest.resource_validation as resource_validation
 from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
 from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
-pytest_plugins = "integrationtest.integrationtest_drunc"
-
-# tweak the print() statement default behavior so that it always flushes the output.
 import functools
-print = functools.partial(print, flush=True)
+print = functools.partial(print, flush=True)  # always flush print() output
+
+pytest_plugins = "integrationtest.integrationtest_drunc"
 
 # Values that help determine the running conditions
 number_of_data_producers = 2
@@ -176,7 +174,7 @@ swtpg_conf.config_substitutions.append(
 
 confgen_arguments = {
     "WIBEth_System": conf_dict,
-    "Software_TPG_System": swtpg_conf,
+    "WIBEth_TPG_System": swtpg_conf,
 }
 
 # 29-Dec-2025, KAB: added sample process manager choices.
@@ -207,27 +205,17 @@ dunerc_command_list += "scrap terminate".split()
 # The tests themselves
 
 
-def test_dunerc_success(run_dunerc):
-    if run_dunerc.verbosity_helper.compare_level(IntegtestVerbosityLevels.drunc_transitions):
-        # print the name of the current test
-        current_test = os.environ.get("PYTEST_CURRENT_TEST")
-        match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
-        if match_obj:
-            current_test = match_obj.group(1)
-        banner_line = re.sub(".", "=", current_test)
-        print(banner_line)
-        print(current_test)
-        print(banner_line)
-
-    # Check that dunerc completed correctly
-    assert run_dunerc.completed_process.returncode == 0
+def test_dunerc_success(run_dunerc, caplog):
+    # checks for run control success, problems during pytest setup, etc.
+    basic_checks.basic_checks(run_dunerc, caplog, print_test_name=True)
 
 
 def test_log_files(run_dunerc):
     if check_for_logfile_errors:
         # Check that there are no warnings or errors in the log files
         assert log_file_checks.logs_are_error_free(
-            run_dunerc.log_files, True, True, ignored_logfile_problems
+            run_dunerc.log_files, True, True, ignored_logfile_problems,
+            verbosity_helper=run_dunerc.verbosity_helper
         )
 
 

--- a/integtest/example_system_test.py
+++ b/integtest/example_system_test.py
@@ -1,6 +1,6 @@
 import pytest
-import os
 import copy
+import os
 import re
 import random
 import string
@@ -8,16 +8,16 @@ import pathlib
 
 import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
+import integrationtest.basic_checks as basic_checks
 import integrationtest.data_classes as data_classes
 import integrationtest.resource_validation as resource_validation
 from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
 from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
-pytest_plugins = "integrationtest.integrationtest_drunc"
-
-# tweak the print() statement default behavior so that it always flushes the output.
 import functools
-print = functools.partial(print, flush=True)
+print = functools.partial(print, flush=True)  # always flush print() output
+
+pytest_plugins = "integrationtest.integrationtest_drunc"
 
 # Values that help determine the running conditions
 run_duration = 20  # seconds
@@ -151,34 +151,13 @@ dunerc_command_list = (
 # The tests themselves
 
 
-def test_dunerc_success(run_dunerc):
-    current_test = os.environ.get("PYTEST_CURRENT_TEST")
-    match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
-    if match_obj:
-        current_test = match_obj.group(1)
-    if run_dunerc.verbosity_helper.compare_level(IntegtestVerbosityLevels.drunc_transitions):
-        # print the name of the current test
-        banner_line = re.sub(".", "=", current_test)
-        print(banner_line)
-        print(current_test)
-        print(banner_line)
-
-    if not host_is_at_ehn1(hostname) and "EHN1" in current_test:
-        pytest.skip(
-            f"This computer ({hostname}) is not at EHN1, not running EHN1 sessions"
-        )
-
-    # Check that dunerc completed correctly
-    assert run_dunerc.completed_process.returncode == 0
+def test_dunerc_success(run_dunerc, caplog):
+    # checks for run control success, problems during pytest setup, etc.
+    basic_checks.basic_checks(run_dunerc, caplog, print_test_name=True)
 
 
 def test_log_files(run_dunerc):
     current_test = os.environ.get("PYTEST_CURRENT_TEST")
-    if not host_is_at_ehn1(hostname) and "EHN1" in current_test:
-        pytest.skip(
-            f"This computer ({hostname}) is not at EHN1, not running EHN1 sessions"
-        )
-
     session_name = run_dunerc.session_name if run_dunerc.session_name is not None else run_dunerc.session
     if host_is_at_ehn1(hostname) and "EHN1" in current_test:
         log_dir = pathlib.Path("/log")
@@ -202,17 +181,13 @@ def test_log_files(run_dunerc):
     if check_for_logfile_errors:
         # Check that there are no warnings or errors in the log files
         assert log_file_checks.logs_are_error_free(
-            run_dunerc.log_files, True, True, ignored_logfile_problems
+            run_dunerc.log_files, True, True, ignored_logfile_problems,
+            verbosity_helper=run_dunerc.verbosity_helper
         )
 
 
 def test_data_files(run_dunerc):
     current_test = os.environ.get("PYTEST_CURRENT_TEST")
-    if not host_is_at_ehn1(hostname) and "EHN1" in current_test:
-        pytest.skip(
-            f"This computer ({hostname}) is not at EHN1, not running EHN1 sessions"
-        )
-
     datafile_params = {
         "Local 1x1 Conf": {"expected_fragment_count": 4, "expected_file_count": 1},
         "Local 2x3 Conf": {"expected_fragment_count": 8, "expected_file_count": 3},

--- a/integtest/example_system_test.py
+++ b/integtest/example_system_test.py
@@ -11,6 +11,7 @@ import integrationtest.log_file_checks as log_file_checks
 import integrationtest.data_classes as data_classes
 import integrationtest.resource_validation as resource_validation
 from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
+from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
 pytest_plugins = "integrationtest.integrationtest_drunc"
 
@@ -88,8 +89,6 @@ resource_validator.cpu_count_needs(30, 60)  # 3 for each data source (incl TPG) 
 resource_validator.free_memory_needs(15, 24)  # 25% more than what we observe being used ('free -h')
 actual_output_path = get_pytest_tmpdir()
 resource_validator.free_disk_space_needs(actual_output_path, 1)  # more than what we observe
-resval_debug_string = resource_validator.get_debug_string()
-print(f"{resval_debug_string}")
 
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)
@@ -153,15 +152,16 @@ dunerc_command_list = (
 
 
 def test_dunerc_success(run_dunerc):
-    # print the name of the current test
     current_test = os.environ.get("PYTEST_CURRENT_TEST")
     match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
     if match_obj:
         current_test = match_obj.group(1)
-    banner_line = re.sub(".", "=", current_test)
-    print(banner_line)
-    print(current_test)
-    print(banner_line)
+    if run_dunerc.verbosity_helper.compare_level(IntegtestVerbosityLevels.drunc_transitions):
+        # print the name of the current test
+        banner_line = re.sub(".", "=", current_test)
+        print(banner_line)
+        print(current_test)
+        print(banner_line)
 
     if not host_is_at_ehn1(hostname) and "EHN1" in current_test:
         pytest.skip(
@@ -260,7 +260,7 @@ def test_data_files(run_dunerc):
     all_ok = True
 
     for idx in range(len(run_dunerc.data_files)):
-        data_file = data_file_checks.DataFile(run_dunerc.data_files[idx])
+        data_file = data_file_checks.DataFile(run_dunerc.data_files[idx], run_dunerc.verbosity_helper)
         all_ok &= data_file_checks.sanity_check(data_file)
         all_ok &= data_file_checks.check_file_attributes(data_file)
         all_ok &= data_file_checks.check_event_count(

--- a/integtest/fake_data_producer_test.py
+++ b/integtest/fake_data_producer_test.py
@@ -10,6 +10,7 @@ import integrationtest.log_file_checks as log_file_checks
 import integrationtest.data_classes as data_classes
 import integrationtest.resource_validation as resource_validation
 from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
+from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
 pytest_plugins = "integrationtest.integrationtest_drunc"
 
@@ -58,8 +59,6 @@ resource_validator.cpu_count_needs(4, 8)  # 4 for everything
 resource_validator.free_memory_needs(4)  # double what we observe being used ('free -h')
 actual_output_path = get_pytest_tmpdir()
 resource_validator.free_disk_space_needs(actual_output_path, 1)  # more than what we observe
-resval_debug_string = resource_validator.get_debug_string()
-print(f"{resval_debug_string}")
 
 # The next three variable declarations *must* be present as globals in the test
 # file. They're read by the "fixtures" in conftest.py to determine how
@@ -124,15 +123,16 @@ dunerc_command_list += "scrap terminate".split()
 # The tests themselves
 
 def test_dunerc_success(run_dunerc):
-    # print the name of the current test
-    current_test = os.environ.get("PYTEST_CURRENT_TEST")
-    match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
-    if match_obj:
-        current_test = match_obj.group(1)
-    banner_line = re.sub(".", "=", current_test)
-    print(banner_line)
-    print(current_test)
-    print(banner_line)
+    if run_dunerc.verbosity_helper.compare_level(IntegtestVerbosityLevels.drunc_transitions):
+        # print the name of the current test
+        current_test = os.environ.get("PYTEST_CURRENT_TEST")
+        match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
+        if match_obj:
+            current_test = match_obj.group(1)
+        banner_line = re.sub(".", "=", current_test)
+        print(banner_line)
+        print(current_test)
+        print(banner_line)
 
     # Check that dunerc completed correctly
     assert run_dunerc.completed_process.returncode == 0
@@ -163,16 +163,15 @@ def test_data_files(run_dunerc):
     fragment_check_list = [frag_params]
 
     # Run some tests on the output data file
-    all_ok = True
-    all_ok &= len(run_dunerc.data_files) == expected_number_of_data_files
-    print("") # Clear potential dot from pytest
+    all_ok = len(run_dunerc.data_files) == expected_number_of_data_files
     if all_ok:
-        print(f"\N{WHITE HEAVY CHECK MARK} The correct number of raw data files was found ({expected_number_of_data_files})")
+        if run_dunerc.verbosity_helper.compare_level(IntegtestVerbosityLevels.drunc_transitions):
+            print(f"\n\N{WHITE HEAVY CHECK MARK} The correct number of raw data files was found ({expected_number_of_data_files})")
     else:
-        print(f"\N{POLICE CARS REVOLVING LIGHT} An incorrect number of raw data files was found, expected {expected_number_of_data_files}, found {len(run_dunerc.data_files)} \N{POLICE CARS REVOLVING LIGHT}")
+        print(f"\n\N{POLICE CARS REVOLVING LIGHT} An incorrect number of raw data files was found, expected {expected_number_of_data_files}, found {len(run_dunerc.data_files)} \N{POLICE CARS REVOLVING LIGHT}")
 
     for idx in range(len(run_dunerc.data_files)):
-        data_file = data_file_checks.DataFile(run_dunerc.data_files[idx])
+        data_file = data_file_checks.DataFile(run_dunerc.data_files[idx], run_dunerc.verbosity_helper)
         all_ok &= data_file_checks.sanity_check(data_file)
         all_ok &= data_file_checks.check_file_attributes(data_file)
         all_ok &= data_file_checks.check_event_count(

--- a/integtest/fake_data_producer_test.py
+++ b/integtest/fake_data_producer_test.py
@@ -1,22 +1,21 @@
 import pytest
 import os
-import re
 import copy
 import urllib.request
 import math
 
 import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
+import integrationtest.basic_checks as basic_checks
 import integrationtest.data_classes as data_classes
 import integrationtest.resource_validation as resource_validation
 from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
 from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
-pytest_plugins = "integrationtest.integrationtest_drunc"
-
-# tweak the print() statement default behavior so that it always flushes the output.
 import functools
-print = functools.partial(print, flush=True)
+print = functools.partial(print, flush=True)  # always flush print() output
+
+pytest_plugins = "integrationtest.integrationtest_drunc"
 
 # Values that help determine the running conditions
 run_duration = 20  # seconds
@@ -122,27 +121,17 @@ dunerc_command_list += "scrap terminate".split()
 
 # The tests themselves
 
-def test_dunerc_success(run_dunerc):
-    if run_dunerc.verbosity_helper.compare_level(IntegtestVerbosityLevels.drunc_transitions):
-        # print the name of the current test
-        current_test = os.environ.get("PYTEST_CURRENT_TEST")
-        match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
-        if match_obj:
-            current_test = match_obj.group(1)
-        banner_line = re.sub(".", "=", current_test)
-        print(banner_line)
-        print(current_test)
-        print(banner_line)
-
-    # Check that dunerc completed correctly
-    assert run_dunerc.completed_process.returncode == 0
+def test_dunerc_success(run_dunerc, caplog):
+    # checks for run control success, problems during pytest setup, etc.
+    basic_checks.basic_checks(run_dunerc, caplog, print_test_name=True)
 
 
 def test_log_files(run_dunerc):
     if check_for_logfile_errors:
         # Check that there are no warnings or errors in the log files
         assert log_file_checks.logs_are_error_free(
-            run_dunerc.log_files, True, True, ignored_logfile_problems
+            run_dunerc.log_files, True, True, ignored_logfile_problems,
+            verbosity_helper=run_dunerc.verbosity_helper
         )
 
 

--- a/integtest/long_window_readout_test.py
+++ b/integtest/long_window_readout_test.py
@@ -14,21 +14,20 @@
 #
 import pytest
 import os
-import re
 import copy
 
 import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
+import integrationtest.basic_checks as basic_checks
 import integrationtest.data_classes as data_classes
 import integrationtest.resource_validation as resource_validation
 from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
 from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
-pytest_plugins = "integrationtest.integrationtest_drunc"
-
-# 20-May-2025, KAB: tweak the print() statement default behavior so that it always flushes the output.
 import functools
-print = functools.partial(print, flush=True)
+print = functools.partial(print, flush=True)  # always flush print() output
+
+pytest_plugins = "integrationtest.integrationtest_drunc"
 
 # Values that help determine the running conditions
 output_path_parameter = "."
@@ -190,27 +189,17 @@ dunerc_command_list += "scrap terminate".split()
 # The tests themselves
 
 
-def test_dunerc_success(run_dunerc):
-    if run_dunerc.verbosity_helper.compare_level(IntegtestVerbosityLevels.drunc_transitions):
-        # print the name of the current test
-        current_test = os.environ.get("PYTEST_CURRENT_TEST")
-        match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
-        if match_obj:
-            current_test = match_obj.group(1)
-        banner_line = re.sub(".", "=", current_test)
-        print(banner_line)
-        print(current_test)
-        print(banner_line)
-
-    # Check that dunerc completed correctly
-    assert run_dunerc.completed_process.returncode == 0
+def test_dunerc_success(run_dunerc, caplog):
+    # checks for run control success, problems during pytest setup, etc.
+    basic_checks.basic_checks(run_dunerc, caplog, print_test_name=False)
 
 
 def test_log_files(run_dunerc):
     if check_for_logfile_errors:
         # Check that there are no warnings or errors in the log files
         assert log_file_checks.logs_are_error_free(
-            run_dunerc.log_files, True, True, ignored_logfile_problems
+            run_dunerc.log_files, True, True, ignored_logfile_problems,
+            verbosity_helper=run_dunerc.verbosity_helper
         )
 
 

--- a/integtest/long_window_readout_test.py
+++ b/integtest/long_window_readout_test.py
@@ -16,14 +16,13 @@ import pytest
 import os
 import re
 import copy
-import shutil
-import psutil
 
 import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
 import integrationtest.data_classes as data_classes
 import integrationtest.resource_validation as resource_validation
 from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
+from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
 pytest_plugins = "integrationtest.integrationtest_drunc"
 
@@ -85,8 +84,6 @@ resource_validator.total_memory_needs()  # no specific request, but it's useful 
 actual_output_path = get_pytest_tmpdir()
 resource_validator.free_disk_space_needs(actual_output_path, 25)  # 25% more than what we need
 resource_validator.total_disk_space_needs(actual_output_path, recommended_total_disk_space=40)  # double what we need
-resval_debug_string = resource_validator.get_debug_string()
-print(f"{resval_debug_string}")
 
 # The next three variable declarations *must* be present as globals in the test
 # file. They're read by the "fixtures" in conftest.py to determine how
@@ -194,15 +191,16 @@ dunerc_command_list += "scrap terminate".split()
 
 
 def test_dunerc_success(run_dunerc):
-    # print the name of the current test
-    current_test = os.environ.get("PYTEST_CURRENT_TEST")
-    match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
-    if match_obj:
-        current_test = match_obj.group(1)
-    banner_line = re.sub(".", "=", current_test)
-    print(banner_line)
-    print(current_test)
-    print(banner_line)
+    if run_dunerc.verbosity_helper.compare_level(IntegtestVerbosityLevels.drunc_transitions):
+        # print the name of the current test
+        current_test = os.environ.get("PYTEST_CURRENT_TEST")
+        match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
+        if match_obj:
+            current_test = match_obj.group(1)
+        banner_line = re.sub(".", "=", current_test)
+        print(banner_line)
+        print(current_test)
+        print(banner_line)
 
     # Check that dunerc completed correctly
     assert run_dunerc.completed_process.returncode == 0
@@ -222,17 +220,16 @@ def test_data_files(run_dunerc):
     fragment_check_list = [triggercandidate_frag_params]
     fragment_check_list.append(wibeth_frag_params)  # WIBEth
 
-    all_ok = True
     # Run some tests on the output data file
-    all_ok &= len(run_dunerc.data_files) == expected_number_of_data_files
-    print("") # Clear potential dot from pytest
+    all_ok = len(run_dunerc.data_files) == expected_number_of_data_files
     if all_ok:
-        print(f"\N{WHITE HEAVY CHECK MARK} The correct number of raw data files was found ({expected_number_of_data_files})")
+        if run_dunerc.verbosity_helper.compare_level(IntegtestVerbosityLevels.drunc_transitions):
+            print(f"\N{WHITE HEAVY CHECK MARK} The correct number of raw data files was found ({expected_number_of_data_files})")
     else:
-        print(f"\N{POLICE CARS REVOLVING LIGHT} An incorrect number of raw data files was found, expected {expected_number_of_data_files}, found {len(run_dunerc.data_files)} \N{POLICE CARS REVOLVING LIGHT}")
+        print(f"\n\N{POLICE CARS REVOLVING LIGHT} An incorrect number of raw data files was found, expected {expected_number_of_data_files}, found {len(run_dunerc.data_files)} \N{POLICE CARS REVOLVING LIGHT}")
 
     for idx in range(len(run_dunerc.data_files)):
-        data_file = data_file_checks.DataFile(run_dunerc.data_files[idx])
+        data_file = data_file_checks.DataFile(run_dunerc.data_files[idx], run_dunerc.verbosity_helper)
         all_ok &= data_file_checks.sanity_check(data_file)
         all_ok &= data_file_checks.check_file_attributes(data_file)
         all_ok &= data_file_checks.check_event_count(
@@ -257,17 +254,19 @@ def test_cleanup(run_dunerc):
             pathlist_string += " " + str(data_file.parent)
 
     if pathlist_string and filelist_string:
-        print("============================================")
-        print("Listing the hdf5 files before deleting them:")
-        print("============================================")
+        if run_dunerc.verbosity_helper.compare_level(IntegtestVerbosityLevels.integtest_debug):
+            print("============================================")
+            print("Listing the hdf5 files before deleting them:")
+            print("============================================")
 
-        os.system(f"df -h {pathlist_string}")
-        print("--------------------")
-        os.system(f"ls -alF {filelist_string}")
+            os.system(f"df -h {pathlist_string}")
+            print("--------------------")
+            os.system(f"ls -alF {filelist_string}")
 
         for data_file in run_dunerc.data_files:
             data_file.unlink()
 
-        print("--------------------")
-        os.system(f"df -h {pathlist_string}")
-        print("============================================")
+        if run_dunerc.verbosity_helper.compare_level(IntegtestVerbosityLevels.integtest_debug):
+            print("--------------------")
+            os.system(f"df -h {pathlist_string}")
+            print("============================================")

--- a/integtest/minimal_system_quick_test.py
+++ b/integtest/minimal_system_quick_test.py
@@ -1,21 +1,19 @@
 import pytest
-import os
-import re
 import urllib.request
 
 import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
+import integrationtest.basic_checks as basic_checks
 import integrationtest.data_classes as data_classes
 import integrationtest.resource_validation as resource_validation
 import integrationtest.opmon_metric_checks as opmon_metric_checks
 from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
 from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
-pytest_plugins = "integrationtest.integrationtest_drunc"
-
-# tweak the print() statement default behavior so that it always flushes the output.
 import functools
-print = functools.partial(print, flush=True)
+print = functools.partial(print, flush=True)  # always flush print() output
+
+pytest_plugins = "integrationtest.integrationtest_drunc"
 
 # Values that help determine the running conditions
 number_of_data_producers = 2
@@ -117,20 +115,9 @@ dunerc_command_list = (
 # The tests themselves
 
 
-def test_dunerc_success(run_dunerc):
-    if run_dunerc.verbosity_helper.compare_level(IntegtestVerbosityLevels.drunc_transitions):
-        # print the name of the current test
-        current_test = os.environ.get("PYTEST_CURRENT_TEST")
-        match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
-        if match_obj:
-            current_test = match_obj.group(1)
-        banner_line = re.sub(".", "=", current_test)
-        print(banner_line)
-        print(current_test)
-        print(banner_line)
-
-    # Check that dunerc completed correctly
-    assert run_dunerc.completed_process.returncode == 0
+def test_dunerc_success(run_dunerc, caplog):
+    # checks for run control success, problems during pytest setup, etc.
+    basic_checks.basic_checks(run_dunerc, caplog, print_test_name=False)
 
 
 def test_log_files(run_dunerc):
@@ -152,7 +139,8 @@ def test_log_files(run_dunerc):
     if check_for_logfile_errors:
         # Check that there are no warnings or errors in the log files
         assert log_file_checks.logs_are_error_free(
-            run_dunerc.log_files, True, True, ignored_logfile_problems
+            run_dunerc.log_files, True, True, ignored_logfile_problems,
+            verbosity_helper=run_dunerc.verbosity_helper
         )
 
 

--- a/integtest/minimal_system_quick_test.py
+++ b/integtest/minimal_system_quick_test.py
@@ -9,6 +9,7 @@ import integrationtest.data_classes as data_classes
 import integrationtest.resource_validation as resource_validation
 import integrationtest.opmon_metric_checks as opmon_metric_checks
 from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
+from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
 pytest_plugins = "integrationtest.integrationtest_drunc"
 
@@ -65,8 +66,6 @@ resource_validator.cpu_count_needs(6, 12)  # 2 for each data source plus 2 more 
 resource_validator.free_memory_needs(5, 8)  # 25% more than what we observe being used ('free -h')
 actual_output_path = get_pytest_tmpdir()
 resource_validator.free_disk_space_needs(actual_output_path, 1)  # more than what we observe
-resval_debug_string = resource_validator.get_debug_string()
-print(f"{resval_debug_string}")
 
 # The next three variable declarations *must* be present as globals in the test
 # file. They're read by the "fixtures" in conftest.py to determine how
@@ -119,15 +118,16 @@ dunerc_command_list = (
 
 
 def test_dunerc_success(run_dunerc):
-    # print the name of the current test
-    current_test = os.environ.get("PYTEST_CURRENT_TEST")
-    match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
-    if match_obj:
-        current_test = match_obj.group(1)
-    banner_line = re.sub(".", "=", current_test)
-    print(banner_line)
-    print(current_test)
-    print(banner_line)
+    if run_dunerc.verbosity_helper.compare_level(IntegtestVerbosityLevels.drunc_transitions):
+        # print the name of the current test
+        current_test = os.environ.get("PYTEST_CURRENT_TEST")
+        match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
+        if match_obj:
+            current_test = match_obj.group(1)
+        banner_line = re.sub(".", "=", current_test)
+        print(banner_line)
+        print(current_test)
+        print(banner_line)
 
     # Check that dunerc completed correctly
     assert run_dunerc.completed_process.returncode == 0
@@ -159,18 +159,18 @@ def test_log_files(run_dunerc):
 def test_data_files(run_dunerc):
     # Run some tests on the output data file
     all_ok = len(run_dunerc.data_files) == expected_number_of_data_files
-    print("") # Clear potential dot from pytest
     if all_ok:
-        print(f"\N{WHITE HEAVY CHECK MARK} The correct number of raw data files was found ({expected_number_of_data_files})")
+        if run_dunerc.verbosity_helper.compare_level(IntegtestVerbosityLevels.drunc_transitions):
+            print(f"\n\N{WHITE HEAVY CHECK MARK} The correct number of raw data files was found ({expected_number_of_data_files})")
     else:
-        print(f"\N{POLICE CARS REVOLVING LIGHT} An incorrect number of raw data files was found, expected {expected_number_of_data_files}, found {len(run_dunerc.data_files)} \N{POLICE CARS REVOLVING LIGHT}")
+        print(f"\n\N{POLICE CARS REVOLVING LIGHT} An incorrect number of raw data files was found, expected {expected_number_of_data_files}, found {len(run_dunerc.data_files)} \N{POLICE CARS REVOLVING LIGHT}")
 
     fragment_check_list = [triggercandidate_frag_params, hsi_frag_params]
     fragment_check_list.append(wibeth_frag_params)
     nontrig_fragment_check_list = [hsi_frag_params, wibeth_frag_params]
 
     for idx in range(len(run_dunerc.data_files)):
-        data_file = data_file_checks.DataFile(run_dunerc.data_files[idx])
+        data_file = data_file_checks.DataFile(run_dunerc.data_files[idx], run_dunerc.verbosity_helper)
         all_ok &= data_file_checks.sanity_check(data_file)
         all_ok &= data_file_checks.check_file_attributes(data_file)
         all_ok &= data_file_checks.check_event_count(
@@ -191,7 +191,8 @@ def test_data_files(run_dunerc):
 
 # 26-Nov-2025, KAB: added some sample opmon metric checks, for demonstration purposes
 def test_metric_files(run_dunerc):
-    print("") # Clear potential dot from pytest
+    if run_dunerc.verbosity_helper.compare_level(IntegtestVerbosityLevels.drunc_transitions):
+        print("") # Clear potential dot from pytest
 
     # 10-Dec-2025, KAB: we have noticed that sometimes drunc transitions (or other parts of
     # a run control session) take a little longer than expected.  This can cause extra metric
@@ -233,10 +234,13 @@ def test_metric_files(run_dunerc):
     # a 20-second run will likely result in 3 metric samples (at 10-second intervals), so a range
     # of 1..5 should always succeed
     all_ok &= opmon_metric_checks.check_metric_sample_count(metric_data, metric_key_list, min_count=1,
-                                                            max_count=max_metric_sample_count)
+                                                            max_count=max_metric_sample_count,
+                                                            verbosity_helper=run_dunerc.verbosity_helper)
     # the number of triggers expected in this test is based on the run duration, so we check for
     # a reported number of generated trigger records between slightly above/below that
     all_ok &= opmon_metric_checks.check_metric_value_sum(metric_data, metric_key_list,
                                                          min_value_sum=run_duration-3,
-                                                         max_value_sum=run_duration+3)
+                                                         max_value_sum=run_duration+3,
+                                                         verbosity_helper=run_dunerc.verbosity_helper)
+
     assert all_ok

--- a/integtest/readout_type_scan_test.py
+++ b/integtest/readout_type_scan_test.py
@@ -1,21 +1,20 @@
 import pytest
 import os
-import re
 import copy
 import urllib.request
 
 import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
+import integrationtest.basic_checks as basic_checks
 import integrationtest.data_classes as data_classes
 import integrationtest.resource_validation as resource_validation
 from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
 from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
-pytest_plugins = "integrationtest.integrationtest_drunc"
-
-# tweak the print() statement default behavior so that it always flushes the output.
 import functools
-print = functools.partial(print, flush=True)
+print = functools.partial(print, flush=True)  # always flush print() output
+
+pytest_plugins = "integrationtest.integrationtest_drunc"
 
 # Values that help determine the running conditions
 number_of_data_producers = 2
@@ -387,27 +386,17 @@ dunerc_command_list = (
 
 # The tests themselves
 
-def test_dunerc_success(run_dunerc):
-    if run_dunerc.verbosity_helper.compare_level(IntegtestVerbosityLevels.drunc_transitions):
-        # print the name of the current test
-        current_test = os.environ.get("PYTEST_CURRENT_TEST")
-        match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
-        if match_obj:
-            current_test = match_obj.group(1)
-        banner_line = re.sub(".", "=", current_test)
-        print(banner_line)
-        print(current_test)
-        print(banner_line)
-
-    # Check that dunerc completed correctly
-    assert run_dunerc.completed_process.returncode == 0
+def test_dunerc_success(run_dunerc, caplog):
+    # checks for run control success, problems during pytest setup, etc.
+    basic_checks.basic_checks(run_dunerc, caplog, print_test_name=True)
 
 
 def test_log_files(run_dunerc):
     if check_for_logfile_errors:
         # Check that there are no warnings or errors in the log files
         assert log_file_checks.logs_are_error_free(
-            run_dunerc.log_files, True, True, ignored_logfile_problems
+            run_dunerc.log_files, True, True, ignored_logfile_problems,
+            verbosity_helper=run_dunerc.verbosity_helper
         )
 
 

--- a/integtest/readout_type_scan_test.py
+++ b/integtest/readout_type_scan_test.py
@@ -9,6 +9,7 @@ import integrationtest.log_file_checks as log_file_checks
 import integrationtest.data_classes as data_classes
 import integrationtest.resource_validation as resource_validation
 from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
+from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
 pytest_plugins = "integrationtest.integrationtest_drunc"
 
@@ -172,8 +173,6 @@ resource_validator.cpu_count_needs(8, 16)  # 3 for each data source (incl TPG) p
 resource_validator.free_memory_needs(6, 10)  # 20% more than what we observe being used ('free -h')
 actual_output_path = get_pytest_tmpdir()
 resource_validator.free_disk_space_needs(actual_output_path, 1)  # more than what we observe
-resval_debug_string = resource_validator.get_debug_string()
-print(f"{resval_debug_string}")
 
 # The next three variable declarations *must* be present as globals in the test
 # file. They're read by the "fixtures" in conftest.py to determine how
@@ -389,15 +388,16 @@ dunerc_command_list = (
 # The tests themselves
 
 def test_dunerc_success(run_dunerc):
-    # print the name of the current test
-    current_test = os.environ.get("PYTEST_CURRENT_TEST")
-    match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
-    if match_obj:
-        current_test = match_obj.group(1)
-    banner_line = re.sub(".", "=", current_test)
-    print(banner_line)
-    print(current_test)
-    print(banner_line)
+    if run_dunerc.verbosity_helper.compare_level(IntegtestVerbosityLevels.drunc_transitions):
+        # print the name of the current test
+        current_test = os.environ.get("PYTEST_CURRENT_TEST")
+        match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
+        if match_obj:
+            current_test = match_obj.group(1)
+        banner_line = re.sub(".", "=", current_test)
+        print(banner_line)
+        print(current_test)
+        print(banner_line)
 
     # Check that dunerc completed correctly
     assert run_dunerc.completed_process.returncode == 0
@@ -472,16 +472,15 @@ def test_data_files(run_dunerc):
             )
 
     # Run some tests on the output data file
-    all_ok = True
-    all_ok &= len(run_dunerc.data_files) == expected_number_of_data_files
-    print("") # Clear potential dot from pytest
+    all_ok = len(run_dunerc.data_files) == expected_number_of_data_files
     if all_ok:
-        print(f"\N{WHITE HEAVY CHECK MARK} The correct number of raw data files was found ({expected_number_of_data_files})")
+        if run_dunerc.verbosity_helper.compare_level(IntegtestVerbosityLevels.drunc_transitions):
+            print(f"\n\N{WHITE HEAVY CHECK MARK} The correct number of raw data files was found ({expected_number_of_data_files})")
     else:
-        print(f"\N{POLICE CARS REVOLVING LIGHT} An incorrect number of raw data files was found, expected {expected_number_of_data_files}, found {len(run_dunerc.data_files)} \N{POLICE CARS REVOLVING LIGHT}")
+        print(f"\n\N{POLICE CARS REVOLVING LIGHT} An incorrect number of raw data files was found, expected {expected_number_of_data_files}, found {len(run_dunerc.data_files)} \N{POLICE CARS REVOLVING LIGHT}")
 
     for idx in range(len(run_dunerc.data_files)):
-        data_file = data_file_checks.DataFile(run_dunerc.data_files[idx])
+        data_file = data_file_checks.DataFile(run_dunerc.data_files[idx], run_dunerc.verbosity_helper)
         all_ok &= data_file_checks.sanity_check(data_file)
         all_ok &= data_file_checks.check_file_attributes(data_file)
         all_ok &= data_file_checks.check_event_count(

--- a/integtest/sample_ehn1_multihost_test.py
+++ b/integtest/sample_ehn1_multihost_test.py
@@ -49,7 +49,6 @@ check_for_logfile_errors = True
 expected_event_count = run_duration * (1.0 + 3.0) # 1 from RTCM, 3 from FakeHSI
 ta_prescale = 1000
 expected_event_count_tolerance = expected_event_count / 10.0
-hostname = os.uname().nodename
 
 wibeth_frag_params = {
     "fragment_type_description": "WIBEth",
@@ -291,6 +290,11 @@ else:
 
 
 def test_dunerc_success(run_dunerc, capsys, caplog):
+    if ".cern.ch" not in hostname:
+        with capsys.disabled():
+            print(f"\n\n\N{LARGE YELLOW CIRCLE} It is not possible to run this test on this computer ({hostname}):")
+            print(f"      {computers_that_are_unreachable}")
+        pytest.skip(f"One or more needed computers are unreachable ({computers_that_are_unreachable}).")
     if len(computers_that_are_unreachable) > 0:
         with capsys.disabled():
             print(f"\n\n\N{LARGE YELLOW CIRCLE} The following computers are needed for this test but are unreachable from this computer ({hostname}) via ssh:")

--- a/integtest/sample_ehn1_multihost_test.py
+++ b/integtest/sample_ehn1_multihost_test.py
@@ -30,7 +30,6 @@ import pytest
 import os
 import copy
 import string
-import pathlib
 
 import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
@@ -124,14 +123,22 @@ computers_that_are_needed = ["np04-srv-021", "np04-srv-022", "np04-srv-028", "np
 computers_that_are_unreachable = []
 sw_area_root = os.environ.get("DBT_AREA_ROOT")
 if sw_area_root is not None:
-    print("")
-    for needed_computer in computers_that_are_needed:
-        print(f"Confirming that we can ssh to {needed_computer}...")
-        proc = subprocess.Popen(f"ssh {needed_computer} 'cd {sw_area_root}; . ./env.sh'", shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        proc.communicate()
-        retval = proc.returncode
-        if retval != 0:
-            computers_that_are_unreachable.append(needed_computer)
+    sw_setup_script = ""
+    if os.path.exists(f"{sw_area_root}/env.sh"):
+        sw_setup_script = "env.sh"
+    elif os.path.exists(f"{sw_area_root}/dbt-setup-release-env.sh.sh"):
+        sw_setup_script = "dbt-setup-release-env.sh"
+    if sw_setup_script:
+        print("")
+        for needed_computer in computers_that_are_needed:
+            print(f"Confirming that we can ssh to {needed_computer}...")
+            proc = subprocess.Popen(f"ssh {needed_computer} 'cd {sw_area_root}; . ./{sw_setup_script}'", shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            proc.communicate()
+            retval = proc.returncode
+            if retval != 0:
+                computers_that_are_unreachable.append(needed_computer)
+    else:
+        computers_that_are_unreachable = ["Unable to determine which software area setup script to use"]
 else:
     computers_that_are_unreachable = ["Unable to determine the value of the DBT_AREA_ROOT env var"]
 

--- a/integtest/sample_ehn1_multihost_test.py
+++ b/integtest/sample_ehn1_multihost_test.py
@@ -118,9 +118,11 @@ ignored_logfile_problems = {
 # the software release from CVMFS onto all of those computers (so the startup of
 # DAQ apps such as the ConnectivityServer don't take a long time initially).
 import subprocess
+import socket
 computers_that_are_unreachable = []
+hostname = socket.getfqdn()
 sw_area_root = os.environ.get("DBT_AREA_ROOT")
-if sw_area_root is not None:
+if sw_area_root is not None and ".cern.ch" in hostname:
     print("")
     needed_computer="np04-srv-021"
     print(f"Confirming that we can ssh to {needed_computer}...")
@@ -150,6 +152,8 @@ if sw_area_root is not None:
     retval = proc.returncode
     if retval != 0:
         computers_that_are_unreachable.append(needed_computer)
+elif ".cern.ch" not in hostname:
+    computers_that_are_unreachable = [f"This test is meant to be run at CERN (hostname {hostname} does not contain .cern.ch)"]
 else:
     computers_that_are_unreachable = ["Unable to determine the value of the DBT_AREA_ROOT env var"]
 

--- a/integtest/sample_ehn1_multihost_test.py
+++ b/integtest/sample_ehn1_multihost_test.py
@@ -118,38 +118,18 @@ ignored_logfile_problems = {
 # the software release from CVMFS onto all of those computers (so the startup of
 # DAQ apps such as the ConnectivityServer don't take a long time initially).
 import subprocess
+computers_that_are_needed = ["np04-srv-021", "np04-srv-022", "np04-srv-028", "np04-srv-029"]
 computers_that_are_unreachable = []
 sw_area_root = os.environ.get("DBT_AREA_ROOT")
 if sw_area_root is not None:
     print("")
-    needed_computer="np04-srv-021"
-    print(f"Confirming that we can ssh to {needed_computer}...")
-    proc = subprocess.Popen(f"ssh {needed_computer} 'cd {sw_area_root}; . ./env.sh'", shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    proc.communicate()
-    retval = proc.returncode
-    if retval != 0:
-        computers_that_are_unreachable.append(needed_computer)
-    needed_computer="np04-srv-022"
-    print(f"Confirming that we can ssh to {needed_computer}...")
-    proc = subprocess.Popen(f"ssh {needed_computer} 'cd {sw_area_root}; . ./env.sh'", shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    proc.communicate()
-    retval = proc.returncode
-    if retval != 0:
-        computers_that_are_unreachable.append(needed_computer)
-    needed_computer="np04-srv-028"
-    print(f"Confirming that we can ssh to {needed_computer}...")
-    proc = subprocess.Popen(f"ssh {needed_computer} 'cd {sw_area_root}; . ./env.sh'", shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    proc.communicate()
-    retval = proc.returncode
-    if retval != 0:
-        computers_that_are_unreachable.append(needed_computer)
-    needed_computer="np04-srv-029"
-    print(f"Confirming that we can ssh to {needed_computer}...")
-    proc = subprocess.Popen(f"ssh {needed_computer} 'cd {sw_area_root}; . ./env.sh'", shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    proc.communicate()
-    retval = proc.returncode
-    if retval != 0:
-        computers_that_are_unreachable.append(needed_computer)
+    for needed_computer in computers_that_are_needed:
+        print(f"Confirming that we can ssh to {needed_computer}...")
+        proc = subprocess.Popen(f"ssh {needed_computer} 'cd {sw_area_root}; . ./env.sh'", shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        proc.communicate()
+        retval = proc.returncode
+        if retval != 0:
+            computers_that_are_unreachable.append(needed_computer)
 else:
     computers_that_are_unreachable = ["Unable to determine the value of the DBT_AREA_ROOT env var"]
 
@@ -410,7 +390,7 @@ def test_data_files(run_dunerc):
     all_ok = True
 
     for idx in range(len(run_dunerc.data_files)):
-        data_file = data_file_checks.DataFile(run_dunerc.data_files[idx])
+        data_file = data_file_checks.DataFile(run_dunerc.data_files[idx], run_dunerc.verbosity_helper)
         all_ok &= data_file_checks.sanity_check(data_file)
         all_ok &= data_file_checks.check_file_attributes(data_file)
         all_ok &= data_file_checks.check_event_count(
@@ -447,7 +427,7 @@ def test_tpstream_files(run_dunerc):
     for idx in range(len(tpstream_files)):
         base_filename = os.path.basename(tpstream_files[idx])
         print(f"Checking {base_filename}...")
-        data_file = data_file_checks.DataFile(tpstream_files[idx])
+        data_file = data_file_checks.DataFile(tpstream_files[idx], run_dunerc.verbosity_helper)
         # all_ok &= data_file_checks.sanity_check(data_file) # Sanity check doesn't work for stream files
         all_ok &= data_file_checks.check_file_attributes(data_file)
         all_ok &= data_file_checks.check_event_count(

--- a/integtest/sample_ehn1_multihost_test.py
+++ b/integtest/sample_ehn1_multihost_test.py
@@ -29,13 +29,15 @@
 import pytest
 import os
 import copy
-import re
 import string
 import pathlib
 
 import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
 import integrationtest.data_classes as data_classes
+
+import functools
+print = functools.partial(print, flush=True)  # always flush print() output
 
 pytest_plugins = "integrationtest.integrationtest_drunc"
 
@@ -301,15 +303,6 @@ def test_dunerc_success(run_dunerc, capsys):
     if retval != 0:
         print("*** WARNING: the cleanup of stale _gunicorn_ process on np04-srv-028 did not succeed...")
 
-    current_test = os.environ.get("PYTEST_CURRENT_TEST")
-    match_obj = re.search(r".*\[(.+)-run_dunerc0\].*", current_test)
-    if match_obj:
-        current_test = match_obj.group(1)
-    banner_line = re.sub(".", "=", current_test)
-    print(banner_line)
-    print(current_test)
-    print(banner_line)
-
     # Check that dunerc completed correctly
     assert run_dunerc.completed_process.returncode == 0
 
@@ -339,7 +332,8 @@ def test_log_files(run_dunerc):
     if check_for_logfile_errors:
         # Check that there are no warnings or errors in the log files
         assert log_file_checks.logs_are_error_free(
-            run_dunerc.log_files, True, True, ignored_logfile_problems
+            run_dunerc.log_files, True, True, ignored_logfile_problems,
+            verbosity_helper=run_dunerc.verbosity_helper
         )
 
 

--- a/integtest/sample_ehn1_multihost_test.py
+++ b/integtest/sample_ehn1_multihost_test.py
@@ -1,10 +1,9 @@
 # 29-Jan-2026, KAB: Steps to run this test:
 # - Log into any np04-srv-XYZ computer and set up a software area with the
 #     appropriate branch of daqsystemtest.
-# - 'cd $DBT_AREA_ROOT/sourcecode/daqsystemtest/integtest'
 # - 'mkdir -p $HOME/dunedaq/scratch'  # only need to do this once per user account
 # - 'export PYTEST_DEBUG_TEMPROOT=$HOME/dunedaq/scratch'  # once per login/shell
-# - 'pytest -s ./sample_ehn1_multihost_test.py'
+# - 'pytest -s $DBT_AREA_ROOT/sourcecode/daqsystemtest/integtest/sample_ehn1_multihost_test.py'
 #
 # This test currently puts the various DAQ processes on the following computers:
 # - np04-srv-021:  ru-01, ru-controller
@@ -18,13 +17,13 @@
 # on a computer other than "localhost" was also to show that it can be done.
 #
 # To enable the capturing of TRACE messages on all of the computers...
-# - 'export TRACE_FILE=/tmp/pytest-of-${USER}/log/${USER}_dunedaq.trace'  # once per login/shell
 # - 'mkdir -p /tmp/pytest-of-${USER}/log'  # only need to do this once per computer
 # - 'ssh np04-srv-021 "mkdir -p /tmp/pytest-of-${USER}/log"'  # only once per user
 # - 'ssh np04-srv-022 "mkdir -p /tmp/pytest-of-${USER}/log"'  # only once per user
 # - 'ssh np04-srv-028 "mkdir -p /tmp/pytest-of-${USER}/log"'  # only once per user
 # - 'ssh np04-srv-029 "mkdir -p /tmp/pytest-of-${USER}/log"'  # only once per user
-# - 'pytest -s ./sample_ehn1_multihost_test.py'
+# - 'export TRACE_FILE=/tmp/pytest-of-${USER}/log/${USER}_dunedaq.trace'  # once per login/shell
+# - 'pytest -s $DBT_AREA_ROOT/sourcecode/daqsystemtest/integtest/sample_ehn1_multihost_test.py'
 
 import pytest
 import os
@@ -33,7 +32,9 @@ import string
 
 import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
+import integrationtest.basic_checks as basic_checks
 import integrationtest.data_classes as data_classes
+from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
 import functools
 print = functools.partial(print, flush=True)  # always flush print() output
@@ -285,7 +286,7 @@ else:
 # The tests themselves
 
 
-def test_dunerc_success(run_dunerc, capsys):
+def test_dunerc_success(run_dunerc, capsys, caplog):
     if len(computers_that_are_unreachable) > 0:
         with capsys.disabled():
             print(f"\n\n\N{LARGE YELLOW CIRCLE} The following computers are needed for this test but are unreachable from this computer ({hostname}) via ssh:")
@@ -300,18 +301,19 @@ def test_dunerc_success(run_dunerc, capsys):
             print("\N{LARGE YELLOW CIRCLE} Please see the comments at the top of this integtest for more information.")
         pytest.skip("The PYTEST_DEBUG_TEMPROOT env var has not been set to point to a valid directory.")
 
-    with capsys.disabled():
-        print("")
-        print("\n\n\N{LARGE YELLOW CIRCLE} PLEASE NOTE: this script is cleaning up stale _gunicorn_ processes on np04-srv-028...")
-        print("")
-    proc = subprocess.Popen(f"ssh np04-srv-028 killall gunicorn", shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    proc.communicate()
-    retval = proc.returncode
-    if retval != 0:
-        print("*** WARNING: the cleanup of stale _gunicorn_ process on np04-srv-028 did not succeed...")
+    # 08-Apr-2026, KAB: maybe gunicorn shutdown is working now?
+    #with capsys.disabled():
+    #    print("")
+    #    print("\n\n\N{LARGE YELLOW CIRCLE} PLEASE NOTE: this script is cleaning up stale _gunicorn_ processes on np04-srv-028...")
+    #    print("")
+    #proc = subprocess.Popen(f"ssh np04-srv-028 killall gunicorn", shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    #proc.communicate()
+    #retval = proc.returncode
+    #if retval != 0:
+    #    print("*** WARNING: the cleanup of stale _gunicorn_ process on np04-srv-028 did not succeed...")
 
-    # Check that dunerc completed correctly
-    assert run_dunerc.completed_process.returncode == 0
+    # check on run control success, problems during pytest setup, etc.
+    basic_checks.basic_checks(run_dunerc, caplog, print_test_name=False)
 
 
 def test_log_files(run_dunerc):
@@ -427,11 +429,11 @@ def test_tpstream_files(run_dunerc):
 
     assert len(tpstream_files) == 1  # one for each run
 
-    print("")
+    #print("")
     all_ok = True
     for idx in range(len(tpstream_files)):
         base_filename = os.path.basename(tpstream_files[idx])
-        print(f"Checking {base_filename}...")
+        #print(f"Checking {base_filename}...")
         data_file = data_file_checks.DataFile(tpstream_files[idx], run_dunerc.verbosity_helper)
         # all_ok &= data_file_checks.sanity_check(data_file) # Sanity check doesn't work for stream files
         all_ok &= data_file_checks.check_file_attributes(data_file)

--- a/integtest/small_footprint_quick_test.py
+++ b/integtest/small_footprint_quick_test.py
@@ -1,20 +1,18 @@
 import pytest
-import os
-import re
 import urllib.request
 
 import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
+import integrationtest.basic_checks as basic_checks
 import integrationtest.data_classes as data_classes
 import integrationtest.resource_validation as resource_validation
 from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
 from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
-pytest_plugins = "integrationtest.integrationtest_drunc"
-
-# tweak the print() statement default behavior so that it always flushes the output.
 import functools
-print = functools.partial(print, flush=True)
+print = functools.partial(print, flush=True)  # always flush print() output
+
+pytest_plugins = "integrationtest.integrationtest_drunc"
 
 # Values that help determine the running conditions
 number_of_data_producers = 1
@@ -111,27 +109,17 @@ dunerc_command_list = (
 # The tests themselves
 
 
-def test_dunerc_success(run_dunerc):
-    if run_dunerc.verbosity_helper.compare_level(IntegtestVerbosityLevels.drunc_transitions):
-        # print the name of the current test
-        current_test = os.environ.get("PYTEST_CURRENT_TEST")
-        match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
-        if match_obj:
-            current_test = match_obj.group(1)
-        banner_line = re.sub(".", "=", current_test)
-        print(banner_line)
-        print(current_test)
-        print(banner_line)
-
-    # Check that dunerc completed correctly
-    assert run_dunerc.completed_process.returncode == 0
+def test_dunerc_success(run_dunerc, caplog):
+    # checks for run control success, problems during pytest setup, etc.
+    basic_checks.basic_checks(run_dunerc, caplog, print_test_name=False)
 
 
 def test_log_files(run_dunerc):
     if check_for_logfile_errors:
         # Check that there are no warnings or errors in the log files
         assert log_file_checks.logs_are_error_free(
-            run_dunerc.log_files, True, True, ignored_logfile_problems
+            run_dunerc.log_files, True, True, ignored_logfile_problems,
+            verbosity_helper=run_dunerc.verbosity_helper
         )
 
 

--- a/integtest/small_footprint_quick_test.py
+++ b/integtest/small_footprint_quick_test.py
@@ -8,6 +8,7 @@ import integrationtest.log_file_checks as log_file_checks
 import integrationtest.data_classes as data_classes
 import integrationtest.resource_validation as resource_validation
 from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
+from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
 pytest_plugins = "integrationtest.integrationtest_drunc"
 
@@ -65,8 +66,6 @@ resource_validator.cpu_count_needs(4, 8)  # 2 for each data source plus 2 more f
 resource_validator.free_memory_needs(4, 6)  # 33% more than what we observe being used ('free -h')
 actual_output_path = get_pytest_tmpdir()
 resource_validator.free_disk_space_needs(actual_output_path, 1)  # more than what we observe
-resval_debug_string = resource_validator.get_debug_string()
-print(f"{resval_debug_string}")
 
 # The next three variable declarations *must* be present as globals in the test
 # file. They're read by the "fixtures" in conftest.py to determine how
@@ -113,15 +112,16 @@ dunerc_command_list = (
 
 
 def test_dunerc_success(run_dunerc):
-    # print the name of the current test
-    current_test = os.environ.get("PYTEST_CURRENT_TEST")
-    match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
-    if match_obj:
-        current_test = match_obj.group(1)
-    banner_line = re.sub(".", "=", current_test)
-    print(banner_line)
-    print(current_test)
-    print(banner_line)
+    if run_dunerc.verbosity_helper.compare_level(IntegtestVerbosityLevels.drunc_transitions):
+        # print the name of the current test
+        current_test = os.environ.get("PYTEST_CURRENT_TEST")
+        match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
+        if match_obj:
+            current_test = match_obj.group(1)
+        banner_line = re.sub(".", "=", current_test)
+        print(banner_line)
+        print(current_test)
+        print(banner_line)
 
     # Check that dunerc completed correctly
     assert run_dunerc.completed_process.returncode == 0
@@ -144,7 +144,7 @@ def test_data_files(run_dunerc):
 
     all_ok = True
     for idx in range(len(run_dunerc.data_files)):
-        data_file = data_file_checks.DataFile(run_dunerc.data_files[idx])
+        data_file = data_file_checks.DataFile(run_dunerc.data_files[idx], run_dunerc.verbosity_helper)
         all_ok &= data_file_checks.sanity_check(data_file)
         all_ok &= data_file_checks.check_file_attributes(data_file)
         all_ok &= data_file_checks.check_event_count(

--- a/integtest/tpg_state_collection_test.py
+++ b/integtest/tpg_state_collection_test.py
@@ -1,21 +1,19 @@
 import pytest
-import os
-import re
 import urllib.request
 
 import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
+import integrationtest.basic_checks as basic_checks
 import integrationtest.data_classes as data_classes
 import integrationtest.opmon_metric_checks as opmon_metric_checks
 import integrationtest.resource_validation as resource_validation
 from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
 from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
-pytest_plugins = "integrationtest.integrationtest_drunc"
-
-# tweak the print() statement default behavior so that it always flushes the output.
 import functools
-print = functools.partial(print, flush=True)
+print = functools.partial(print, flush=True)  # always flush print() output
+
+pytest_plugins = "integrationtest.integrationtest_drunc"
 
 # Values that help determine the running conditions
 number_of_data_producers = 2
@@ -196,7 +194,7 @@ conf_dict.config_substitutions.append(
     )
 )
 
-confgen_arguments = {"Software_TPG_System": conf_dict}
+confgen_arguments = {"WIBEth_TPG_System": conf_dict}
 
 # The commands to run in dunerc, as a list
 dunerc_command_list = (
@@ -213,27 +211,17 @@ dunerc_command_list = (
 # The tests themselves
 
 
-def test_dunerc_success(run_dunerc):
-    if run_dunerc.verbosity_helper.compare_level(IntegtestVerbosityLevels.drunc_transitions):
-        # print the name of the current test
-        current_test = os.environ.get("PYTEST_CURRENT_TEST")
-        match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
-        if match_obj:
-            current_test = match_obj.group(1)
-        banner_line = re.sub(".", "=", current_test)
-        print(banner_line)
-        print(current_test)
-        print(banner_line)
-
-    # Check that dunerc completed correctly
-    assert run_dunerc.completed_process.returncode == 0
+def test_dunerc_success(run_dunerc, caplog):
+    # checks for run control success, problems during pytest setup, etc.
+    basic_checks.basic_checks(run_dunerc, caplog, print_test_name=False)
 
 
 def test_log_files(run_dunerc):
     if check_for_logfile_errors:
         # Check that there are no warnings or errors in the log files
         assert log_file_checks.logs_are_error_free(
-            run_dunerc.log_files, True, True, ignored_logfile_problems
+            run_dunerc.log_files, True, True, ignored_logfile_problems,
+            verbosity_helper=run_dunerc.verbosity_helper
         )
 
 

--- a/integtest/tpg_state_collection_test.py
+++ b/integtest/tpg_state_collection_test.py
@@ -9,6 +9,7 @@ import integrationtest.data_classes as data_classes
 import integrationtest.opmon_metric_checks as opmon_metric_checks
 import integrationtest.resource_validation as resource_validation
 from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
+from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
 pytest_plugins = "integrationtest.integrationtest_drunc"
 
@@ -114,8 +115,6 @@ resource_validator.cpu_count_needs(8, 16)  # 3 for each data source (incl TPG) p
 resource_validator.free_memory_needs(6, 10)  # 20% more than what we observe being used ('free -h')
 actual_output_path = get_pytest_tmpdir()
 resource_validator.free_disk_space_needs(actual_output_path, 1)  # more than what we observe
-resval_debug_string = resource_validator.get_debug_string()
-print(f"{resval_debug_string}")
 
 object_databases = ["config/daqsystemtest/integrationtest-objects.data.xml"]
 
@@ -215,15 +214,16 @@ dunerc_command_list = (
 
 
 def test_dunerc_success(run_dunerc):
-    # print the name of the current test
-    current_test = os.environ.get("PYTEST_CURRENT_TEST")
-    match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
-    if match_obj:
-        current_test = match_obj.group(1)
-    banner_line = re.sub(".", "=", current_test)
-    print(banner_line)
-    print(current_test)
-    print(banner_line)
+    if run_dunerc.verbosity_helper.compare_level(IntegtestVerbosityLevels.drunc_transitions):
+        # print the name of the current test
+        current_test = os.environ.get("PYTEST_CURRENT_TEST")
+        match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
+        if match_obj:
+            current_test = match_obj.group(1)
+        banner_line = re.sub(".", "=", current_test)
+        print(banner_line)
+        print(current_test)
+        print(banner_line)
 
     # Check that dunerc completed correctly
     assert run_dunerc.completed_process.returncode == 0
@@ -269,7 +269,7 @@ def test_data_files(run_dunerc):
 
     all_ok = True
     for idx in range(len(run_dunerc.data_files)):
-        data_file = data_file_checks.DataFile(run_dunerc.data_files[idx])
+        data_file = data_file_checks.DataFile(run_dunerc.data_files[idx], run_dunerc.verbosity_helper)
         all_ok &= data_file_checks.sanity_check(data_file)
         all_ok &= data_file_checks.check_file_attributes(data_file)
         all_ok &= data_file_checks.check_event_count(
@@ -297,7 +297,7 @@ def test_tpstream_files(run_dunerc):
 
     all_ok = True
     for idx in range(len(tpstream_files)):
-        data_file = data_file_checks.DataFile(tpstream_files[idx])
+        data_file = data_file_checks.DataFile(tpstream_files[idx], run_dunerc.verbosity_helper)
         # all_ok &= data_file_checks.sanity_check(data_file) # Sanity check doesn't work for stream files
         all_ok &= data_file_checks.check_file_attributes(data_file)
         all_ok &= data_file_checks.check_event_count(
@@ -316,7 +316,8 @@ def test_tpstream_files(run_dunerc):
 # 26-Nov-2025, KAB: added checking of opmon metrics to verify that the ones that are
 # specifically enabled in this test work as expected.
 def test_metric_files(run_dunerc):
-    print("") # Clear potential dot from pytest
+    if run_dunerc.verbosity_helper.compare_level(IntegtestVerbosityLevels.drunc_transitions):
+        print("") # Clear potential dot from pytest
 
     session_name = run_dunerc.session_name if run_dunerc.session_name else run_dunerc.session
     metric_data = opmon_metric_checks.collate_opmon_data_from_files(run_dunerc.opmon_files)
@@ -326,8 +327,10 @@ def test_metric_files(run_dunerc):
     # *** Check that the pedestal subtraction processor metrics are being produced as expected.
     # DLH-0, 'accum' metrics
     metric_key_list = [session_name, "ru-det-conn-0", "DLH-0", "WIBEthFrameProcessor", "def-wib-processor", "datahandlinglibs.TPGProcessorInfo", "*", "accum"]
-    all_ok &= opmon_metric_checks.check_metric_sample_count(metric_data, metric_key_list, min_count=1)
-    all_ok &= opmon_metric_checks.check_metric_value_sum(metric_data, metric_key_list, min_value_sum=1)
+    all_ok &= opmon_metric_checks.check_metric_sample_count(metric_data, metric_key_list, min_count=1,
+                                                            verbosity_helper=run_dunerc.verbosity_helper)
+    all_ok &= opmon_metric_checks.check_metric_value_sum(metric_data, metric_key_list, min_value_sum=1,
+                                                         verbosity_helper=run_dunerc.verbosity_helper)
 
     # DLH-0, 'pedestal' metrics
     # (In this test, the calculation of the pedestal for each WIB channel [used in TP
@@ -340,13 +343,17 @@ def test_metric_files(run_dunerc):
     # Because of all of that, the pedestal value check in this section can verify that the metric
     # reporting system sees a pedestal value of zero.)
     metric_key_list = [session_name, "ru-det-conn-0", "DLH-0", "WIBEthFrameProcessor", "def-wib-processor", "datahandlinglibs.TPGProcessorInfo", "*", "pedestal"]
-    all_ok &= opmon_metric_checks.check_metric_sample_count(metric_data, metric_key_list, min_count=1)
-    all_ok &= opmon_metric_checks.check_metric_value_sum(metric_data, metric_key_list, min_value_sum=0, max_value_sum=0)
+    all_ok &= opmon_metric_checks.check_metric_sample_count(metric_data, metric_key_list, min_count=1,
+                                                            verbosity_helper=run_dunerc.verbosity_helper)
+    all_ok &= opmon_metric_checks.check_metric_value_sum(metric_data, metric_key_list, min_value_sum=0, max_value_sum=0,
+                                                         verbosity_helper=run_dunerc.verbosity_helper)
 
     # DLH-1, 'accum' metrics
     metric_key_list = [session_name, "ru-det-conn-0", "DLH-1", "WIBEthFrameProcessor", "def-wib-processor", "datahandlinglibs.TPGProcessorInfo", "*", "accum"]
-    all_ok &= opmon_metric_checks.check_metric_sample_count(metric_data, metric_key_list, min_count=1)
-    all_ok &= opmon_metric_checks.check_metric_value_sum(metric_data, metric_key_list, min_value_sum=1)
+    all_ok &= opmon_metric_checks.check_metric_sample_count(metric_data, metric_key_list, min_count=1,
+                                                            verbosity_helper=run_dunerc.verbosity_helper)
+    all_ok &= opmon_metric_checks.check_metric_value_sum(metric_data, metric_key_list, min_value_sum=1,
+                                                         verbosity_helper=run_dunerc.verbosity_helper)
 
     # DLH-1, 'pedestal' metrics
     # (In this test, the calculation of the pedestal for each WIB channel [used in TP
@@ -359,7 +366,9 @@ def test_metric_files(run_dunerc):
     # Because of all of that, the pedestal value check in this section can verify that the metric
     # reporting system sees a pedestal value of zero.)
     metric_key_list = [session_name, "ru-det-conn-0", "DLH-1", "WIBEthFrameProcessor", "def-wib-processor", "datahandlinglibs.TPGProcessorInfo", "*", "pedestal"]
-    all_ok &= opmon_metric_checks.check_metric_sample_count(metric_data, metric_key_list, min_count=1)
-    all_ok &= opmon_metric_checks.check_metric_value_sum(metric_data, metric_key_list, min_value_sum=0, max_value_sum=0)
+    all_ok &= opmon_metric_checks.check_metric_sample_count(metric_data, metric_key_list, min_count=1,
+                                                            verbosity_helper=run_dunerc.verbosity_helper)
+    all_ok &= opmon_metric_checks.check_metric_value_sum(metric_data, metric_key_list, min_value_sum=0, max_value_sum=0,
+                                                         verbosity_helper=run_dunerc.verbosity_helper)
 
     assert all_ok

--- a/integtest/tpreplay_test.py
+++ b/integtest/tpreplay_test.py
@@ -38,6 +38,7 @@ import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
 import integrationtest.resource_validation as resource_validation
 from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
+from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
 from daqconf.consolidate import copy_configuration
 from pathlib import Path
@@ -81,8 +82,6 @@ resource_validator.cpu_count_needs(6, 12)  # 3 for ConnSvc threads plus 3 more f
 resource_validator.free_memory_needs(3, 4)  # 50% more than what we observe being used ('free -h')
 actual_output_path = get_pytest_tmpdir()
 resource_validator.free_disk_space_needs(actual_output_path, 1)  # more than what we observe
-resval_debug_string = resource_validator.get_debug_string()
-print(f"{resval_debug_string}")
 
 ### Config setup
 # Create temp config
@@ -256,15 +255,16 @@ atexit.register(_cleanup_tmpdir)
 ### Tests
 # Run control
 def test_dunerc_success(run_dunerc):
-    # print the name of the current test
-    current_test = os.environ.get("PYTEST_CURRENT_TEST")
-    match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
-    if match_obj:
-        current_test = match_obj.group(1)
-    banner_line = re.sub(".", "=", current_test)
-    print(banner_line)
-    print(current_test)
-    print(banner_line)
+    if run_dunerc.verbosity_helper.compare_level(IntegtestVerbosityLevels.drunc_transitions):
+        # print the name of the current test
+        current_test = os.environ.get("PYTEST_CURRENT_TEST")
+        match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
+        if match_obj:
+            current_test = match_obj.group(1)
+        banner_line = re.sub(".", "=", current_test)
+        print(banner_line)
+        print(current_test)
+        print(banner_line)
 
     # Check that dunerc completed correctly
     assert run_dunerc.completed_process.returncode == 0
@@ -296,7 +296,8 @@ def test_log_files(run_dunerc):
     if check_for_logfile_errors:
         # Check that there are no warnings or errors in the log files
         assert log_file_checks.logs_are_error_free(
-            run_dunerc.log_files, True, True, ignored_logfile_problems
+            run_dunerc.log_files, True, True, ignored_logfile_problems,
+            verbosity_helper=run_dunerc.verbosity_helper
         ), f"Errors found in log files: {run_dunerc.log_files}"
 
 # Data files
@@ -315,26 +316,27 @@ def test_data_files(run_dunerc):
     for key in datafile_params.keys():
         if key in current_test:
             selected_params = datafile_params[key]
-            print("Selected params for", key, ":", selected_params)
+            if run_dunerc.verbosity_helper.compare_level(IntegtestVerbosityLevels.integtest_debug):
+                print("Selected params for", key, ":", selected_params)
             break
     if not selected_params:
         print(f"\n*** ERROR: unable to determine the datafile_params for test {current_test}.")
 
     ### Run some tests on the output data file
-    all_ok = True
-
-    all_ok &= len(run_dunerc.data_files) == selected_params["n_data_files"]
+    all_ok = len(run_dunerc.data_files) == selected_params["n_data_files"]
     if all_ok:
-        print(f"\N{WHITE HEAVY CHECK MARK} The correct number of raw data files was found ({selected_params['n_data_files']})")
+        if run_dunerc.verbosity_helper.compare_level(IntegtestVerbosityLevels.drunc_transitions):
+            print(f"\n\N{WHITE HEAVY CHECK MARK} The correct number of raw data files was found ({selected_params['n_data_files']})")
     else:
-        print(f"\N{POLICE CARS REVOLVING LIGHT} An incorrect number of raw data files was found, expected {selected_params['n_data_files']}, found {len(run_dunerc.data_files)} \N{POLICE CARS REVOLVING LIGHT}")
+        print(f"\n\N{POLICE CARS REVOLVING LIGHT} An incorrect number of raw data files was found, expected {selected_params['n_data_files']}, found {len(run_dunerc.data_files)} \N{POLICE CARS REVOLVING LIGHT}")
 
     ## Other test
     # number of SIDs
-    data_file = data_file_checks.DataFile(run_dunerc.data_files[0])
+    data_file = data_file_checks.DataFile(run_dunerc.data_files[0], run_dunerc.verbosity_helper)
     all_ok &= data_file_checks.check_n_unique_sids(data_file, selected_params['n_sids_tp'], selected_params['n_sids_ta'], selected_params['n_sids_tc'] )
     if all_ok:
-        print(f"\N{WHITE HEAVY CHECK MARK} The expected number of unique Source IDs was found ({selected_params['n_sids_tp'], selected_params['n_sids_ta'], selected_params['n_sids_tc']})")
+        if run_dunerc.verbosity_helper.compare_level(IntegtestVerbosityLevels.drunc_transitions):
+            print(f"\N{WHITE HEAVY CHECK MARK} The expected number of unique Source IDs was found ({selected_params['n_sids_tp'], selected_params['n_sids_ta'], selected_params['n_sids_tc']})")
     else:
         print(f"\N{POLICE CARS REVOLVING LIGHT} The number of unique Source IDs is NOT as expected ({selected_params['n_sids_tp'], selected_params['n_sids_ta'], selected_params['n_sids_tc']})! \N{POLICE CARS REVOLVING LIGHT}")
 

--- a/integtest/tpreplay_test.py
+++ b/integtest/tpreplay_test.py
@@ -28,7 +28,6 @@ import os
 import pathlib
 import pytest
 import random
-import re
 import shutil
 import string
 import tempfile
@@ -36,6 +35,7 @@ import tempfile
 import integrationtest.data_classes as data_classes
 import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
+import integrationtest.basic_checks as basic_checks
 import integrationtest.resource_validation as resource_validation
 from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
 from integrationtest.verbosity_helper import IntegtestVerbosityLevels
@@ -48,11 +48,10 @@ def _cleanup_tmpdir():
     if os.path.exists(tmpdirname):
         shutil.rmtree(tmpdirname)
 
-pytest_plugins = "integrationtest.integrationtest_drunc"
-
-# tweak the print() statement default behavior so that it always flushes the output.
 import functools
-print = functools.partial(print, flush=True)
+print = functools.partial(print, flush=True)  # always flush print() output
+
+pytest_plugins = "integrationtest.integrationtest_drunc"
 
 # Run setup
 run_duration = 20  # seconds
@@ -254,20 +253,9 @@ atexit.register(_cleanup_tmpdir)
 
 ### Tests
 # Run control
-def test_dunerc_success(run_dunerc):
-    if run_dunerc.verbosity_helper.compare_level(IntegtestVerbosityLevels.drunc_transitions):
-        # print the name of the current test
-        current_test = os.environ.get("PYTEST_CURRENT_TEST")
-        match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
-        if match_obj:
-            current_test = match_obj.group(1)
-        banner_line = re.sub(".", "=", current_test)
-        print(banner_line)
-        print(current_test)
-        print(banner_line)
-
-    # Check that dunerc completed correctly
-    assert run_dunerc.completed_process.returncode == 0
+def test_dunerc_success(run_dunerc, caplog):
+    # checks for run control success, problems during pytest setup, etc.
+    basic_checks.basic_checks(run_dunerc, caplog, print_test_name=True)
 
 # Log files
 def test_log_files(run_dunerc):

--- a/integtest/tpstream_writing_test.py
+++ b/integtest/tpstream_writing_test.py
@@ -8,6 +8,7 @@ import integrationtest.log_file_checks as log_file_checks
 import integrationtest.data_classes as data_classes
 import integrationtest.resource_validation as resource_validation
 from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
+from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
 pytest_plugins = "integrationtest.integrationtest_drunc"
 
@@ -113,8 +114,6 @@ resource_validator.cpu_count_needs(8, 16)  # 3 for each data source (incl TPG) p
 resource_validator.free_memory_needs(6, 10)  # 20% more than what we observe being used ('free -h')
 actual_output_path = get_pytest_tmpdir()
 resource_validator.free_disk_space_needs(actual_output_path, 1)  # more than what we observe
-resval_debug_string = resource_validator.get_debug_string()
-print(f"{resval_debug_string}")
 
 object_databases = ["config/daqsystemtest/integrationtest-objects.data.xml"]
 
@@ -194,15 +193,16 @@ dunerc_command_list = (
 
 
 def test_dunerc_success(run_dunerc):
-    # print the name of the current test
-    current_test = os.environ.get("PYTEST_CURRENT_TEST")
-    match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
-    if match_obj:
-        current_test = match_obj.group(1)
-    banner_line = re.sub(".", "=", current_test)
-    print(banner_line)
-    print(current_test)
-    print(banner_line)
+    if run_dunerc.verbosity_helper.compare_level(IntegtestVerbosityLevels.drunc_transitions):
+        # print the name of the current test
+        current_test = os.environ.get("PYTEST_CURRENT_TEST")
+        match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
+        if match_obj:
+            current_test = match_obj.group(1)
+        banner_line = re.sub(".", "=", current_test)
+        print(banner_line)
+        print(current_test)
+        print(banner_line)
 
     # Check that dunerc completed correctly
     assert run_dunerc.completed_process.returncode == 0
@@ -248,7 +248,7 @@ def test_data_files(run_dunerc):
 
     all_ok = True
     for idx in range(len(run_dunerc.data_files)):
-        data_file = data_file_checks.DataFile(run_dunerc.data_files[idx])
+        data_file = data_file_checks.DataFile(run_dunerc.data_files[idx], run_dunerc.verbosity_helper)
         all_ok &= data_file_checks.sanity_check(data_file)
         all_ok &= data_file_checks.check_file_attributes(data_file)
         all_ok &= data_file_checks.check_event_count(
@@ -276,7 +276,7 @@ def test_tpstream_files(run_dunerc):
 
     all_ok = True
     for idx in range(len(tpstream_files)):
-        data_file = data_file_checks.DataFile(tpstream_files[idx])
+        data_file = data_file_checks.DataFile(tpstream_files[idx], run_dunerc.verbosity_helper)
         # all_ok &= data_file_checks.sanity_check(data_file) # Sanity check doesn't work for stream files
         all_ok &= data_file_checks.check_file_attributes(data_file)
         all_ok &= data_file_checks.check_event_count(

--- a/integtest/tpstream_writing_test.py
+++ b/integtest/tpstream_writing_test.py
@@ -1,20 +1,18 @@
 import pytest
-import os
-import re
 import urllib.request
 
 import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
+import integrationtest.basic_checks as basic_checks
 import integrationtest.data_classes as data_classes
 import integrationtest.resource_validation as resource_validation
 from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
 from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
-pytest_plugins = "integrationtest.integrationtest_drunc"
-
-# tweak the print() statement default behavior so that it always flushes the output.
 import functools
-print = functools.partial(print, flush=True)
+print = functools.partial(print, flush=True)  # always flush print() output
+
+pytest_plugins = "integrationtest.integrationtest_drunc"
 
 # Values that help determine the running conditions
 number_of_data_producers = 2
@@ -175,7 +173,7 @@ conf_dict.config_substitutions.append(
     )
 )
 
-confgen_arguments = {"Software_TPG_System": conf_dict}
+confgen_arguments = {"WIBEth_TPG_System": conf_dict}
 
 # The commands to run in dunerc, as a list
 dunerc_command_list = (
@@ -192,27 +190,17 @@ dunerc_command_list = (
 # The tests themselves
 
 
-def test_dunerc_success(run_dunerc):
-    if run_dunerc.verbosity_helper.compare_level(IntegtestVerbosityLevels.drunc_transitions):
-        # print the name of the current test
-        current_test = os.environ.get("PYTEST_CURRENT_TEST")
-        match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
-        if match_obj:
-            current_test = match_obj.group(1)
-        banner_line = re.sub(".", "=", current_test)
-        print(banner_line)
-        print(current_test)
-        print(banner_line)
-
-    # Check that dunerc completed correctly
-    assert run_dunerc.completed_process.returncode == 0
+def test_dunerc_success(run_dunerc, caplog):
+    # checks for run control success, problems during pytest setup, etc.
+    basic_checks.basic_checks(run_dunerc, caplog, print_test_name=False)
 
 
 def test_log_files(run_dunerc):
     if check_for_logfile_errors:
         # Check that there are no warnings or errors in the log files
         assert log_file_checks.logs_are_error_free(
-            run_dunerc.log_files, True, True, ignored_logfile_problems
+            run_dunerc.log_files, True, True, ignored_logfile_problems,
+            verbosity_helper=run_dunerc.verbosity_helper
         )
 
 

--- a/integtest/trigger_bitwords_test.py
+++ b/integtest/trigger_bitwords_test.py
@@ -29,21 +29,20 @@ import os
 import pathlib
 import pytest
 import random
-import re
 import string
 
 import integrationtest.data_classes as data_classes
 import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
+import integrationtest.basic_checks as basic_checks
 import integrationtest.resource_validation as resource_validation
 from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
 from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
-pytest_plugins = "integrationtest.integrationtest_drunc"
-
-# tweak the print() statement default behavior so that it always flushes the output.
 import functools
-print = functools.partial(print, flush=True)
+print = functools.partial(print, flush=True)  # always flush print() output
+
+pytest_plugins = "integrationtest.integrationtest_drunc"
 
 # Run setup
 run_duration = 15  # seconds
@@ -248,20 +247,9 @@ dunerc_command_list += "scrap terminate".split()
 
 ### Tests
 # Run control
-def test_dunerc_success(run_dunerc):
-    if run_dunerc.verbosity_helper.compare_level(IntegtestVerbosityLevels.drunc_transitions):
-        # print the name of the current test
-        current_test = os.environ.get("PYTEST_CURRENT_TEST")
-        match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
-        if match_obj:
-            current_test = match_obj.group(1)
-        banner_line = re.sub(".", "=", current_test)
-        print(banner_line)
-        print(current_test)
-        print(banner_line)
-
-    # Check that dunerc completed correctly
-    assert run_dunerc.completed_process.returncode == 0
+def test_dunerc_success(run_dunerc, caplog):
+    # checks for run control success, problems during pytest setup, etc.
+    basic_checks.basic_checks(run_dunerc, caplog, print_test_name=True)
 
 # Log files
 def test_log_files(run_dunerc):
@@ -290,7 +278,8 @@ def test_log_files(run_dunerc):
     if check_for_logfile_errors:
         # Check that there are no warnings or errors in the log files
         assert log_file_checks.logs_are_error_free(
-            run_dunerc.log_files, True, True, ignored_logfile_problems
+            run_dunerc.log_files, True, True, ignored_logfile_problems,
+            verbosity_helper=run_dunerc.verbosity_helper
         ), f"Errors found in log files: {run_dunerc.log_files}"
 
 # Data files

--- a/integtest/trigger_bitwords_test.py
+++ b/integtest/trigger_bitwords_test.py
@@ -37,6 +37,7 @@ import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
 import integrationtest.resource_validation as resource_validation
 from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
+from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
 pytest_plugins = "integrationtest.integrationtest_drunc"
 
@@ -67,8 +68,6 @@ resource_validator.cpu_count_needs(15, 30)  # 3 for each data source (incl TPG) 
 resource_validator.free_memory_needs(9, 14)  # 30% more than what we observe being used ('free -h')
 actual_output_path = get_pytest_tmpdir()
 resource_validator.free_disk_space_needs(actual_output_path, 1)  # more than what we observe
-resval_debug_string = resource_validator.get_debug_string()
-print(f"{resval_debug_string}")
 
 ### Config setup
 common_config_obj = data_classes.drunc_config()
@@ -250,15 +249,16 @@ dunerc_command_list += "scrap terminate".split()
 ### Tests
 # Run control
 def test_dunerc_success(run_dunerc):
-    # print the name of the current test
-    current_test = os.environ.get("PYTEST_CURRENT_TEST")
-    match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
-    if match_obj:
-        current_test = match_obj.group(1)
-    banner_line = re.sub(".", "=", current_test)
-    print(banner_line)
-    print(current_test)
-    print(banner_line)
+    if run_dunerc.verbosity_helper.compare_level(IntegtestVerbosityLevels.drunc_transitions):
+        # print the name of the current test
+        current_test = os.environ.get("PYTEST_CURRENT_TEST")
+        match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
+        if match_obj:
+            current_test = match_obj.group(1)
+        banner_line = re.sub(".", "=", current_test)
+        print(banner_line)
+        print(current_test)
+        print(banner_line)
 
     # Check that dunerc completed correctly
     assert run_dunerc.completed_process.returncode == 0
@@ -298,7 +298,7 @@ def test_data_files(run_dunerc):
     current_test = os.environ.get("PYTEST_CURRENT_TEST")
 
     # sanity checks
-    data_file_checks.trigger_sanity_checks()
+    data_file_checks.trigger_sanity_checks(run_dunerc.verbosity_helper)
 
     datafile_params = {
         "no-bit": {"n_data_files": 1, "expected_trigger_types": ["kTiming", "kPrescale", "kRandom"], "multi_required": False},
@@ -316,36 +316,39 @@ def test_data_files(run_dunerc):
     for key in datafile_params.keys():
         if key in current_test:
             selected_params = datafile_params[key]
-            print("Selected params for", key, ":", selected_params)
+            if run_dunerc.verbosity_helper.compare_level(IntegtestVerbosityLevels.integtest_debug):
+                print("Selected params for", key, ":", selected_params)
             break
     if not selected_params:
         print(f"\n*** ERROR: unable to determine the datafile_params for test {current_test}.")
 
     ### Run some tests on the output data file
-    all_ok = True
 
     ## N of data files
-    all_ok &= len(run_dunerc.data_files) == selected_params["n_data_files"]
+    all_ok = len(run_dunerc.data_files) == selected_params["n_data_files"]
 
     if all_ok:
-        print(f"\N{WHITE HEAVY CHECK MARK} The correct number of raw data files was found ({selected_params['n_data_files']})")
+        if run_dunerc.verbosity_helper.compare_level(IntegtestVerbosityLevels.drunc_transitions):
+            print(f"\N{WHITE HEAVY CHECK MARK} The correct number of raw data files was found ({selected_params['n_data_files']})")
     else:
         print(f"\N{POLICE CARS REVOLVING LIGHT} An incorrect number of raw data files was found, expected {selected_params['n_data_files']}, found {len(run_dunerc.data_files)} \N{POLICE CARS REVOLVING LIGHT}")
 
     ## Other test
     if selected_params["n_data_files"] > 0:
-        data_file = data_file_checks.DataFile(run_dunerc.data_files[0])
+        data_file = data_file_checks.DataFile(run_dunerc.data_files[0], run_dunerc.verbosity_helper)
         # TR types
         all_ok &= data_file_checks.check_tr_trigger_types(data_file, selected_params['expected_trigger_types'])
         if all_ok:
-            print(f"\N{WHITE HEAVY CHECK MARK} All expected TC bits were found ({selected_params['expected_trigger_types']})")
+            if run_dunerc.verbosity_helper.compare_level(IntegtestVerbosityLevels.drunc_transitions):
+                print(f"\N{WHITE HEAVY CHECK MARK} All expected TC bits were found ({selected_params['expected_trigger_types']})")
         else:
             print(f"\N{POLICE CARS REVOLVING LIGHT} The extracted TC bits do not correspond to the expected ones! \N{POLICE CARS REVOLVING LIGHT}")
 
         # TR multiplicity
         all_ok &= data_file_checks.check_tr_type_multiplicity(data_file, selected_params['multi_required'])
         if all_ok:
-            print(f"\N{WHITE HEAVY CHECK MARK} The TR type multiplicity was found as expected ({selected_params['multi_required']})")
+            if run_dunerc.verbosity_helper.compare_level(IntegtestVerbosityLevels.drunc_transitions):
+                print(f"\N{WHITE HEAVY CHECK MARK} The TR type multiplicity was found as expected ({selected_params['multi_required']})")
         else:
             print(f"\N{POLICE CARS REVOLVING LIGHT} The TR type multiplicity is NOT as expected ({selected_params['multi_required']})! \N{POLICE CARS REVOLVING LIGHT}")
 

--- a/scripts/dunedaq_integtest_bundle.sh
+++ b/scripts/dunedaq_integtest_bundle.sh
@@ -21,10 +21,13 @@ Options:
     -n <number of times to run each individual test, default=1>
     -N <number of times to run the full set of selected tests, default=1>
     --stop-on-failure : causes the script to stop when one of the integtests reports a failure
+    --verbosity <level> : requested level of console messages, in range 1-6, where 1 is least
+    --trigger-full-rc-output <phrase that will trigger the full printout of run control messages>
+       - the phrase can be a Python regex, which can be useful in handling colorized text
     --concise-output : suppresses run control and DAQApp messages in order to focus on test results
-    --tmpdir : specifies a root directory to use for test output, e.g. a directory instead of '/tmp'
+    --tmpdir <dir> : specifies a root directory to use for test output, e.g. a directory instead of '/tmp'
     --list-only : list the tests that match the requested patterns without running them
-    --pytest-options : string with one or more dunedaq-specific command-line options to pass to Pytest
+    --pytest-options <options> : string with one or more dunedaq-specific command-line options to pass to Pytest
        - available options include the following:
          --dunerc-path <path> : Path to DUNE run control. Default is to search in \$PATH
          --skip-resource-checks : Whether to skip the node resource (CPU/Memory) checks for this test
@@ -50,7 +53,7 @@ CaptureOutput() {
     tee -a $1
 }
 
-GETOPT_TEMP=`getopt -o hr:k:x:n:N: --long help,stop-on-failure,concise-output,include:,exclude:,tmpdir:,list-only,pytest-options: -- "$@"`
+GETOPT_TEMP=`getopt -o hr:k:x:n:N: --long help,stop-on-failure,concise-output,include:,exclude:,tmpdir:,verbosity:,trigger-full-rc-output:,list-only,pytest-options: -- "$@"`
 if [ $? -ne 0 ]; then
     usage
     exit 1
@@ -64,6 +67,7 @@ requested_test_names=
 excluded_test_names=
 only_list_tests=""
 PYTEST_COMMAND="pytest -s --tb=short"  # our core pytest command, with DAQ printout included and short pytest traceback
+PYTEST_OPTIONS=""
 
 while true; do
     case "$1" in
@@ -135,8 +139,21 @@ while true; do
             export PYTEST_DEBUG_TEMPROOT=${tmpdir_root}
             shift 2
             ;;
+        --verbosity)
+            PYTEST_OPTIONS="$PYTEST_OPTIONS --integtest-verbosity $2"
+            let level=$2
+            if [[ $level -ge 6 ]]; then
+                PYTEST_OPTIONS="$PYTEST_OPTIONS --dunerc-option log-level debug"
+            fi
+            shift 2
+            ;;
+        --trigger-full-rc-output)
+            watch_string=`echo "$2" | sed 's/ /_SPC_/g'`
+            PYTEST_OPTIONS="$PYTEST_OPTIONS --dunerc-fullprint-watch-string $watch_string"
+            shift 2
+            ;;
         --pytest-options)
-            PYTEST_COMMAND="${PYTEST_COMMAND} $2 --"  # Add the specified options to the pytest command
+            PYTEST_OPTIONS="$PYTEST_OPTIONS $2"
             shift 2
             ;;
         --list-only)
@@ -149,6 +166,9 @@ while true; do
             ;;
     esac
 done
+if [[ "${PYTEST_OPTIONS}" != "" ]]; then
+    PYTEST_COMMAND="${PYTEST_COMMAND} ${PYTEST_OPTIONS} --"  # Add the requested options to the pytest command
+fi
 
 # run the integtests from the daqsystemtest repo if no repo was specified
 if [[ "${integtest_list}" == "" ]]; then

--- a/scripts/dunedaq_integtest_bundle.sh
+++ b/scripts/dunedaq_integtest_bundle.sh
@@ -21,10 +21,11 @@ Options:
     -n <number of times to run each individual test, default=1>
     -N <number of times to run the full set of selected tests, default=1>
     --stop-on-failure : causes the script to stop when one of the integtests reports a failure
-    --verbosity <level> : requested level of console messages, in range 1-6, where 1 is least
+    --verbosity <level> : requested level of console messages, in range 1-6, where 1 is least, 6 is DRUNC debug
     --trigger-full-rc-output <phrase that will trigger the full printout of run control messages>
        - the phrase can be a Python regex, which can be useful in handling colorized text
     --concise-output : suppresses run control and DAQApp messages in order to focus on test results
+       - this is equivalent to \"--verbosity 1\"
     --tmpdir <dir> : specifies a root directory to use for test output, e.g. a directory instead of '/tmp'
     --list-only : list the tests that match the requested patterns without running them
     --pytest-options <options> : string with one or more dunedaq-specific command-line options to pass to Pytest
@@ -130,8 +131,7 @@ while true; do
             shift
             ;;
         --concise-output)
-            # replace the pytest "-s" option with "-rs" to suppress all output except pytest.skip messages
-            PYTEST_COMMAND="`echo ${PYTEST_COMMAND} | sed 's/ -s/ -rs/'`"
+            PYTEST_OPTIONS="$PYTEST_OPTIONS --integtest-verbosity 1"
             shift
             ;;
         --tmpdir)

--- a/scripts/dunedaq_integtest_bundle.sh
+++ b/scripts/dunedaq_integtest_bundle.sh
@@ -345,7 +345,6 @@ done
 
 # print out summary information
 echo ""                                                   | CaptureOutput ${ITGRUNNER_LOG_FILE}
-echo ""                                                   | CaptureOutput ${ITGRUNNER_LOG_FILE}
 echo "+++++++++++++++++++++++++++++++++++++++++++++++++"  | CaptureOutput ${ITGRUNNER_LOG_FILE}
 echo "++++++++++++++++++++ SUMMARY ++++++++++++++++++++"  | CaptureOutput ${ITGRUNNER_LOG_FILE}
 echo "+++++++++++++++++++++++++++++++++++++++++++++++++"  | CaptureOutput ${ITGRUNNER_LOG_FILE}


### PR DESCRIPTION
These changes are intended for the `fddaq-v5.7.0` software release.

# Description

In discussions of possible improvements to our regression/integration tests, it was suggested to provide several different levels of verbosity.  These changes are part of implementing those, and this PR is best tested and merged with DUNE-DAQ/integrationtest#152.  The `integrationtest` PR has some details about the changes.

In this repo, there were a few changes that were made in addition to the ones needed for verbosity levels.  Those include the following:

- configuration names in integtests that had "Software_TPG" in their name have been modified to say WIBEth_TPG or DAPHNE_TPG since all TPG is software-based these days
- most, if not all, integtests have been modified to make use of the new `basic_checks` common function for verifying successful running of the integrationtest fixtures
- a couple of unneeded hostname checks in `example_system_test` have been removed
- the `sample_ehn1_multihost_test` was modified so that it can be successfully run from a base release
- in the `dunedaq_integtest_bundle.sh` script,
    - command-line options were added for verbosity level and full run-control output (`--verbosity` and `--trigger-full-rc-output`)
    - the `concise-output` command-line option was re-mapped to correspond to `--verbosity 1`

Please see the suggested instructions for testing these changes in DUNE-DAQ/integrationtest#152.

## Type of change

- [x] New feature or enhancement (non-breaking change which adds functionality)

## Testing checklist

- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
