### PR TITLE
Modified the integtests to support user-requested deletion of HDF5 files at the end of each integtest.

### DIFF
--- a/integtest/3ru_1df_multirun_test.py
+++ b/integtest/3ru_1df_multirun_test.py
@@ -233,7 +233,3 @@ def test_data_files(run_dunerc):
                 data_file, fragment_check_list[jdx]
             )
     assert all_ok
-
-
-def test_cleanup(run_dunerc):
-    utility_functions.remove_hdf5_files_if_requested(run_dunerc, this_test_requests_hdf5_file_removal=False)

--- a/integtest/3ru_1df_multirun_test.py
+++ b/integtest/3ru_1df_multirun_test.py
@@ -5,9 +5,9 @@ import urllib.request
 
 import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
-import integrationtest.basic_checks as basic_checks
 import integrationtest.data_classes as data_classes
 import integrationtest.resource_validation as resource_validation
+import integrationtest.utility_functions as utility_functions
 from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
 from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
@@ -166,7 +166,7 @@ dunerc_command_list += "scrap terminate".split()
 
 def test_dunerc_success(run_dunerc, caplog):
     # checks for run control success, problems during pytest setup, etc.
-    basic_checks.basic_checks(run_dunerc, caplog, print_test_name=True)
+    utility_functions.basic_checks(run_dunerc, caplog, print_test_name=True)
 
 
 def test_log_files(run_dunerc):
@@ -223,3 +223,7 @@ def test_data_files(run_dunerc):
                 data_file, fragment_check_list[jdx]
             )
     assert all_ok
+
+
+def test_cleanup(run_dunerc):
+    utility_functions.remove_hdf5_files_if_requested(run_dunerc, this_test_requests_hdf5_file_removal=False)

--- a/integtest/3ru_3df_multirun_test.py
+++ b/integtest/3ru_3df_multirun_test.py
@@ -257,7 +257,3 @@ def test_data_files(run_dunerc):
         for kdx in range(len(nontrig_fragment_check_list)):
             all_ok &= data_file_checks.check_fragment_error_flags( data_file, nontrig_fragment_check_list[kdx])
     assert all_ok
-
-
-def test_cleanup(run_dunerc):
-    utility_functions.remove_hdf5_files_if_requested(run_dunerc, this_test_requests_hdf5_file_removal=False)

--- a/integtest/3ru_3df_multirun_test.py
+++ b/integtest/3ru_3df_multirun_test.py
@@ -4,9 +4,9 @@ import urllib.request
 
 import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
-import integrationtest.basic_checks as basic_checks
 import integrationtest.data_classes as data_classes
 import integrationtest.resource_validation as resource_validation
+import integrationtest.utility_functions as utility_functions
 from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
 from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
@@ -192,7 +192,7 @@ dunerc_command_list += "scrap terminate".split()
 
 def test_dunerc_success(run_dunerc, caplog):
     # checks for run control success, problems during pytest setup, etc.
-    basic_checks.basic_checks(run_dunerc, caplog, print_test_name=True)
+    utility_functions.basic_checks(run_dunerc, caplog, print_test_name=True)
 
 
 def test_log_files(run_dunerc):
@@ -257,3 +257,7 @@ def test_data_files(run_dunerc):
         for kdx in range(len(nontrig_fragment_check_list)):
             all_ok &= data_file_checks.check_fragment_error_flags( data_file, nontrig_fragment_check_list[kdx])
     assert all_ok
+
+
+def test_cleanup(run_dunerc):
+    utility_functions.remove_hdf5_files_if_requested(run_dunerc, this_test_requests_hdf5_file_removal=False)

--- a/integtest/disabled_tpg_test.py
+++ b/integtest/disabled_tpg_test.py
@@ -14,9 +14,9 @@ import os
 
 import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
-import integrationtest.basic_checks as basic_checks
 import integrationtest.data_classes as data_classes
 import integrationtest.resource_validation as resource_validation
+import integrationtest.utility_functions as utility_functions
 from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
 from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
@@ -132,7 +132,7 @@ dunerc_command_list = (
 
 def test_dunerc_success(run_dunerc, caplog):
     # check for run control success, problems during pytest setup, etc.
-    basic_checks.basic_checks(run_dunerc, caplog, print_test_name=True)
+    utility_functions.basic_checks(run_dunerc, caplog, print_test_name=True)
 
 
 def test_log_files(run_dunerc):
@@ -186,3 +186,7 @@ def test_data_files(run_dunerc):
             )
 
     assert all_ok
+
+
+def test_cleanup(run_dunerc):
+    utility_functions.remove_hdf5_files_if_requested(run_dunerc, this_test_requests_hdf5_file_removal=False)

--- a/integtest/disabled_tpg_test.py
+++ b/integtest/disabled_tpg_test.py
@@ -186,7 +186,3 @@ def test_data_files(run_dunerc):
             )
 
     assert all_ok
-
-
-def test_cleanup(run_dunerc):
-    utility_functions.remove_hdf5_files_if_requested(run_dunerc, this_test_requests_hdf5_file_removal=False)

--- a/integtest/example_system_test.py
+++ b/integtest/example_system_test.py
@@ -8,9 +8,9 @@ import pathlib
 
 import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
-import integrationtest.basic_checks as basic_checks
 import integrationtest.data_classes as data_classes
 import integrationtest.resource_validation as resource_validation
+import integrationtest.utility_functions as utility_functions
 from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
 from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
@@ -153,7 +153,7 @@ dunerc_command_list = (
 
 def test_dunerc_success(run_dunerc, caplog):
     # checks for run control success, problems during pytest setup, etc.
-    basic_checks.basic_checks(run_dunerc, caplog, print_test_name=True)
+    utility_functions.basic_checks(run_dunerc, caplog, print_test_name=True)
 
 
 def test_log_files(run_dunerc):
@@ -249,3 +249,7 @@ def test_data_files(run_dunerc):
             )
 
     assert all_ok
+
+
+def test_cleanup(run_dunerc):
+    utility_functions.remove_hdf5_files_if_requested(run_dunerc, this_test_requests_hdf5_file_removal=False)

--- a/integtest/example_system_test.py
+++ b/integtest/example_system_test.py
@@ -249,7 +249,3 @@ def test_data_files(run_dunerc):
             )
 
     assert all_ok
-
-
-def test_cleanup(run_dunerc):
-    utility_functions.remove_hdf5_files_if_requested(run_dunerc, this_test_requests_hdf5_file_removal=False)

--- a/integtest/fake_data_producer_test.py
+++ b/integtest/fake_data_producer_test.py
@@ -6,9 +6,9 @@ import math
 
 import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
-import integrationtest.basic_checks as basic_checks
 import integrationtest.data_classes as data_classes
 import integrationtest.resource_validation as resource_validation
+import integrationtest.utility_functions as utility_functions
 from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
 from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
@@ -122,7 +122,7 @@ dunerc_command_list += "scrap terminate".split()
 
 def test_dunerc_success(run_dunerc, caplog):
     # checks for run control success, problems during pytest setup, etc.
-    basic_checks.basic_checks(run_dunerc, caplog, print_test_name=True)
+    utility_functions.basic_checks(run_dunerc, caplog, print_test_name=True)
 
 
 def test_log_files(run_dunerc):
@@ -174,3 +174,7 @@ def test_data_files(run_dunerc):
             )
 
     assert all_ok
+
+
+def test_cleanup(run_dunerc):
+    utility_functions.remove_hdf5_files_if_requested(run_dunerc, this_test_requests_hdf5_file_removal=False)

--- a/integtest/fake_data_producer_test.py
+++ b/integtest/fake_data_producer_test.py
@@ -174,7 +174,3 @@ def test_data_files(run_dunerc):
             )
 
     assert all_ok
-
-
-def test_cleanup(run_dunerc):
-    utility_functions.remove_hdf5_files_if_requested(run_dunerc, this_test_requests_hdf5_file_removal=False)

--- a/integtest/long_window_readout_test.py
+++ b/integtest/long_window_readout_test.py
@@ -18,9 +18,9 @@ import copy
 
 import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
-import integrationtest.basic_checks as basic_checks
 import integrationtest.data_classes as data_classes
 import integrationtest.resource_validation as resource_validation
+import integrationtest.utility_functions as utility_functions
 from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
 from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
@@ -179,7 +179,7 @@ dunerc_command_list += "scrap terminate".split()
 
 def test_dunerc_success(run_dunerc, caplog):
     # checks for run control success, problems during pytest setup, etc.
-    basic_checks.basic_checks(run_dunerc, caplog, print_test_name=False)
+    utility_functions.basic_checks(run_dunerc, caplog, print_test_name=False)
 
 
 def test_log_files(run_dunerc):
@@ -223,27 +223,4 @@ def test_data_files(run_dunerc):
 
 
 def test_cleanup(run_dunerc):
-    pathlist_string = ""
-    filelist_string = ""
-    for data_file in run_dunerc.data_files:
-        filelist_string += " " + str(data_file)
-        if str(data_file.parent) not in pathlist_string:
-            pathlist_string += " " + str(data_file.parent)
-
-    if pathlist_string and filelist_string:
-        if run_dunerc.verbosity_helper.compare_level(IntegtestVerbosityLevels.integtest_debug):
-            print("============================================")
-            print("Listing the hdf5 files before deleting them:")
-            print("============================================")
-
-            os.system(f"df -h {pathlist_string}")
-            print("--------------------")
-            os.system(f"ls -alF {filelist_string}")
-
-        for data_file in run_dunerc.data_files:
-            data_file.unlink()
-
-        if run_dunerc.verbosity_helper.compare_level(IntegtestVerbosityLevels.integtest_debug):
-            print("--------------------")
-            os.system(f"df -h {pathlist_string}")
-            print("============================================")
+    utility_functions.remove_hdf5_files_if_requested(run_dunerc, this_test_requests_hdf5_file_removal=True)

--- a/integtest/long_window_readout_test.py
+++ b/integtest/long_window_readout_test.py
@@ -93,6 +93,7 @@ conf_dict.config_session_name = "longwindow"
 conf_dict.tpg_enabled = False
 conf_dict.n_df_apps = number_of_dataflow_apps
 conf_dict.fake_hsi_enabled = False
+conf_dict.remove_hdf5_files = True
 
 conf_dict.config_substitutions.append(
     data_classes.attribute_substitution(
@@ -220,7 +221,3 @@ def test_data_files(run_dunerc):
                 data_file, fragment_check_list[jdx]
             )
     assert all_ok, "\N{POLICE CARS REVOLVING LIGHT} One or more data file checks failed! \N{POLICE CARS REVOLVING LIGHT}"
-
-
-def test_cleanup(run_dunerc):
-    utility_functions.remove_hdf5_files_if_requested(run_dunerc, this_test_requests_hdf5_file_removal=True)

--- a/integtest/minimal_system_quick_test.py
+++ b/integtest/minimal_system_quick_test.py
@@ -3,10 +3,10 @@ import urllib.request
 
 import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
-import integrationtest.basic_checks as basic_checks
 import integrationtest.data_classes as data_classes
 import integrationtest.resource_validation as resource_validation
 import integrationtest.opmon_metric_checks as opmon_metric_checks
+import integrationtest.utility_functions as utility_functions
 from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
 from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
@@ -114,7 +114,7 @@ dunerc_command_list = (
 
 def test_dunerc_success(run_dunerc, caplog):
     # checks for run control success, problems during pytest setup, etc.
-    basic_checks.basic_checks(run_dunerc, caplog, print_test_name=False)
+    utility_functions.basic_checks(run_dunerc, caplog, print_test_name=False)
 
 
 def test_log_files(run_dunerc):
@@ -228,3 +228,7 @@ def test_metric_files(run_dunerc):
                                                          verbosity_helper=run_dunerc.verbosity_helper)
 
     assert all_ok
+
+
+def test_cleanup(run_dunerc):
+    utility_functions.remove_hdf5_files_if_requested(run_dunerc, this_test_requests_hdf5_file_removal=False)

--- a/integtest/minimal_system_quick_test.py
+++ b/integtest/minimal_system_quick_test.py
@@ -228,7 +228,3 @@ def test_metric_files(run_dunerc):
                                                          verbosity_helper=run_dunerc.verbosity_helper)
 
     assert all_ok
-
-
-def test_cleanup(run_dunerc):
-    utility_functions.remove_hdf5_files_if_requested(run_dunerc, this_test_requests_hdf5_file_removal=False)

--- a/integtest/readout_type_scan_test.py
+++ b/integtest/readout_type_scan_test.py
@@ -485,7 +485,3 @@ def test_data_files(run_dunerc):
             )
 
     assert all_ok
-
-
-def test_cleanup(run_dunerc):
-    utility_functions.remove_hdf5_files_if_requested(run_dunerc, this_test_requests_hdf5_file_removal=False)

--- a/integtest/readout_type_scan_test.py
+++ b/integtest/readout_type_scan_test.py
@@ -5,9 +5,9 @@ import urllib.request
 
 import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
-import integrationtest.basic_checks as basic_checks
 import integrationtest.data_classes as data_classes
 import integrationtest.resource_validation as resource_validation
+import integrationtest.utility_functions as utility_functions
 from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
 from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
@@ -376,7 +376,7 @@ dunerc_command_list = (
 
 def test_dunerc_success(run_dunerc, caplog):
     # checks for run control success, problems during pytest setup, etc.
-    basic_checks.basic_checks(run_dunerc, caplog, print_test_name=True)
+    utility_functions.basic_checks(run_dunerc, caplog, print_test_name=True)
 
 
 def test_log_files(run_dunerc):
@@ -472,3 +472,7 @@ def test_data_files(run_dunerc):
             )
 
     assert all_ok
+
+
+def test_cleanup(run_dunerc):
+    utility_functions.remove_hdf5_files_if_requested(run_dunerc, this_test_requests_hdf5_file_removal=False)

--- a/integtest/sample_ehn1_multihost_test.py
+++ b/integtest/sample_ehn1_multihost_test.py
@@ -458,4 +458,9 @@ def test_tpstream_files(run_dunerc):
 
 
 def test_cleanup(run_dunerc):
+    if len(computers_that_are_unreachable) > 0:
+        pytest.skip(f"One or more needed computers are unreachable ({computers_that_are_unreachable}).")
+    if not pytest_tmpdir_looks_reasonable:
+        pytest.skip("The PYTEST_DEBUG_TEMPROOT env var has not been set to point to a valid directory.")
+
     utility_functions.remove_hdf5_files_if_requested(run_dunerc, this_test_requests_hdf5_file_removal=False)

--- a/integtest/sample_ehn1_multihost_test.py
+++ b/integtest/sample_ehn1_multihost_test.py
@@ -455,12 +455,3 @@ def test_tpstream_files(run_dunerc):
                 data_file, fragment_check_list[jdx]
             )
     assert all_ok
-
-
-def test_cleanup(run_dunerc):
-    if len(computers_that_are_unreachable) > 0:
-        pytest.skip(f"One or more needed computers are unreachable ({computers_that_are_unreachable}).")
-    if not pytest_tmpdir_looks_reasonable:
-        pytest.skip("The PYTEST_DEBUG_TEMPROOT env var has not been set to point to a valid directory.")
-
-    utility_functions.remove_hdf5_files_if_requested(run_dunerc, this_test_requests_hdf5_file_removal=False)

--- a/integtest/sample_ehn1_multihost_test.py
+++ b/integtest/sample_ehn1_multihost_test.py
@@ -32,8 +32,8 @@ import string
 
 import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
-import integrationtest.basic_checks as basic_checks
 import integrationtest.data_classes as data_classes
+import integrationtest.utility_functions as utility_functions
 from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
 import functools
@@ -321,7 +321,7 @@ def test_dunerc_success(run_dunerc, capsys, caplog):
     #    print("*** WARNING: the cleanup of stale _gunicorn_ process on np04-srv-028 did not succeed...")
 
     # check on run control success, problems during pytest setup, etc.
-    basic_checks.basic_checks(run_dunerc, caplog, print_test_name=False)
+    utility_functions.basic_checks(run_dunerc, caplog, print_test_name=False)
 
 
 def test_log_files(run_dunerc):
@@ -455,3 +455,7 @@ def test_tpstream_files(run_dunerc):
                 data_file, fragment_check_list[jdx]
             )
     assert all_ok
+
+
+def test_cleanup(run_dunerc):
+    utility_functions.remove_hdf5_files_if_requested(run_dunerc, this_test_requests_hdf5_file_removal=False)

--- a/integtest/small_footprint_quick_test.py
+++ b/integtest/small_footprint_quick_test.py
@@ -141,7 +141,3 @@ def test_data_files(run_dunerc):
                 data_file, fragment_check_list[jdx]
             )
     assert all_ok
-
-
-def test_cleanup(run_dunerc):
-    utility_functions.remove_hdf5_files_if_requested(run_dunerc, this_test_requests_hdf5_file_removal=False)

--- a/integtest/small_footprint_quick_test.py
+++ b/integtest/small_footprint_quick_test.py
@@ -3,9 +3,9 @@ import urllib.request
 
 import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
-import integrationtest.basic_checks as basic_checks
 import integrationtest.data_classes as data_classes
 import integrationtest.resource_validation as resource_validation
+import integrationtest.utility_functions as utility_functions
 from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
 from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
@@ -98,7 +98,7 @@ dunerc_command_list = (
 
 def test_dunerc_success(run_dunerc, caplog):
     # checks for run control success, problems during pytest setup, etc.
-    basic_checks.basic_checks(run_dunerc, caplog, print_test_name=False)
+    utility_functions.basic_checks(run_dunerc, caplog, print_test_name=False)
 
 
 def test_log_files(run_dunerc):
@@ -133,3 +133,7 @@ def test_data_files(run_dunerc):
                 data_file, fragment_check_list[jdx]
             )
     assert all_ok
+
+
+def test_cleanup(run_dunerc):
+    utility_functions.remove_hdf5_files_if_requested(run_dunerc, this_test_requests_hdf5_file_removal=False)

--- a/integtest/tpg_state_collection_test.py
+++ b/integtest/tpg_state_collection_test.py
@@ -351,7 +351,3 @@ def test_metric_files(run_dunerc):
                                                          verbosity_helper=run_dunerc.verbosity_helper)
 
     assert all_ok
-
-
-def test_cleanup(run_dunerc):
-    utility_functions.remove_hdf5_files_if_requested(run_dunerc, this_test_requests_hdf5_file_removal=False)

--- a/integtest/tpg_state_collection_test.py
+++ b/integtest/tpg_state_collection_test.py
@@ -3,10 +3,10 @@ import urllib.request
 
 import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
-import integrationtest.basic_checks as basic_checks
 import integrationtest.data_classes as data_classes
 import integrationtest.opmon_metric_checks as opmon_metric_checks
 import integrationtest.resource_validation as resource_validation
+import integrationtest.utility_functions as utility_functions
 from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
 from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
@@ -205,7 +205,7 @@ dunerc_command_list = (
 
 def test_dunerc_success(run_dunerc, caplog):
     # checks for run control success, problems during pytest setup, etc.
-    basic_checks.basic_checks(run_dunerc, caplog, print_test_name=False)
+    utility_functions.basic_checks(run_dunerc, caplog, print_test_name=False)
 
 
 def test_log_files(run_dunerc):
@@ -351,3 +351,7 @@ def test_metric_files(run_dunerc):
                                                          verbosity_helper=run_dunerc.verbosity_helper)
 
     assert all_ok
+
+
+def test_cleanup(run_dunerc):
+    utility_functions.remove_hdf5_files_if_requested(run_dunerc, this_test_requests_hdf5_file_removal=False)

--- a/integtest/tpreplay_test.py
+++ b/integtest/tpreplay_test.py
@@ -35,8 +35,8 @@ import tempfile
 import integrationtest.data_classes as data_classes
 import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
-import integrationtest.basic_checks as basic_checks
 import integrationtest.resource_validation as resource_validation
+import integrationtest.utility_functions as utility_functions
 from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
 from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
@@ -255,7 +255,7 @@ atexit.register(_cleanup_tmpdir)
 # Run control
 def test_dunerc_success(run_dunerc, caplog):
     # checks for run control success, problems during pytest setup, etc.
-    basic_checks.basic_checks(run_dunerc, caplog, print_test_name=True)
+    utility_functions.basic_checks(run_dunerc, caplog, print_test_name=True)
 
 # Log files
 def test_log_files(run_dunerc):
@@ -330,3 +330,6 @@ def test_data_files(run_dunerc):
 
     assert all_ok, "\N{POLICE CARS REVOLVING LIGHT} One or more data file checks failed! \N{POLICE CARS REVOLVING LIGHT}"
 
+
+def test_cleanup(run_dunerc):
+    utility_functions.remove_hdf5_files_if_requested(run_dunerc, this_test_requests_hdf5_file_removal=False)

--- a/integtest/tpreplay_test.py
+++ b/integtest/tpreplay_test.py
@@ -329,7 +329,3 @@ def test_data_files(run_dunerc):
         print(f"\N{POLICE CARS REVOLVING LIGHT} The number of unique Source IDs is NOT as expected ({selected_params['n_sids_tp'], selected_params['n_sids_ta'], selected_params['n_sids_tc']})! \N{POLICE CARS REVOLVING LIGHT}")
 
     assert all_ok, "\N{POLICE CARS REVOLVING LIGHT} One or more data file checks failed! \N{POLICE CARS REVOLVING LIGHT}"
-
-
-def test_cleanup(run_dunerc):
-    utility_functions.remove_hdf5_files_if_requested(run_dunerc, this_test_requests_hdf5_file_removal=False)

--- a/integtest/tpstream_writing_test.py
+++ b/integtest/tpstream_writing_test.py
@@ -270,7 +270,3 @@ def test_tpstream_files(run_dunerc):
                 data_file, fragment_check_list[jdx]
             )
     assert all_ok
-
-
-def test_cleanup(run_dunerc):
-    utility_functions.remove_hdf5_files_if_requested(run_dunerc, this_test_requests_hdf5_file_removal=False)

--- a/integtest/tpstream_writing_test.py
+++ b/integtest/tpstream_writing_test.py
@@ -3,9 +3,9 @@ import urllib.request
 
 import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
-import integrationtest.basic_checks as basic_checks
 import integrationtest.data_classes as data_classes
 import integrationtest.resource_validation as resource_validation
+import integrationtest.utility_functions as utility_functions
 from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
 from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
@@ -184,7 +184,7 @@ dunerc_command_list = (
 
 def test_dunerc_success(run_dunerc, caplog):
     # checks for run control success, problems during pytest setup, etc.
-    basic_checks.basic_checks(run_dunerc, caplog, print_test_name=False)
+    utility_functions.basic_checks(run_dunerc, caplog, print_test_name=False)
 
 
 def test_log_files(run_dunerc):
@@ -270,3 +270,7 @@ def test_tpstream_files(run_dunerc):
                 data_file, fragment_check_list[jdx]
             )
     assert all_ok
+
+
+def test_cleanup(run_dunerc):
+    utility_functions.remove_hdf5_files_if_requested(run_dunerc, this_test_requests_hdf5_file_removal=False)

--- a/integtest/trigger_bitwords_test.py
+++ b/integtest/trigger_bitwords_test.py
@@ -342,7 +342,3 @@ def test_data_files(run_dunerc):
             print(f"\N{POLICE CARS REVOLVING LIGHT} The TR type multiplicity is NOT as expected ({selected_params['multi_required']})! \N{POLICE CARS REVOLVING LIGHT}")
 
     assert all_ok, "\N{POLICE CARS REVOLVING LIGHT} One or more data file checks failed! \N{POLICE CARS REVOLVING LIGHT}"
-
-
-def test_cleanup(run_dunerc):
-    utility_functions.remove_hdf5_files_if_requested(run_dunerc, this_test_requests_hdf5_file_removal=False)

--- a/integtest/trigger_bitwords_test.py
+++ b/integtest/trigger_bitwords_test.py
@@ -34,8 +34,8 @@ import string
 import integrationtest.data_classes as data_classes
 import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
-import integrationtest.basic_checks as basic_checks
 import integrationtest.resource_validation as resource_validation
+import integrationtest.utility_functions as utility_functions
 from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
 from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
@@ -249,7 +249,7 @@ dunerc_command_list += "scrap terminate".split()
 # Run control
 def test_dunerc_success(run_dunerc, caplog):
     # checks for run control success, problems during pytest setup, etc.
-    basic_checks.basic_checks(run_dunerc, caplog, print_test_name=True)
+    utility_functions.basic_checks(run_dunerc, caplog, print_test_name=True)
 
 # Log files
 def test_log_files(run_dunerc):
@@ -343,3 +343,6 @@ def test_data_files(run_dunerc):
 
     assert all_ok, "\N{POLICE CARS REVOLVING LIGHT} One or more data file checks failed! \N{POLICE CARS REVOLVING LIGHT}"
 
+
+def test_cleanup(run_dunerc):
+    utility_functions.remove_hdf5_files_if_requested(run_dunerc, this_test_requests_hdf5_file_removal=False)


### PR DESCRIPTION
# Description

The ability to remove HDF5 files at the end of each integtest (upon user request) was suggested some time ago in discussions about changes to the `integrationtest` infrastructure.  The `integrationtest` code has been modified to support this functionality (DUNE-DAQ/integrationtest#157), and the changes in this PR take advantage of those changes.

These changes should be tested and merged in conjunction with the changes in the `integrationtest` and other repos.  Please see DUNE-DAQ/integrationtest#157 for suggested testing steps.

## Type of change

- [x] Optimization (non-breaking change that improves code/performance)

## Testing checklist

- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
