### PR TITLE
Modified the small_footprint_quick_test to check if the overall DAQ session run time is getting longer...

### DIFF
--- a/integtest/small_footprint_quick_test.py
+++ b/integtest/small_footprint_quick_test.py
@@ -100,7 +100,7 @@ def test_dunerc_success(run_dunerc, caplog):
     # checks for run control success, problems during pytest setup, etc.
     basic_checks.basic_checks(run_dunerc, caplog, print_test_name=False)
 
-    expected_max_time_sec = 60
+    expected_max_time_sec = 65
     if run_dunerc.daq_session_overall_time > expected_max_time_sec:
         fail_msg = f"The run control session took longer than expected. The overall run time was {round(run_dunerc.daq_session_overall_time,1)} sec, and the typical run time is less than {expected_max_time_sec} sec. Check whether one or more transitions are now taking longer to complete."
         pytest.fail(fail_msg, pytrace=False)

--- a/integtest/small_footprint_quick_test.py
+++ b/integtest/small_footprint_quick_test.py
@@ -104,6 +104,9 @@ def test_dunerc_success(run_dunerc, caplog):
     if run_dunerc.daq_session_overall_time > expected_max_time_sec:
         fail_msg = f"The run control session took longer than expected. The overall run time was {round(run_dunerc.daq_session_overall_time,1)} sec, and the typical run time is less than {expected_max_time_sec} sec. Check whether one or more transitions are now taking longer to complete."
         pytest.fail(fail_msg, pytrace=False)
+    else:
+        run_dunerc.verbosity_helper.lvl_print(IntegtestVerbosityLevels.drunc_transitions,
+                                              f"\N{WHITE HEAVY CHECK MARK} The run control session took the expected amount of time (<={expected_max_time_sec} sec)")
 
 
 def test_log_files(run_dunerc):

--- a/integtest/small_footprint_quick_test.py
+++ b/integtest/small_footprint_quick_test.py
@@ -100,9 +100,9 @@ def test_dunerc_success(run_dunerc, caplog):
     # checks for run control success, problems during pytest setup, etc.
     basic_checks.basic_checks(run_dunerc, caplog, print_test_name=False)
 
-    #print(f"\nDAQ session overall time: {run_dunerc.daq_session_overall_time} seconds")
-    if run_dunerc.daq_session_overall_time > 60:
-        fail_msg = f"The run control session took longer than expected. The overall run time was {round(run_dunerc.daq_session_overall_time,1)} sec, and the typical run time is less than 60 sec. Check whether one or more transitions are now taking longer to complete."
+    expected_max_time_sec = 60
+    if run_dunerc.daq_session_overall_time > expected_max_time_sec:
+        fail_msg = f"The run control session took longer than expected. The overall run time was {round(run_dunerc.daq_session_overall_time,1)} sec, and the typical run time is less than {expected_max_time_sec} sec. Check whether one or more transitions are now taking longer to complete."
         pytest.fail(fail_msg, pytrace=False)
 
 

--- a/integtest/small_footprint_quick_test.py
+++ b/integtest/small_footprint_quick_test.py
@@ -100,6 +100,11 @@ def test_dunerc_success(run_dunerc, caplog):
     # checks for run control success, problems during pytest setup, etc.
     basic_checks.basic_checks(run_dunerc, caplog, print_test_name=False)
 
+    #print(f"\nDAQ session overall time: {run_dunerc.daq_session_overall_time} seconds")
+    if run_dunerc.daq_session_overall_time > 60:
+        fail_msg = f"The run control session took longer than expected. The overall run time was {round(run_dunerc.daq_session_overall_time,1)} sec, and the typical run time is less than 60 sec. Check whether one or more transitions are now taking longer to complete."
+        pytest.fail(fail_msg, pytrace=False)
+
 
 def test_log_files(run_dunerc):
     if check_for_logfile_errors:


### PR DESCRIPTION
... (which may indicate an undesirable change)

# Description

It would have been great if the extra delay in the DAQ system at shutdown time that we fixed recently (DUNE-DAQ/ipm#124) had been noticed independent of the "exit code 137" and garbled OpMon strings that _were_ noticed.  That extra delay added ~20 seconds to the overall runtime of a simple DAQ session.

The changes in this PR add such a check to the existing `small_footprint_quick_test` regression test.  Hopefully, this will help us catch changes in the overall runtime of a DAQ session more quickly if/when it ever happens again.

Here are suggested instructions for testing these changes:

```
DATE_PREFIX=`date '+%d%b'`
TIME_SUFFIX=`date '+%H%M'`

source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
setup_dbt latest
dbt-create -n NFD_DEV_260616_A9 ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}
cd ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}/sourcecode

git clone https://github.com/DUNE-DAQ/daqsystemtest.git -b kbiery/sfqt_overall_runtime_check
git clone https://github.com/DUNE-DAQ/dfmodules.git -b develop
git clone https://github.com/DUNE-DAQ/fdreadoutmodules.git -b develop
git clone https://github.com/DUNE-DAQ/hsilibs.git -b develop
git clone https://github.com/DUNE-DAQ/trigger.git -b develop
git clone https://github.com/DUNE-DAQ/ipm.git -b develop
cd ipm ; git checkout 233209724d6; cd ..
cd ..

. ./env.sh
dbt-build -j 2
dbt-workarea-env

dunedaq_integtest_bundle.sh -k small

echo ""
echo -e "\U1F535 \U2705 Note that the SFQT integtest failed because the overall runtime was too long. \U2705 \U1F535"
echo ""
echo ""
sleep 3

cd sourcecode/ipm
git checkout develop
cd ../..
dbt-build -j 12
dbt-workarea-env

dunedaq_integtest_bundle.sh -k small

echo ""
echo -e "\U1F535 \U2705 Note that the SFQT integtest passes with the latest IPM code. \U2705 \U1F535"
echo ""
echo ""
```

## Type of change

- [x] Optimization (non-breaking change that improves code/performance)

## Testing checklist

- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
