### PR TITLE
Modified integtests to make use of new utility functions for setting trigger config params

### DIFF
--- a/integtest/3ru_1df_multirun_test.py
+++ b/integtest/3ru_1df_multirun_test.py
@@ -8,6 +8,7 @@ import integrationtest.log_file_checks as log_file_checks
 import integrationtest.basic_checks as basic_checks
 import integrationtest.data_classes as data_classes
 import integrationtest.resource_validation as resource_validation
+import integrationtest.utility_functions2 as utility_functions
 from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
 from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
@@ -106,13 +107,8 @@ conf_dict.dro_map_config.n_apps = number_of_readout_apps
 conf_dict.op_env = "integtest"
 conf_dict.config_session_name = "3ru1df"
 conf_dict.tpg_enabled = False
+utility_functions.set_RTCM_trigger_params(conf_dict, trigger_rate=trigger_rate)
 
-conf_dict.config_substitutions.append(
-    data_classes.attribute_substitution(
-        obj_class="RandomTCMakerConf",
-        updates={"trigger_rate_hz": trigger_rate},
-    )
-)
 conf_dict.config_substitutions.append(
     data_classes.attribute_substitution(
         obj_class="LatencyBuffer", updates={"size": 200000}

--- a/integtest/3ru_1df_multirun_test.py
+++ b/integtest/3ru_1df_multirun_test.py
@@ -106,7 +106,7 @@ conf_dict.dro_map_config.n_apps = number_of_readout_apps
 conf_dict.op_env = "integtest"
 conf_dict.config_session_name = "3ru1df"
 conf_dict.tpg_enabled = False
-utility_functions.set_RTCM_trigger_params(conf_dict, trigger_rate=trigger_rate)
+utility_functions.set_rtcm_trigger_params(conf_dict, trigger_rate=trigger_rate)
 # To verify that the ability to have run control start the Connectivity Service continues to
 # work, we include that option in this integtest.
 conf_dict.connsvc_control = data_classes.ConnSvcControl.RUNCONTROL

--- a/integtest/3ru_3df_multirun_test.py
+++ b/integtest/3ru_3df_multirun_test.py
@@ -131,7 +131,7 @@ conf_dict.op_env = "integtest"
 conf_dict.config_session_name = "3ru3df"
 conf_dict.tpg_enabled = False
 conf_dict.n_df_apps = number_of_dataflow_apps
-utility_functions.set_RTCM_trigger_params(conf_dict, trigger_rate=trigger_rate)
+utility_functions.set_rtcm_trigger_params(conf_dict, trigger_rate=trigger_rate)
 
 conf_dict.config_substitutions.append(
     data_classes.attribute_substitution(

--- a/integtest/3ru_3df_multirun_test.py
+++ b/integtest/3ru_3df_multirun_test.py
@@ -7,6 +7,7 @@ import integrationtest.log_file_checks as log_file_checks
 import integrationtest.basic_checks as basic_checks
 import integrationtest.data_classes as data_classes
 import integrationtest.resource_validation as resource_validation
+import integrationtest.utility_functions2 as utility_functions
 from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
 from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
@@ -131,13 +132,8 @@ conf_dict.op_env = "integtest"
 conf_dict.config_session_name = "3ru3df"
 conf_dict.tpg_enabled = False
 conf_dict.n_df_apps = number_of_dataflow_apps
+utility_functions.set_RTCM_trigger_params(conf_dict, trigger_rate=trigger_rate)
 
-conf_dict.config_substitutions.append(
-    data_classes.attribute_substitution(
-        obj_class="RandomTCMakerConf",
-        updates={"trigger_rate_hz": trigger_rate},
-    )
-)
 conf_dict.config_substitutions.append(
     data_classes.attribute_substitution(
         obj_class="LatencyBuffer", updates={"size": 200000}

--- a/integtest/fake_data_producer_test.py
+++ b/integtest/fake_data_producer_test.py
@@ -9,6 +9,7 @@ import integrationtest.log_file_checks as log_file_checks
 import integrationtest.basic_checks as basic_checks
 import integrationtest.data_classes as data_classes
 import integrationtest.resource_validation as resource_validation
+import integrationtest.utility_functions2 as utility_functions
 from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
 from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
@@ -70,28 +71,11 @@ conf_dict.op_env = "integtest"
 conf_dict.config_session_name = "fakedata"
 conf_dict.use_fakedataprod = True
 conf_dict.dro_map_config.n_streams = number_of_data_producers
-
-conf_dict.config_substitutions.append(
-    data_classes.attribute_substitution(
-     obj_id="random-tc-generator",
-     obj_class="RandomTCMakerConf",
-        updates={"trigger_rate_hz": 1},
-    )
-)
+utility_functions.set_RTCM_trigger_params(conf_dict, trigger_rate=1)
 
 doublewindow_conf = copy.deepcopy(conf_dict)
-
-doublewindow_conf.config_substitutions.append(
-    data_classes.attribute_substitution(
-        obj_class="RandomTCMakerConf",
-        obj_id = "random-tc-generator",
-        updates={
-            "candidate_backshift_ts": 0,
-            "candidate_window_before_ts": 2000,
-            "candidate_window_after_ts": 2001,
-        },
-    )
-)
+utility_functions.set_RTCM_trigger_params(doublewindow_conf, readout_window_backshift_ticks=0,
+                                          readout_window_before_ticks=2000, readout_window_after_ticks=2001)
 
 confgen_arguments = {
     "Baseline_Window_Size": conf_dict,

--- a/integtest/fake_data_producer_test.py
+++ b/integtest/fake_data_producer_test.py
@@ -70,10 +70,10 @@ conf_dict.op_env = "integtest"
 conf_dict.config_session_name = "fakedata"
 conf_dict.use_fakedataprod = True
 conf_dict.dro_map_config.n_streams = number_of_data_producers
-utility_functions.set_RTCM_trigger_params(conf_dict, trigger_rate=1)
+utility_functions.set_rtcm_trigger_params(conf_dict, trigger_rate=1)
 
 doublewindow_conf = copy.deepcopy(conf_dict)
-utility_functions.set_RTCM_trigger_params(doublewindow_conf, readout_window_backshift_ticks=0,
+utility_functions.set_rtcm_trigger_params(doublewindow_conf, readout_window_backshift_ticks=0,
                                           readout_window_before_ticks=2000, readout_window_after_ticks=2001)
 
 confgen_arguments = {

--- a/integtest/long_window_readout_test.py
+++ b/integtest/long_window_readout_test.py
@@ -21,6 +21,7 @@ import integrationtest.log_file_checks as log_file_checks
 import integrationtest.basic_checks as basic_checks
 import integrationtest.data_classes as data_classes
 import integrationtest.resource_validation as resource_validation
+import integrationtest.utility_functions2 as utility_functions
 from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
 from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
@@ -93,6 +94,11 @@ conf_dict.config_session_name = "longwindow"
 conf_dict.tpg_enabled = False
 conf_dict.n_df_apps = number_of_dataflow_apps
 conf_dict.fake_hsi_enabled = False
+utility_functions.set_RTCM_trigger_params(conf_dict,
+                                          trigger_rate=trigger_rate,
+                                          readout_window_backshift_ticks=0,
+                                          readout_window_before_ticks=readout_window_time_before,
+                                          readout_window_after_ticks=readout_window_time_after)
 
 conf_dict.config_substitutions.append(
     data_classes.attribute_substitution(
@@ -100,24 +106,6 @@ conf_dict.config_substitutions.append(
     )
 )
 
-
-conf_dict.config_substitutions.append(
-    data_classes.attribute_substitution(
-        obj_class="RandomTCMakerConf",
-        updates={"trigger_rate_hz": trigger_rate},
-    )
-)
-conf_dict.config_substitutions.append(
-    data_classes.attribute_substitution(
-        obj_class="RandomTCMakerConf",
-        obj_id = "random-tc-generator",
-        updates={
-            "candidate_backshift_ts": 0,
-            "candidate_window_before_ts": readout_window_time_before,
-            "candidate_window_after_ts": readout_window_time_after,
-        },
-    )
-)
 conf_dict.config_substitutions.append(
     data_classes.attribute_substitution(
         obj_class="DataStoreConf",

--- a/integtest/long_window_readout_test.py
+++ b/integtest/long_window_readout_test.py
@@ -94,7 +94,7 @@ conf_dict.tpg_enabled = False
 conf_dict.n_df_apps = number_of_dataflow_apps
 conf_dict.fake_hsi_enabled = False
 conf_dict.remove_hdf5_files = True
-utility_functions.set_RTCM_trigger_params(conf_dict,
+utility_functions.set_rtcm_trigger_params(conf_dict,
                                           trigger_rate=trigger_rate,
                                           readout_window_backshift_ticks=0,
                                           readout_window_before_ticks=readout_window_time_before,

--- a/integtest/minimal_system_quick_test.py
+++ b/integtest/minimal_system_quick_test.py
@@ -75,7 +75,7 @@ conf_dict.dro_map_config.n_streams = number_of_data_producers
 conf_dict.op_env = "integtest"
 conf_dict.config_session_name = "minimal"
 conf_dict.tpg_enabled = False
-utility_functions.set_RTCM_trigger_params(conf_dict, trigger_rate=1)
+utility_functions.set_rtcm_trigger_params(conf_dict, trigger_rate=1)
 
 # For testing, allow drunc to manage ConnectivityService
 #conf_dict.connsvc_control = ConnSvcControl.RUNCONTROL

--- a/integtest/minimal_system_quick_test.py
+++ b/integtest/minimal_system_quick_test.py
@@ -7,6 +7,7 @@ import integrationtest.basic_checks as basic_checks
 import integrationtest.data_classes as data_classes
 import integrationtest.resource_validation as resource_validation
 import integrationtest.opmon_metric_checks as opmon_metric_checks
+import integrationtest.utility_functions2 as utility_functions
 from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
 from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
@@ -18,8 +19,6 @@ pytest_plugins = "integrationtest.integrationtest_drunc"
 # Values that help determine the running conditions
 number_of_data_producers = 2
 run_duration = 20  # seconds
-readout_window_time_before = 1000
-readout_window_time_after = 1001
 
 # Default values for validation parameters
 expected_number_of_data_files = 1
@@ -77,31 +76,15 @@ conf_dict.dro_map_config.n_streams = number_of_data_producers
 conf_dict.op_env = "integtest"
 conf_dict.config_session_name = "minimal"
 conf_dict.tpg_enabled = False
+utility_functions.set_RTCM_trigger_params(conf_dict, trigger_rate=1)
 
 # For testing, allow drunc to manage ConnectivityService
 #conf_dict.connsvc_control = ConnSvcControl.RUNCONTROL
 # For testing, specify connectivity service port (default is 0, a random port is chosen for the Connectivity Service)
 #conf_dict.connsvc_port = 12345
 
-substitution = data_classes.attribute_substitution(
-    obj_id="random-tc-generator",
-    obj_class="RandomTCMakerConf",
-    updates={"trigger_rate_hz": 1},
-)
-conf_dict.config_substitutions.append(
-    data_classes.attribute_substitution(
-        obj_class="TCReadoutMap",
-        obj_id = "def-random-readout",
-        updates={
-            "time_before": readout_window_time_before,
-            "time_after": readout_window_time_after,
-        },
-    )
-)
-conf_dict.config_substitutions.append(substitution)
-
-
 confgen_arguments = {"MinimalSystem": conf_dict}
+
 # The commands to run in dunerc, as a list
 dunerc_command_list = (
     "boot conf start --run-number 101 wait 1 enable-triggers wait ".split()

--- a/integtest/readout_type_scan_test.py
+++ b/integtest/readout_type_scan_test.py
@@ -180,7 +180,7 @@ conf_dict.op_env = "integtest"
 conf_dict.config_session_name = "readout"
 conf_dict.tpg_enabled = False
 conf_dict.frame_file = "asset://?label=ProtoWIB&subsystem=readout"  # ProtoWIB
-utility_functions.set_RTCM_trigger_params(conf_dict, trigger_rate=1)
+utility_functions.set_rtcm_trigger_params(conf_dict, trigger_rate=1)
 
 wib_tpg_conf = copy.deepcopy(conf_dict)
 wib_tpg_conf.tpg_enabled = True
@@ -247,7 +247,7 @@ tde_tpg_conf.config_substitutions.append(
 daphne_stream_conf = copy.deepcopy(conf_dict)
 daphne_stream_conf.dro_map_config.det_id = 2  # det_id = 2 for HD_PDS
 daphne_stream_conf.frame_file = "asset://?label=DAPHNEStream&subsystem=readout"
-utility_functions.set_RTCM_trigger_params(daphne_stream_conf, readout_window_backshift_ticks=0,
+utility_functions.set_rtcm_trigger_params(daphne_stream_conf, readout_window_backshift_ticks=0,
                                           readout_window_before_ticks=62000, readout_window_after_ticks=500)
 
 daphne_eth_stream_conf = copy.deepcopy(conf_dict)
@@ -256,13 +256,13 @@ daphne_eth_stream_conf.use_fakedataprod = True
 daphne_eth_stream_conf.fake_data_fragment_type = "DAPHNEEthStream"
 # TODO: replace use_fakedataprod with asset file once one exists
 # daphne_eth_stream_conf.frame_file = "asset://?label=DAPHNEEthStream&subsystem=readout"
-utility_functions.set_RTCM_trigger_params(daphne_eth_stream_conf, readout_window_backshift_ticks=0,
+utility_functions.set_rtcm_trigger_params(daphne_eth_stream_conf, readout_window_backshift_ticks=0,
                                           readout_window_before_ticks=62000, readout_window_after_ticks=500)
 
 daphne_conf = copy.deepcopy(conf_dict)
 daphne_conf.dro_map_config.det_id = 2  # det_id = 2 for HD_PDS
 daphne_conf.frame_file = "asset://?checksum=a8990a9eb3a505d4ded62dfdfa9e2681" # np02vd_run036012_sample_membrane_pds
-utility_functions.set_RTCM_trigger_params(daphne_conf, readout_window_backshift_ticks=0,
+utility_functions.set_rtcm_trigger_params(daphne_conf, readout_window_backshift_ticks=0,
                                           readout_window_before_ticks=62000, readout_window_after_ticks=500)
 
 daphne_tpg_conf = copy.deepcopy(daphne_conf)
@@ -281,7 +281,7 @@ daphne_eth_conf.use_fakedataprod = True
 daphne_eth_conf.fake_data_fragment_type = "DAPHNEEth"
 # TODO: replace use_fakedataprod with asset file once one exists
 # daphne_eth_conf.frame_file = "asset://?label=DAPHNEEth&subsystem=readout"
-utility_functions.set_RTCM_trigger_params(daphne_eth_conf, readout_window_backshift_ticks=0,
+utility_functions.set_rtcm_trigger_params(daphne_eth_conf, readout_window_backshift_ticks=0,
                                           readout_window_before_ticks=62000, readout_window_after_ticks=500)
 
 daphne_eth_tpg_conf = copy.deepcopy(daphne_eth_conf)
@@ -297,24 +297,14 @@ daphne_eth_tpg_conf.config_substitutions.append(
 bern_crt_conf = copy.deepcopy(conf_dict)
 bern_crt_conf.dro_map_config.det_id = 12
 bern_crt_conf.frame_file = "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798" # WIBEth All Zeros
-bern_crt_conf.config_substitutions.append(
-    data_classes.attribute_substitution(
-        obj_class="RandomTCMakerConf",
-        obj_id="random-tc-generator",
-        updates={"candidate_window_before_ts": 8000, "candidate_window_after_ts": 10},
-    )
-)
+utility_functions.set_rtcm_trigger_params(bern_crt_conf, readout_window_before_ticks=8000,
+                                          readout_window_after_ticks=10)
 
 grenoble_crt_conf = copy.deepcopy(conf_dict)
 grenoble_crt_conf.dro_map_config.det_id = 13
 grenoble_crt_conf.frame_file = "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798" # WIBEth All Zeros
-grenoble_crt_conf.config_substitutions.append(
-    data_classes.attribute_substitution(
-        obj_class="RandomTCMakerConf",
-        obj_id="random-tc-generator",
-        updates={"candidate_window_before_ts": 8000, "candidate_window_after_ts": 10},
-    )
-)
+utility_functions.set_rtcm_trigger_params(grenoble_crt_conf, readout_window_before_ticks=8000,
+                                          readout_window_after_ticks=10)
 
 confgen_arguments = {
     "WIBEth_System": wibeth_conf,

--- a/integtest/readout_type_scan_test.py
+++ b/integtest/readout_type_scan_test.py
@@ -8,6 +8,7 @@ import integrationtest.log_file_checks as log_file_checks
 import integrationtest.basic_checks as basic_checks
 import integrationtest.data_classes as data_classes
 import integrationtest.resource_validation as resource_validation
+import integrationtest.utility_functions2 as utility_functions
 from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
 from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
@@ -180,13 +181,7 @@ conf_dict.op_env = "integtest"
 conf_dict.config_session_name = "readout"
 conf_dict.tpg_enabled = False
 conf_dict.frame_file = "asset://?label=ProtoWIB&subsystem=readout"  # ProtoWIB
-
-conf_dict.config_substitutions.append(
-    data_classes.attribute_substitution(
-        obj_class="RandomTCMakerConf",
-        updates={"trigger_rate_hz": 1},
-    )
-)
+utility_functions.set_RTCM_trigger_params(conf_dict, trigger_rate=1)
 
 wib_tpg_conf = copy.deepcopy(conf_dict)
 wib_tpg_conf.tpg_enabled = True
@@ -253,18 +248,8 @@ tde_tpg_conf.config_substitutions.append(
 daphne_stream_conf = copy.deepcopy(conf_dict)
 daphne_stream_conf.dro_map_config.det_id = 2  # det_id = 2 for HD_PDS
 daphne_stream_conf.frame_file = "asset://?label=DAPHNEStream&subsystem=readout"
-
-daphne_stream_conf.config_substitutions.append(
-    data_classes.attribute_substitution(
-        obj_class="RandomTCMakerConf",
-        obj_id = "random-tc-generator",
-        updates={
-            "candidate_backshift_ts": 0,
-            "candidate_window_before_ts": 62000,
-            "candidate_window_after_ts": 500,
-        },
-    )
-)
+utility_functions.set_RTCM_trigger_params(daphne_stream_conf, readout_window_backshift_ticks=0,
+                                          readout_window_before_ticks=62000, readout_window_after_ticks=500)
 
 daphne_eth_stream_conf = copy.deepcopy(conf_dict)
 daphne_eth_stream_conf.dro_map_config.det_id = 2  # det_id = 2 for HD_PDS
@@ -272,33 +257,14 @@ daphne_eth_stream_conf.use_fakedataprod = True
 daphne_eth_stream_conf.fake_data_fragment_type = "DAPHNEEthStream"
 # TODO: replace use_fakedataprod with asset file once one exists
 # daphne_eth_stream_conf.frame_file = "asset://?label=DAPHNEEthStream&subsystem=readout"
-
-daphne_eth_stream_conf.config_substitutions.append(
-    data_classes.attribute_substitution(
-        obj_class="RandomTCMakerConf",
-        obj_id = "random-tc-generator",
-        updates={
-            "candidate_backshift_ts": 0,
-            "candidate_window_before_ts": 62000,
-            "candidate_window_after_ts": 500,
-        },
-    )
-)
+utility_functions.set_RTCM_trigger_params(daphne_eth_stream_conf, readout_window_backshift_ticks=0,
+                                          readout_window_before_ticks=62000, readout_window_after_ticks=500)
 
 daphne_conf = copy.deepcopy(conf_dict)
 daphne_conf.dro_map_config.det_id = 2  # det_id = 2 for HD_PDS
 daphne_conf.frame_file = "asset://?checksum=a8990a9eb3a505d4ded62dfdfa9e2681" # np02vd_run036012_sample_membrane_pds
-daphne_conf.config_substitutions.append(
-    data_classes.attribute_substitution(
-        obj_class="RandomTCMakerConf",
-        obj_id = "random-tc-generator",
-        updates={
-            "candidate_backshift_ts": 0,
-            "candidate_window_before_ts": 62000,
-            "candidate_window_after_ts": 500,
-        },
-    )
-)
+utility_functions.set_RTCM_trigger_params(daphne_conf, readout_window_backshift_ticks=0,
+                                          readout_window_before_ticks=62000, readout_window_after_ticks=500)
 
 daphne_tpg_conf = copy.deepcopy(daphne_conf)
 daphne_tpg_conf.tpg_enabled = True
@@ -316,17 +282,8 @@ daphne_eth_conf.use_fakedataprod = True
 daphne_eth_conf.fake_data_fragment_type = "DAPHNEEth"
 # TODO: replace use_fakedataprod with asset file once one exists
 # daphne_eth_conf.frame_file = "asset://?label=DAPHNEEth&subsystem=readout"
-daphne_eth_conf.config_substitutions.append(
-    data_classes.attribute_substitution(
-        obj_class="RandomTCMakerConf",
-        obj_id = "random-tc-generator",
-        updates={
-            "candidate_backshift_ts": 0,
-            "candidate_window_before_ts": 62000,
-            "candidate_window_after_ts": 500,
-        },
-    )
-)
+utility_functions.set_RTCM_trigger_params(daphne_eth_conf, readout_window_backshift_ticks=0,
+                                          readout_window_before_ticks=62000, readout_window_after_ticks=500)
 
 daphne_eth_tpg_conf = copy.deepcopy(daphne_eth_conf)
 daphne_eth_tpg_conf.tpg_enabled = True

--- a/integtest/small_footprint_quick_test.py
+++ b/integtest/small_footprint_quick_test.py
@@ -6,6 +6,7 @@ import integrationtest.log_file_checks as log_file_checks
 import integrationtest.basic_checks as basic_checks
 import integrationtest.data_classes as data_classes
 import integrationtest.resource_validation as resource_validation
+import integrationtest.utility_functions2 as utility_functions
 from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
 from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
@@ -73,17 +74,12 @@ conf_dict.dro_map_config.n_streams = number_of_data_producers
 conf_dict.op_env = "integtest"
 conf_dict.config_session_name = "smallfootprint"
 conf_dict.tpg_enabled = False
-conf_dict.fake_hsi_enabled = True
+utility_functions.enable_fake_hsi_trigger(conf_dict, trigger_rate=1.0)
 
 conf_dict.config_substitutions.append(
     data_classes.attribute_substitution(obj_class="LatencyBuffer", updates={"size": 50000})
 )
-conf_dict.config_substitutions.append(
-    data_classes.attribute_substitution(
-        obj_class="FakeHSIEventGeneratorConf",
-        updates={"trigger_rate": 1.0},
-    )
-)
+
 confgen_arguments = {"SmallFootprint": conf_dict}
 
 # The commands to run in dunerc, as a list

--- a/integtest/tpg_state_collection_test.py
+++ b/integtest/tpg_state_collection_test.py
@@ -7,6 +7,7 @@ import integrationtest.basic_checks as basic_checks
 import integrationtest.data_classes as data_classes
 import integrationtest.opmon_metric_checks as opmon_metric_checks
 import integrationtest.resource_validation as resource_validation
+import integrationtest.utility_functions2 as utility_functions
 from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
 from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
@@ -125,13 +126,8 @@ conf_dict.n_df_apps = number_of_dataflow_apps
 conf_dict.frame_file = (
     "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798"  # WIBEth All Zeros
 )
+utility_functions.set_RTCM_trigger_params(conf_dict, trigger_rate=pulser_trigger_rate)
 
-conf_dict.config_substitutions.append(
-    data_classes.attribute_substitution(
-        obj_class="RandomTCMakerConf",
-        updates={"trigger_rate_hz": pulser_trigger_rate},
-    )
-)
 conf_dict.config_substitutions.append(
     data_classes.attribute_substitution(
         obj_class="LatencyBuffer", updates={"size": 200000}

--- a/integtest/tpg_state_collection_test.py
+++ b/integtest/tpg_state_collection_test.py
@@ -125,7 +125,7 @@ conf_dict.n_df_apps = number_of_dataflow_apps
 conf_dict.frame_file = (
     "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798"  # WIBEth All Zeros
 )
-utility_functions.set_RTCM_trigger_params(conf_dict, trigger_rate=pulser_trigger_rate)
+utility_functions.set_rtcm_trigger_params(conf_dict, trigger_rate=pulser_trigger_rate)
 
 conf_dict.config_substitutions.append(
     data_classes.attribute_substitution(

--- a/integtest/tpreplay_test.py
+++ b/integtest/tpreplay_test.py
@@ -158,7 +158,7 @@ tpreplay_local_conf.config_substitutions.append(
 )
 
 ## update random TC maker
-utility_functions.set_RTCM_trigger_params(tpreplay_local_conf, trigger_rate=0)
+utility_functions.set_rtcm_trigger_params(tpreplay_local_conf, trigger_rate=0)
 
 ## update HSI
 utility_functions.set_fake_hsi_trigger_params(tpreplay_local_conf, trigger_rate=0)

--- a/integtest/tpreplay_test.py
+++ b/integtest/tpreplay_test.py
@@ -37,6 +37,7 @@ import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
 import integrationtest.basic_checks as basic_checks
 import integrationtest.resource_validation as resource_validation
+import integrationtest.utility_functions2 as utility_functions
 from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
 from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
@@ -158,24 +159,10 @@ tpreplay_local_conf.config_substitutions.append(
 )
 
 ## update random TC maker
-tpreplay_local_conf.config_substitutions.append(
-    data_classes.attribute_substitution(
-        obj_id="random-tc-generator",
-        obj_class="RandomTCMakerConf",
-        updates={
-            "trigger_rate_hz": 0
-            },)
-)
+utility_functions.set_RTCM_trigger_params(tpreplay_local_conf, trigger_rate=0)
 
 ## update HSI
-tpreplay_local_conf.config_substitutions.append(
-    data_classes.attribute_substitution(
-        obj_id="fakehsi",
-        obj_class="FakeHSIEventGeneratorConf",
-        updates={
-            "trigger_rate": 0
-            },)
-)
+utility_functions.set_fake_hsi_trigger_params(tpreplay_local_conf, trigger_rate=0)
 
 # prep NP04 conf
 tpreplay_np04_conf = copy.deepcopy(tpreplay_local_conf)

--- a/integtest/tpstream_writing_test.py
+++ b/integtest/tpstream_writing_test.py
@@ -124,7 +124,7 @@ conf_dict.n_df_apps = number_of_dataflow_apps
 conf_dict.frame_file = (
     "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798"  # WIBEth All Zeros
 )
-utility_functions.set_RTCM_trigger_params(conf_dict, trigger_rate=pulser_trigger_rate)
+utility_functions.set_rtcm_trigger_params(conf_dict, trigger_rate=pulser_trigger_rate)
 
 conf_dict.config_substitutions.append(
     data_classes.attribute_substitution(

--- a/integtest/tpstream_writing_test.py
+++ b/integtest/tpstream_writing_test.py
@@ -6,6 +6,7 @@ import integrationtest.log_file_checks as log_file_checks
 import integrationtest.basic_checks as basic_checks
 import integrationtest.data_classes as data_classes
 import integrationtest.resource_validation as resource_validation
+import integrationtest.utility_functions2 as utility_functions
 from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
 from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
@@ -124,13 +125,8 @@ conf_dict.n_df_apps = number_of_dataflow_apps
 conf_dict.frame_file = (
     "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798"  # WIBEth All Zeros
 )
+utility_functions.set_RTCM_trigger_params(conf_dict, trigger_rate=pulser_trigger_rate)
 
-conf_dict.config_substitutions.append(
-    data_classes.attribute_substitution(
-        obj_class="RandomTCMakerConf",
-        updates={"trigger_rate_hz": pulser_trigger_rate},
-    )
-)
 conf_dict.config_substitutions.append(
     data_classes.attribute_substitution(
         obj_class="LatencyBuffer", updates={"size": 200000}

--- a/integtest/trigger_bitwords_test.py
+++ b/integtest/trigger_bitwords_test.py
@@ -200,7 +200,7 @@ coincidence_bitword_conf.config_substitutions.append(
             "merge_overlapping_tcs": True
             },)
 )
-utility_functions.set_RTCM_trigger_params(coincidence_bitword_conf, trigger_rate=40,
+utility_functions.set_rtcm_trigger_params(coincidence_bitword_conf, trigger_rate=40,
                                           readout_window_backshift_ticks=0, readout_window_before_ticks=62500,
                                           readout_window_after_ticks=62500)
 utility_functions.set_fake_hsi_trigger_params(coincidence_bitword_conf, trigger_rate=30,

--- a/integtest/trigger_bitwords_test.py
+++ b/integtest/trigger_bitwords_test.py
@@ -36,6 +36,7 @@ import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
 import integrationtest.basic_checks as basic_checks
 import integrationtest.resource_validation as resource_validation
+import integrationtest.utility_functions2 as utility_functions
 from integrationtest.get_pytest_tmpdir import get_pytest_tmpdir
 from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
@@ -200,30 +201,12 @@ coincidence_bitword_conf.config_substitutions.append(
             "merge_overlapping_tcs": True
             },)
 )
-coincidence_bitword_conf.config_substitutions.append(
-    data_classes.attribute_substitution(
-        obj_id="random-tc-generator",
-        obj_class="RandomTCMakerConf",
-        updates={"trigger_rate_hz": 40, "candidate_backshift_ts": 0, "candidate_window_before_ts": 62500, "candidate_window_after_ts": 62500},)
-)
-coincidence_bitword_conf.config_substitutions.append(
-    data_classes.attribute_substitution(
-        obj_id="def-random-readout",
-        obj_class="TCReadoutMap",
-        updates={"time_before": 62500, "time_after": 62500},)
-)
-coincidence_bitword_conf.config_substitutions.append(
-    data_classes.attribute_substitution(
-        obj_id="fakehsi",
-        obj_class="FakeHSIEventGeneratorConf",
-        updates={"trigger_rate": 30},)
-)
-coincidence_bitword_conf.config_substitutions.append(
-    data_classes.attribute_substitution(
-        obj_id="def-hsi-tc-map",
-        obj_class="TCReadoutMap",
-        updates={"time_before": 62500, "time_after": 62500},)
-)
+utility_functions.set_RTCM_trigger_params(coincidence_bitword_conf, trigger_rate=40,
+                                          readout_window_backshift_ticks=0, readout_window_before_ticks=62500,
+                                          readout_window_after_ticks=62500)
+utility_functions.set_fake_hsi_trigger_params(coincidence_bitword_conf, trigger_rate=30,
+                                              readout_window_before_ticks=62500,
+                                              readout_window_after_ticks=62500)
 
 # Finally store configs in map
 confgen_arguments = {


### PR DESCRIPTION
# Description

These changes make use of the changes made in the `integrationtest` repo to provide utility functions that set various trigger parameters for integration tests (DUNE-DAQ/integrationtest#161).

There are instructions for testing these changes in DUNE-DAQ/integrationtest#161, and these changes need to be tested and merged together the with changes in the `integrationtest` repo.

## Type of change

- [x] Optimization (non-breaking change that improves code/performance)

## Testing checklist

- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
