### PR TITLE
Modified the integtests to reflect changes in the names of the drunc_config "session" parameters

### DIFF
--- a/integtest/3ru_1df_multirun_test.py
+++ b/integtest/3ru_1df_multirun_test.py
@@ -23,7 +23,6 @@ number_of_data_producers = 3
 number_of_readout_apps = 3
 run_duration = 20  # seconds
 trigger_rate = 1  # Hz
-data_rate_slowdown_factor = 1
 ta_prescale = 100
 
 # Default values for validation parameters
@@ -113,16 +112,9 @@ conf_dict = data_classes.drunc_config()
 conf_dict.dro_map_config.n_streams = number_of_data_producers
 conf_dict.dro_map_config.n_apps = number_of_readout_apps
 conf_dict.op_env = "integtest"
-conf_dict.session = "3ru1df"
+conf_dict.config_session_name = "3ru1df"
 conf_dict.tpg_enabled = False
 
-conf_dict.config_substitutions.append(
-    data_classes.attribute_substitution(
-        obj_id=conf_dict.session,
-        obj_class="Session",
-        updates={"data_rate_slowdown_factor": data_rate_slowdown_factor},
-    )
-)
 conf_dict.config_substitutions.append(
     data_classes.attribute_substitution(
         obj_class="RandomTCMakerConf",

--- a/integtest/3ru_3df_multirun_test.py
+++ b/integtest/3ru_3df_multirun_test.py
@@ -22,7 +22,6 @@ number_of_readout_apps = 3
 number_of_dataflow_apps = 3
 trigger_rate = 3.0  # Hz
 run_duration = 20  # seconds
-data_rate_slowdown_factor = 1
 ta_prescale = 100
 
 # Default values for validation parameters
@@ -139,17 +138,10 @@ conf_dict = data_classes.drunc_config()
 conf_dict.dro_map_config.n_streams = number_of_data_producers
 conf_dict.dro_map_config.n_apps = number_of_readout_apps
 conf_dict.op_env = "integtest"
-conf_dict.session = "3ru3df"
+conf_dict.config_session_name = "3ru3df"
 conf_dict.tpg_enabled = False
 conf_dict.n_df_apps = number_of_dataflow_apps
 
-conf_dict.config_substitutions.append(
-    data_classes.attribute_substitution(
-        obj_id=conf_dict.session,
-        obj_class="Session",
-        updates={"data_rate_slowdown_factor": data_rate_slowdown_factor},
-    )
-)
 conf_dict.config_substitutions.append(
     data_classes.attribute_substitution(
         obj_class="RandomTCMakerConf",

--- a/integtest/example_system_test.py
+++ b/integtest/example_system_test.py
@@ -109,20 +109,20 @@ common_config_obj.config_substitutions.append(
 )
 
 onebyone_local_conf = copy.deepcopy(common_config_obj)
-onebyone_local_conf.session = "local-1x1-config"
+onebyone_local_conf.config_session_name = "local-1x1-config"
 
 twobythree_local_conf = copy.deepcopy(common_config_obj)
-twobythree_local_conf.session = "local-2x3-config"
+twobythree_local_conf.config_session_name = "local-2x3-config"
 
 username=os.environ.get("USER")
 onebyone_ehn1_conf = copy.deepcopy(common_config_obj)
-onebyone_ehn1_conf.session = "ehn1-local-1x1-config"
-onebyone_ehn1_conf.session_name = f"ehn1-local-1x1-config-{username}-{''.join(random.choices(string.ascii_letters, k=4))}"
+onebyone_ehn1_conf.config_session_name = "ehn1-local-1x1-config"
+onebyone_ehn1_conf.daq_session_name = f"ehn1-local-1x1-config-{username}-{''.join(random.choices(string.ascii_letters, k=4))}"
 onebyone_ehn1_conf.connsvc_port = None
 
 twobythree_ehn1_conf = copy.deepcopy(common_config_obj)
-twobythree_ehn1_conf.session = "ehn1-local-2x3-config"
-twobythree_ehn1_conf.session_name = f"ehn1-local-2x3-config-{username}-{''.join(random.choices(string.ascii_letters, k=4))}"
+twobythree_ehn1_conf.config_session_name = "ehn1-local-2x3-config"
+twobythree_ehn1_conf.daq_session_name = f"ehn1-local-2x3-config-{username}-{''.join(random.choices(string.ascii_letters, k=4))}"
 twobythree_ehn1_conf.connsvc_port = None
 
 def host_is_at_ehn1(hostname):
@@ -179,24 +179,23 @@ def test_log_files(run_nanorc):
             f"This computer ({hostname}) is not at EHN1, not running EHN1 sessions"
         )
 
-    session_name = run_nanorc.session_name if run_nanorc.session_name is not None else run_nanorc.session
     if host_is_at_ehn1(hostname) and "EHN1" in current_test:
         log_dir = pathlib.Path("/log")
-        run_nanorc.log_files += list(log_dir.glob(f"log_*_{session_name}*.txt"))
+        run_nanorc.log_files += list(log_dir.glob(f"log_*_{run_nanorc.daq_session_name}*.txt"))
 
     # Check that at least some of the expected log files are present
     assert any(
-        f"{session_name}_df-01" in str(logname)
+        f"{run_nanorc.daq_session_name}_df-01" in str(logname)
         for logname in run_nanorc.log_files
     )
     assert any(
-        f"{session_name}_dfo" in str(logname) for logname in run_nanorc.log_files
+        f"{run_nanorc.daq_session_name}_dfo" in str(logname) for logname in run_nanorc.log_files
     )
     assert any(
-        f"{session_name}_mlt" in str(logname) for logname in run_nanorc.log_files
+        f"{run_nanorc.daq_session_name}_mlt" in str(logname) for logname in run_nanorc.log_files
     )
     assert any(
-        f"{session_name}_ru" in str(logname) for logname in run_nanorc.log_files
+        f"{run_nanorc.daq_session_name}_ru" in str(logname) for logname in run_nanorc.log_files
     )
 
     if check_for_logfile_errors:

--- a/integtest/fake_data_producer_test.py
+++ b/integtest/fake_data_producer_test.py
@@ -70,7 +70,7 @@ object_databases = ["config/daqsystemtest/integrationtest-objects.data.xml"]
 
 conf_dict = data_classes.drunc_config()
 conf_dict.op_env = "integtest"
-conf_dict.session = "fakedata"
+conf_dict.config_session_name = "fakedata"
 conf_dict.use_fakedataprod = True
 conf_dict.dro_map_config.n_streams = number_of_data_producers
 

--- a/integtest/long_window_readout_test.py
+++ b/integtest/long_window_readout_test.py
@@ -44,7 +44,6 @@ readout_window_time_after = 1000000
 trigger_record_sequence_length = 500000  # intention is 8 msec
 tr_queue_size = token_count * (readout_window_time_before + readout_window_time_after) / trigger_record_sequence_length /  number_of_dataflow_apps
 latency_buffer_size = 600000
-data_rate_slowdown_factor = 1
 
 # Default values for validation parameters
 expected_number_of_data_files = 4 * number_of_dataflow_apps
@@ -98,18 +97,11 @@ conf_dict = data_classes.drunc_config()
 conf_dict.dro_map_config.n_streams = number_of_data_producers
 conf_dict.dro_map_config.n_apps = number_of_readout_apps
 conf_dict.op_env = "integtest"
-conf_dict.session = "longwindow"
+conf_dict.config_session_name = "longwindow"
 conf_dict.tpg_enabled = False
 conf_dict.n_df_apps = number_of_dataflow_apps
 conf_dict.fake_hsi_enabled = False
 
-conf_dict.config_substitutions.append(
-    data_classes.attribute_substitution(
-        obj_id=conf_dict.session,
-        obj_class="Session",
-        updates={"data_rate_slowdown_factor": data_rate_slowdown_factor},
-    )
-)
 conf_dict.config_substitutions.append(
     data_classes.attribute_substitution(
         obj_class="LatencyBuffer", updates={"size": latency_buffer_size}

--- a/integtest/minimal_system_quick_test.py
+++ b/integtest/minimal_system_quick_test.py
@@ -18,7 +18,6 @@ print = functools.partial(print, flush=True)
 
 # Values that help determine the running conditions
 number_of_data_producers = 2
-data_rate_slowdown_factor = 1  # 10 for ProtoWIB/DuneWIB
 run_duration = 20  # seconds
 readout_window_time_before = 1000
 readout_window_time_after = 1001
@@ -81,7 +80,7 @@ object_databases = ["config/daqsystemtest/integrationtest-objects.data.xml"]
 conf_dict = data_classes.drunc_config()
 conf_dict.dro_map_config.n_streams = number_of_data_producers
 conf_dict.op_env = "integtest"
-conf_dict.session = "minimal"
+conf_dict.config_session_name = "minimal"
 conf_dict.tpg_enabled = False
 
 # For testing, allow drunc to manage ConnectivityService (default is False, integrationtest manages Connectivity Service)
@@ -136,17 +135,17 @@ def test_nanorc_success(run_nanorc):
 def test_log_files(run_nanorc):
     # Check that at least some of the expected log files are present
     assert any(
-        f"{run_nanorc.session}_df-01" in str(logname)
+        f"{run_nanorc.daq_session_name}_df-01" in str(logname)
         for logname in run_nanorc.log_files
     )
     assert any(
-        f"{run_nanorc.session}_dfo" in str(logname) for logname in run_nanorc.log_files
+        f"{run_nanorc.daq_session_name}_dfo" in str(logname) for logname in run_nanorc.log_files
     )
     assert any(
-        f"{run_nanorc.session}_mlt" in str(logname) for logname in run_nanorc.log_files
+        f"{run_nanorc.daq_session_name}_mlt" in str(logname) for logname in run_nanorc.log_files
     )
     assert any(
-        f"{run_nanorc.session}_ru" in str(logname) for logname in run_nanorc.log_files
+        f"{run_nanorc.daq_session_name}_ru" in str(logname) for logname in run_nanorc.log_files
     )
 
     if check_for_logfile_errors:
@@ -225,10 +224,9 @@ def test_metric_files(run_nanorc):
     except AttributeError:
         pass
 
-    session_name = run_nanorc.session_name if run_nanorc.session_name else run_nanorc.session
     metric_data = opmon_metric_checks.collate_opmon_data_from_files(run_nanorc.opmon_files)
 
-    metric_key_list = [session_name, "df-01", "df-01-trb", "dfmodules.TRBInfo", "generated_trigger_records"]
+    metric_key_list = [run_nanorc.daq_session_name, "df-01", "df-01-trb", "dfmodules.TRBInfo", "generated_trigger_records"]
     all_ok = True
     # a 20-second run will likely result in 3 metric samples (at 10-second intervals), so a range
     # of 1..5 should always succeed

--- a/integtest/readout_type_scan_test.py
+++ b/integtest/readout_type_scan_test.py
@@ -19,7 +19,6 @@ print = functools.partial(print, flush=True)
 # Values that help determine the running conditions
 number_of_data_producers = 2
 run_duration = 20  # seconds
-data_rate_slowdown_factor = 10  # is this still used anywhere?  (KAB, 28-Apr-2050)
 
 # Default values for validation parameters
 expected_number_of_data_files = 1
@@ -158,17 +157,10 @@ object_databases = ["config/daqsystemtest/integrationtest-objects.data.xml"]
 conf_dict = data_classes.drunc_config()
 conf_dict.dro_map_config.n_streams = number_of_data_producers
 conf_dict.op_env = "integtest"
-conf_dict.session = "readout"
+conf_dict.config_session_name = "readout"
 conf_dict.tpg_enabled = False
 conf_dict.frame_file = "asset://?label=ProtoWIB&subsystem=readout"  # ProtoWIB
 
-conf_dict.config_substitutions.append(
-    data_classes.attribute_substitution(
-        obj_id=conf_dict.session,
-        obj_class="Session",
-        updates={"data_rate_slowdown_factor": data_rate_slowdown_factor},
-    )
-)
 conf_dict.config_substitutions.append(
     data_classes.attribute_substitution(
         obj_class="RandomTCMakerConf",

--- a/integtest/sample_ehn1_multihost_test.py
+++ b/integtest/sample_ehn1_multihost_test.py
@@ -277,7 +277,7 @@ common_config_obj.config_substitutions.append(
 )
 
 ehn1_multihost_1x1_conf = copy.deepcopy(common_config_obj)
-ehn1_multihost_1x1_conf.session = "local-1x1-config"
+ehn1_multihost_1x1_conf.config_session_name = "local-1x1-config"
 ehn1_multihost_1x1_conf.connsvc_port = 0  # random
 
 confgen_arguments = {"EHN1 MultiHost 1x1 Conf": ehn1_multihost_1x1_conf}
@@ -337,19 +337,18 @@ def test_log_files(run_nanorc):
         pytest.skip("The PYTEST_DEBUG_TEMPROOT env var has not been set to point to a valid directory.")
 
     # Check that at least some of the expected log files are present
-    session_name = run_nanorc.session_name if run_nanorc.session_name is not None else run_nanorc.session
     assert any(
-        f"{session_name}_df-01" in str(logname)
+        f"{run_nanorc.daq_session_name}_df-01" in str(logname)
         for logname in run_nanorc.log_files
     )
     assert any(
-        f"{session_name}_dfo" in str(logname) for logname in run_nanorc.log_files
+        f"{run_nanorc.daq_session_name}_dfo" in str(logname) for logname in run_nanorc.log_files
     )
     assert any(
-        f"{session_name}_mlt" in str(logname) for logname in run_nanorc.log_files
+        f"{run_nanorc.daq_session_name}_mlt" in str(logname) for logname in run_nanorc.log_files
     )
     assert any(
-        f"{session_name}_ru" in str(logname) for logname in run_nanorc.log_files
+        f"{run_nanorc.daq_session_name}_ru" in str(logname) for logname in run_nanorc.log_files
     )
 
     if check_for_logfile_errors:

--- a/integtest/small_footprint_quick_test.py
+++ b/integtest/small_footprint_quick_test.py
@@ -17,7 +17,6 @@ print = functools.partial(print, flush=True)
 
 # Values that help determine the running conditions
 number_of_data_producers = 1
-data_rate_slowdown_factor = 1  # 10 for ProtoWIB/DuneWIB
 run_duration = 20  # seconds
 
 # Default values for validation parameters
@@ -80,17 +79,10 @@ object_databases = ["config/daqsystemtest/integrationtest-objects.data.xml"]
 conf_dict = data_classes.drunc_config()
 conf_dict.dro_map_config.n_streams = number_of_data_producers
 conf_dict.op_env = "integtest"
-conf_dict.session = "smallfootprint"
+conf_dict.config_session_name = "smallfootprint"
 conf_dict.tpg_enabled = False
 conf_dict.fake_hsi_enabled = True
 
-conf_dict.config_substitutions.append(
-    data_classes.attribute_substitution(
-        obj_id=conf_dict.session,
-        obj_class="Session",
-        updates={"data_rate_slowdown_factor": data_rate_slowdown_factor},
-    )
-)
 conf_dict.config_substitutions.append(
     data_classes.attribute_substitution(obj_class="LatencyBuffer", updates={"size": 50000})
 )

--- a/integtest/tpg_state_collection_test.py
+++ b/integtest/tpg_state_collection_test.py
@@ -22,7 +22,6 @@ number_of_readout_apps = 1
 number_of_dataflow_apps = 2
 pulser_trigger_rate = 1.0  # Hz
 run_duration = 30  # seconds
-data_rate_slowdown_factor = 1
 output_dir = "."
 
 # Default values for validation parameters
@@ -123,20 +122,13 @@ conf_dict = data_classes.drunc_config()
 conf_dict.dro_map_config.n_streams = number_of_data_producers
 conf_dict.dro_map_config.n_apps = number_of_readout_apps
 conf_dict.op_env = "integtest"
-conf_dict.session = "tpstream"
+conf_dict.config_session_name = "tpstream"
 conf_dict.tpg_enabled = True
 conf_dict.n_df_apps = number_of_dataflow_apps
 conf_dict.frame_file = (
     "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798"  # WIBEth All Zeros
 )
 
-conf_dict.config_substitutions.append(
-    data_classes.attribute_substitution(
-        obj_id=conf_dict.session,
-        obj_class="Session",
-        updates={"data_rate_slowdown_factor": data_rate_slowdown_factor},
-    )
-)
 conf_dict.config_substitutions.append(
     data_classes.attribute_substitution(
         obj_class="RandomTCMakerConf",
@@ -318,14 +310,13 @@ def test_tpstream_files(run_nanorc):
 def test_metric_files(run_nanorc):
     print("") # Clear potential dot from pytest
 
-    session_name = run_nanorc.session_name if run_nanorc.session_name else run_nanorc.session
     metric_data = opmon_metric_checks.collate_opmon_data_from_files(run_nanorc.opmon_files)
 
     all_ok = True
 
     # *** Check that the pedestal subtraction processor metrics are being produced as expected.
     # DLH-0, 'accum' metrics
-    metric_key_list = [session_name, "ru-det-conn-0", "DLH-0", "WIBEthFrameProcessor", "def-wib-processor", "datahandlinglibs.TPGProcessorInfo", "*", "accum"]
+    metric_key_list = [run_nanorc.daq_session_name, "ru-det-conn-0", "DLH-0", "WIBEthFrameProcessor", "def-wib-processor", "datahandlinglibs.TPGProcessorInfo", "*", "accum"]
     all_ok &= opmon_metric_checks.check_metric_sample_count(metric_data, metric_key_list, min_count=1)
     all_ok &= opmon_metric_checks.check_metric_value_sum(metric_data, metric_key_list, min_value_sum=1)
 
@@ -339,12 +330,12 @@ def test_metric_files(run_nanorc):
     # the rate of such fake non-zero signals is not large enough to affect the calculated pedestal.
     # Because of all of that, the pedestal value check in this section can verify that the metric
     # reporting system sees a pedestal value of zero.)
-    metric_key_list = [session_name, "ru-det-conn-0", "DLH-0", "WIBEthFrameProcessor", "def-wib-processor", "datahandlinglibs.TPGProcessorInfo", "*", "pedestal"]
+    metric_key_list = [run_nanorc.daq_session_name, "ru-det-conn-0", "DLH-0", "WIBEthFrameProcessor", "def-wib-processor", "datahandlinglibs.TPGProcessorInfo", "*", "pedestal"]
     all_ok &= opmon_metric_checks.check_metric_sample_count(metric_data, metric_key_list, min_count=1)
     all_ok &= opmon_metric_checks.check_metric_value_sum(metric_data, metric_key_list, min_value_sum=0, max_value_sum=0)
 
     # DLH-1, 'accum' metrics
-    metric_key_list = [session_name, "ru-det-conn-0", "DLH-1", "WIBEthFrameProcessor", "def-wib-processor", "datahandlinglibs.TPGProcessorInfo", "*", "accum"]
+    metric_key_list = [run_nanorc.daq_session_name, "ru-det-conn-0", "DLH-1", "WIBEthFrameProcessor", "def-wib-processor", "datahandlinglibs.TPGProcessorInfo", "*", "accum"]
     all_ok &= opmon_metric_checks.check_metric_sample_count(metric_data, metric_key_list, min_count=1)
     all_ok &= opmon_metric_checks.check_metric_value_sum(metric_data, metric_key_list, min_value_sum=1)
 
@@ -358,7 +349,7 @@ def test_metric_files(run_nanorc):
     # the rate of such fake non-zero signals is not large enough to affect the calculated pedestal.
     # Because of all of that, the pedestal value check in this section can verify that the metric
     # reporting system sees a pedestal value of zero.)
-    metric_key_list = [session_name, "ru-det-conn-0", "DLH-1", "WIBEthFrameProcessor", "def-wib-processor", "datahandlinglibs.TPGProcessorInfo", "*", "pedestal"]
+    metric_key_list = [run_nanorc.daq_session_name, "ru-det-conn-0", "DLH-1", "WIBEthFrameProcessor", "def-wib-processor", "datahandlinglibs.TPGProcessorInfo", "*", "pedestal"]
     all_ok &= opmon_metric_checks.check_metric_sample_count(metric_data, metric_key_list, min_count=1)
     all_ok &= opmon_metric_checks.check_metric_value_sum(metric_data, metric_key_list, min_value_sum=0, max_value_sum=0)
 

--- a/integtest/tpreplay_test.py
+++ b/integtest/tpreplay_test.py
@@ -103,7 +103,7 @@ common_config_obj.config_db = ( tmpdirname + "/example-configs.data.xml" )
 
 # Get default tpreplay config
 tpreplay_local_conf = copy.deepcopy(common_config_obj)
-tpreplay_local_conf.session = "local-tpreplay-config"
+tpreplay_local_conf.config_session_name = "local-tpreplay-config"
 
 # Get necessary dal objects
 a_source_id_dal = local_db.get_dal(class_name="SourceIDConf", uid="tpreplay-tp-srcid-100000")
@@ -271,7 +271,7 @@ def test_nanorc_success(run_nanorc):
 
 # Log files
 def test_log_files(run_nanorc):
-    session_name = run_nanorc.session_name if run_nanorc.session_name is not None else run_nanorc.session
+    session_name = run_nanorc.daq_session_name
 
     log_dir = pathlib.Path("/log")
     run_nanorc.log_files += [

--- a/integtest/tpstream_writing_test.py
+++ b/integtest/tpstream_writing_test.py
@@ -21,7 +21,6 @@ number_of_readout_apps = 1
 number_of_dataflow_apps = 2
 pulser_trigger_rate = 1.0  # Hz
 run_duration = 30  # seconds
-data_rate_slowdown_factor = 1
 output_dir = "."
 
 # Default values for validation parameters
@@ -122,20 +121,13 @@ conf_dict = data_classes.drunc_config()
 conf_dict.dro_map_config.n_streams = number_of_data_producers
 conf_dict.dro_map_config.n_apps = number_of_readout_apps
 conf_dict.op_env = "integtest"
-conf_dict.session = "tpstream"
+conf_dict.config_session_name = "tpstream"
 conf_dict.tpg_enabled = True
 conf_dict.n_df_apps = number_of_dataflow_apps
 conf_dict.frame_file = (
     "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798"  # WIBEth All Zeros
 )
 
-conf_dict.config_substitutions.append(
-    data_classes.attribute_substitution(
-        obj_id=conf_dict.session,
-        obj_class="Session",
-        updates={"data_rate_slowdown_factor": data_rate_slowdown_factor},
-    )
-)
 conf_dict.config_substitutions.append(
     data_classes.attribute_substitution(
         obj_class="RandomTCMakerConf",

--- a/integtest/trigger_bitwords_test.py
+++ b/integtest/trigger_bitwords_test.py
@@ -80,7 +80,7 @@ common_config_obj.config_db = (
 
 # Get default 1x1 config
 onebyone_local_conf = copy.deepcopy(common_config_obj)
-onebyone_local_conf.session = "local-1x1-config"
+onebyone_local_conf.config_session_name = "local-1x1-config"
 
 # Get necessary dal objects
 db = conffwk.Configuration("oksconflibs:" + str(common_config_obj.config_db))
@@ -271,7 +271,7 @@ def test_nanorc_success(run_nanorc):
 
 # Log files
 def test_log_files(run_nanorc):
-    session_name = run_nanorc.session_name if run_nanorc.session_name is not None else run_nanorc.session
+    session_name = run_nanorc.daq_session_name
 
     log_dir = pathlib.Path("/log")
     run_nanorc.log_files += [


### PR DESCRIPTION
# Description

These changes are intended to be included in `fddaq-v5.7.0`...

As described in DUNE-DAQ/integrationtest#153, I believe that there is value in making the names of the session-based parameters in our `integrationtest` `drunc_config` data structure more clear.  The changes in this PR reflect the new names that are part of DUNE-DAQ/integrationtest#153.  Please see the `integrationtest` PR for more details, including suggested instructions for testing the changes.

Two small additional changes that are part of this PR are the following:

- I removed references to the currently-unused `data_rate_slowdown_factor` configuration parameter
- I changed the configuration session name that should be used in a couple of integtests to better reflect the purpose of the test

## Type of change

- [x] Optimization (non-breaking change that improves code/performance)

## Testing checklist

- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
