### PR TITLE
Modified the 3ru_1df integtest so that it asks run control to start the Connectivity Service...

### DIFF
--- a/integtest/3ru_1df_multirun_test.py
+++ b/integtest/3ru_1df_multirun_test.py
@@ -106,6 +106,9 @@ conf_dict.dro_map_config.n_apps = number_of_readout_apps
 conf_dict.op_env = "integtest"
 conf_dict.config_session_name = "3ru1df"
 conf_dict.tpg_enabled = False
+# To verify that the ability to have run control start the Connectivity Service continues to
+# work, we include that option in this integtest.
+conf_dict.connsvc_control = data_classes.ConnSvcControl.RUNCONTROL
 
 conf_dict.config_substitutions.append(
     data_classes.attribute_substitution(
@@ -170,6 +173,13 @@ def test_dunerc_success(run_dunerc, caplog):
 
 
 def test_log_files(run_dunerc):
+    # Check that the ConnSvc log file has the name that run control uses
+    if not any(
+        f"{run_dunerc.daq_session_name}_local-connection-server" in str(logname) for logname in run_dunerc.log_files
+    ):
+        fail_msg = "It appears that something other than run control started the Connectivity Service, based on the name of the ConnSvc log file, and one of the conditions of this integtest is to have RC start the ConnSvc."
+        pytest.fail(fail_msg, pytrace=False)
+
     if check_for_logfile_errors:
         # Check that there are no warnings or errors in the log files
         assert log_file_checks.logs_are_error_free(


### PR DESCRIPTION
… (so that we validate that this functionality continues to work).

# Description

In our discussions on Slack and in the SWI&T meeting today about the possibility of getting rid of the CONNECTION_PORT env var in our example configuration, I realized that none of our existing integration tests make use of the functionality in which `drunc` starts the Connectivity Service.

I would like to remedy that situation, and my thought is to modify an existing test to do that, rather than creating a brand new test.  I chose the `3ru_1df_multirun_test` since it is one that is commonly run and it tests a moderate amount of DAQ system functionality.

To test this change, we can include the changes in this PR in a software area based on a recently nightly build, run the `3ru_1df` test, and verify that the integtest continues to run without problems.  An example way to run the integtest would be the following:

```
dunedaq_integtest_bundle.sh -k 1df --verb 2
```

## Type of change

- [x] Optimization (non-breaking change that improves code/performance)

## Testing checklist

- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
