### PR TITLE
Fixed typo in the name of the base release setup script in sample_ehn…

### DIFF
--- a/integtest/sample_ehn1_multihost_test.py
+++ b/integtest/sample_ehn1_multihost_test.py
@@ -128,7 +128,7 @@ if sw_area_root is not None and ".cern.ch" in hostname:
     sw_setup_script = ""
     if os.path.exists(f"{sw_area_root}/env.sh"):
         sw_setup_script = "env.sh"
-    elif os.path.exists(f"{sw_area_root}/dbt-setup-release-env.sh.sh"):
+    elif os.path.exists(f"{sw_area_root}/dbt-setup-release-env.sh"):
         sw_setup_script = "dbt-setup-release-env.sh"
     if sw_setup_script:
         print("")


### PR DESCRIPTION
…1_multihost_test.py

# Description

This is needed so that we can run the sample_ehn1_multihost_test from a base release.
