### PR TITLE
Modified the bundle script and its helper scripts to include integtests from python-only packages

### DIFF
--- a/scripts/dunedaq_integtest_bundle.sh
+++ b/scripts/dunedaq_integtest_bundle.sh
@@ -285,7 +285,10 @@ while [[ ${full_set_loop_count} -lt ${full_set_requested_interations} ]]; do
             echo -e "\U0001F535 \033[0;34mStarting test ${overall_test_index} of ${total_number_of_tests}...\033[0m \U0001F535" | CaptureOutput ${ITGRUNNER_LOG_FILE}
 
             echo -e "\u2B95 \033[0;1mRunning ${FULL_TEST_NAME}\033[0m \u2B05" | CaptureOutput ${ITGRUNNER_LOG_FILE}
-            if [[ -e "./${test_name}" ]]; then
+
+            if [[ "`ls ${DBT_AREA_ROOT}/.venv/lib/python*/site-packages/${test_repo}/integtest/${test_name} 2>/dev/null`" != "" ]]; then
+                ${PYTEST_COMMAND} ${DBT_AREA_ROOT}/.venv/lib/python*/site-packages/${test_repo}/integtest/${test_name} | CaptureOutputNoANSI ${ITGRUNNER_LOG_FILE}
+            elif [[ -e "./${test_name}" ]]; then
                 ${PYTEST_COMMAND} ./${test_name} | CaptureOutputNoANSI ${ITGRUNNER_LOG_FILE}
             elif [[ -e "${DBT_AREA_ROOT}/sourcecode/${test_repo}/integtest/${test_name}" ]]; then
                 if [[ -w "${DBT_AREA_ROOT}" ]]; then

--- a/scripts/dunedaq_integtest_bundle.sh
+++ b/scripts/dunedaq_integtest_bundle.sh
@@ -286,10 +286,18 @@ while [[ ${full_set_loop_count} -lt ${full_set_requested_interations} ]]; do
 
             echo -e "\u2B95 \033[0;1mRunning ${FULL_TEST_NAME}\033[0m \u2B05" | CaptureOutput ${ITGRUNNER_LOG_FILE}
 
+            # First, check if the test is found in the Python virtual environment.
+            # This picks up tests from our Python-only software packages.
             if [[ "`ls ${DBT_AREA_ROOT}/.venv/lib/python*/site-packages/${test_repo}/integtest/${test_name} 2>/dev/null`" != "" ]]; then
                 ${PYTEST_COMMAND} ${DBT_AREA_ROOT}/.venv/lib/python*/site-packages/${test_repo}/integtest/${test_name} | CaptureOutputNoANSI ${ITGRUNNER_LOG_FILE}
+
+            # Next, check if the test exists in the current working directory.
+            # This is a convenience for developers when they are working on an integtest
+            # in a C++ package (the test is found without rebuilding the software).
             elif [[ -e "./${test_name}" ]]; then
                 ${PYTEST_COMMAND} ./${test_name} | CaptureOutputNoANSI ${ITGRUNNER_LOG_FILE}
+
+            # Next, check if the test exists in the local software area.
             elif [[ -e "${DBT_AREA_ROOT}/sourcecode/${test_repo}/integtest/${test_name}" ]]; then
                 if [[ -w "${DBT_AREA_ROOT}" ]]; then
                     ${PYTEST_COMMAND} ${DBT_AREA_ROOT}/sourcecode/${test_repo}/integtest/${test_name} | CaptureOutputNoANSI ${ITGRUNNER_LOG_FILE}
@@ -298,6 +306,9 @@ while [[ ${full_set_loop_count} -lt ${full_set_requested_interations} ]]; do
                     PYTEST_COMMAND=`echo ${PYTEST_COMMAND} | sed 's/--$//'`
                     ${PYTEST_COMMAND} -p no:cacheprovider --no-summary ${DBT_AREA_ROOT}/sourcecode/${test_repo}/integtest/${test_name} | CaptureOutputNoANSI ${ITGRUNNER_LOG_FILE}
                 fi
+
+            # Lastly, we assume that the test can be found in the installed software
+            # area (for C++ packages).
             else
                 share_envvar_name="${test_repo^^}_SHARE"  # double caret converts env var to uppercase
                 # remove the trailing "--" in PYTEST_COMMAND since we are adding more pytest options here

--- a/scripts/list_available_integtests.sh
+++ b/scripts/list_available_integtests.sh
@@ -95,23 +95,26 @@ echo "" >&2
 for repo_name in "${repo_list[@]}"; do
     share_envvar_name="${repo_name^^}_SHARE"  # double caret converts env var to uppercase
     # ${!var} returns what var points to
-    if [[ -e "${!share_envvar_name}/integtest" ]] || [[ -e "${DBT_AREA_ROOT}/sourcecode/${repo_name}/integtest" ]]; then
-        integtest_list=(`ls -1 ${!share_envvar_name}/integtest/*_test.py ${DBT_AREA_ROOT}/sourcecode/${repo_name}/integtest/*_test.py 2>/dev/null | xargs -r -n 1 basename | sort -u`)
-        if [[ ${#integtest_list[@]} -gt 0 ]]; then
-            for test_name in "${integtest_list[@]}"; do
-                echo "${repo_name}/${test_name}"
-            done
-        else
-            echo "-> No integtests were found for repository \"${repo_name}\"." >&2
-        fi
+    integtest_list=(`ls -1 ${!share_envvar_name}/integtest/*_test.py ${DBT_AREA_ROOT}/sourcecode/${repo_name}/integtest/*_test.py ${DBT_AREA_ROOT}/.venv/lib/python*/site-packages/${repo_name}/integtest/*_test.py 2>/dev/null | xargs -r -n 1 basename | sort -u`)
+    if [[ ${#integtest_list[@]} -gt 0 ]]; then
+        for test_name in "${integtest_list[@]}"; do
+            echo "${repo_name}/${test_name}"
+        done
     else
+        echo "-> No integtests were found for repository \"${repo_name}\"." >&2
+
         if [[ -e "${DBT_AREA_ROOT}/sourcecode/${repo_name}" ]]; then
             echo "-> No integtest directory was found in ${DBT_AREA_ROOT}/sourcecode/${repo_name}." >&2
         fi
-        if [[ "${!share_envvar_name}" == "" ]]; then
+        if [[ "${!share_envvar_name}" == "" ]] && [[ `pip list | grep "^${repo_name} "` == "" ]]; then
             echo "-> \"${repo_name}\" does not appear to be a valid repository name." >&2
         else
-            echo "-> No integtest directory was found in ${share_envvar_name} (${!share_envvar_name})." >&2
+            if [[ "${!share_envvar_name}" != "" ]]; then
+                echo "-> No integtest directory was found in ${share_envvar_name} (${!share_envvar_name})." >&2
+            fi
+            if [[ `pip list | grep "^${repo_name} "` != "" ]]; then
+                echo "-> No integtest directory was found in ${DBT_AREA_ROOT}/venv for repo \"${repo_name}\"." >&2
+            fi
         fi
     fi
 done

--- a/scripts/list_available_integtests.sh
+++ b/scripts/list_available_integtests.sh
@@ -94,6 +94,9 @@ echo "" >&2
 
 for repo_name in "${repo_list[@]}"; do
     share_envvar_name="${repo_name^^}_SHARE"  # double caret converts env var to uppercase
+
+    # Here, we list all integtests that exist either in the installed software area (C++ packages),
+    # the local software area, or the Python virtual environment (the .venv subdir).
     # ${!var} returns what var points to
     integtest_list=(`ls -1 ${!share_envvar_name}/integtest/*_test.py ${DBT_AREA_ROOT}/sourcecode/${repo_name}/integtest/*_test.py ${DBT_AREA_ROOT}/.venv/lib/python*/site-packages/${repo_name}/integtest/*_test.py 2>/dev/null | xargs -r -n 1 basename | sort -u`)
     if [[ ${#integtest_list[@]} -gt 0 ]]; then
@@ -103,6 +106,9 @@ for repo_name in "${repo_list[@]}"; do
     else
         echo "-> No integtests were found for repository \"${repo_name}\"." >&2
 
+        # The following logic is simply an attempt to provide a little more information
+        # about *why* the integtest was not found.  It attemts to take into account
+        # differences between C++ packages and Python packages.
         if [[ -e "${DBT_AREA_ROOT}/sourcecode/${repo_name}" ]]; then
             echo "-> No integtest directory was found in ${DBT_AREA_ROOT}/sourcecode/${repo_name}." >&2
         fi

--- a/scripts/list_repos_with_integtests.sh
+++ b/scripts/list_repos_with_integtests.sh
@@ -4,10 +4,13 @@
 if [[ "$1" == "--help" ]] || [[ "$1" == "-h" ]] || [[ "$1" == "-?" ]]; then
     echo
     echo "Usage: `basename $0` [optional \"local\" keyword]"
+    echo
     echo "  Lists the software repositories that have integration tests (integtests) in them."
+    echo
     echo "  For C++ packages, the base release, local install dir, and local sourcecode dir"
     echo "  are searched, unless \"local\" is passed as an argument. In that case, only the"
     echo "  local install and sourcecode directories are searched."
+    echo
     echo "  For Python packages, the \$DBT_AREA_ROOT/.venv area is searched, independent of"
     echo "  whether that area is part of a local software area or a base release. If the"
     echo "  \"local\" flag is specified, an attempt is made to limit the results to packages"

--- a/scripts/list_repos_with_integtests.sh
+++ b/scripts/list_repos_with_integtests.sh
@@ -5,9 +5,13 @@ if [[ "$1" == "--help" ]] || [[ "$1" == "-h" ]] || [[ "$1" == "-?" ]]; then
     echo
     echo "Usage: `basename $0` [optional \"local\" keyword]"
     echo "  Lists the software repositories that have integration tests (integtests) in them."
-    echo "  Searches the base releases, local install dir, and local sourcecode dir,"
-    echo "  unless \"local\" is passed as an argument. In that case, only the local"
-    echo "  install and sourcecode directories are searched."
+    echo "  For C++ packages, the base release, local install dir, and local sourcecode dir"
+    echo "  are searched, unless \"local\" is passed as an argument. In that case, only the"
+    echo "  local install and sourcecode directories are searched."
+    echo "  For Python packages, the \$DBT_AREA_ROOT/.venv area is searched, independent of"
+    echo "  whether that area is part of a local software area or a base release. If the"
+    echo "  \"local\" flag is specified, an attempt is made to limit the results to packages"
+    echo "  that have been cloned into the local 'pythoncode' directory."
     echo
     exit
 fi
@@ -26,20 +30,37 @@ if [[ $# -eq 0 ]] || [[ "$1" != "local" ]]; then
     base_release_name=`dbt-info release | grep 'Base release name:' | cut -d' ' -f4`
     base_release_dir="${release_dir}/../${base_release_name}"
 
-    # look up the paths of all of the repositories in the core and detector-specific categories
-    det_rel_repo_paths=(`ls -1d ${release_dir}/spack-installation/opt/spack/*linux*/gcc-*/*/*/integtest/*_test.py`)
-    base_rel_repo_paths=(`ls -1d ${base_release_dir}/spack-installation/opt/spack/*linux*/gcc-*/*/*/integtest/*_test.py`)
+    # look up the paths of all of the C++ repositories in the core and detector-specific categories with integtests
+    det_rel_repo_paths=(`ls -1d ${release_dir}/spack-installation/opt/spack/*linux*/gcc-*/*/*/integtest/*_test.py 2>/dev/null`)
+    base_rel_repo_paths=(`ls -1d ${base_release_dir}/spack-installation/opt/spack/*linux*/gcc-*/*/*/integtest/*_test.py 2>/dev/null`)
     all_repo_paths=("${det_rel_repo_paths[@]}" "${base_rel_repo_paths[@]}")
+
+    # add in the paths of the Python repositories with integtests
+    if [[ "${DBT_AREA_ROOT}" != "" ]]; then
+        venv_dir_repo_paths=(`ls -1 ${DBT_AREA_ROOT}/.venv/lib/python*/site-packages/*/integtest/*_test.py`)
+        all_repo_paths=("${all_repo_paths[@]}" "${venv_dir_repo_paths[@]}")
+    fi
 else
     echo "Looking for _local_ repositories with integtests in them..." >&2
     echo "" >&2
 fi
 
-# add in the paths of the repositories in the local install and sourcecode dirs
+# add in the paths of the C++ repositories in the local install and sourcecode dirs
 if [[ "$DBT_AREA_ROOT" != "" ]]; then
-    install_dir_repo_paths=(`ls -1 ${DBT_AREA_ROOT}/install/*/share/integtest/*_test.py`)
-    sourcecode_dir_repo_paths=(`ls -1 ${DBT_AREA_ROOT}/sourcecode/*/integtest/*_test.py`)
+    install_dir_repo_paths=(`ls -1 ${DBT_AREA_ROOT}/install/*/share/integtest/*_test.py 2>/dev/null`)
+    sourcecode_dir_repo_paths=(`ls -1 ${DBT_AREA_ROOT}/sourcecode/*/integtest/*_test.py 2>/dev/null`)
     all_repo_paths=("${all_repo_paths[@]}" "${install_dir_repo_paths[@]}" "${sourcecode_dir_repo_paths[@]}")
+fi
+
+# add in the paths of the Python repositories that have integtests and are cloned locally
+if [[ "`echo $DBT_AREA_ROOT | grep '^/cvmfs'`" == "" ]]; then
+    venv_dir_repo_paths=(`ls -1 ${DBT_AREA_ROOT}/.venv/lib/python*/site-packages/*/integtest/*_test.py 2>/dev/null`)
+    for path in "${venv_dir_repo_paths[@]}"; do
+        repo_name=`echo ${path} | cut -d'/' -f 11`
+        if [[ -e $DBT_AREA_ROOT/pythoncode/${repo_name} ]]; then
+            all_repo_paths=("${all_repo_paths[@]}" "${path}")
+        fi
+    done
 fi
 
 repos_with_integtests=(`echo "${all_repo_paths[@]}" | sed 's,/share,,g' | xargs -r -n 1 dirname | xargs -r -n 1 dirname | xargs -r -n 1 basename | cut -d'-' -f1 | sort -u`)

--- a/scripts/list_repos_with_integtests.sh
+++ b/scripts/list_repos_with_integtests.sh
@@ -59,7 +59,7 @@ fi
 if [[ "`echo $DBT_AREA_ROOT | grep '^/cvmfs'`" == "" ]]; then
     venv_dir_repo_paths=(`ls -1 ${DBT_AREA_ROOT}/.venv/lib/python*/site-packages/*/integtest/*_test.py 2>/dev/null`)
     for path in "${venv_dir_repo_paths[@]}"; do
-        repo_name=`echo ${path} | cut -d'/' -f 11`
+        repo_name=`echo ${path} | sed 's,.*site-packages/,,' | sed 's,/integtest.*,,'`
         if [[ -e $DBT_AREA_ROOT/pythoncode/${repo_name} ]]; then
             all_repo_paths=("${all_repo_paths[@]}" "${path}")
         fi


### PR DESCRIPTION
# Description

Now that we have integration tests from Python packages installed in the `.venv` directory of software areas, we can proceed to include them in the global bundle script and its helper scripts:

- `dunedaq_integtest_bundle.sh`
- `list_available_integtests.sh`
- `list_repos_with_integtests.sh`

The changes in this Pull Request attempt to do that.

Two notes:

- I have attempted to continue to support the "local" keyword for finding integtests in software packages that are included in a local software area.  For Python packages, this corresponds to the presence of the package in the `pythoncode` subdirectory.  (Typically, **_all_** Python packages are installed in the `.venv` subdirectory of a local software area, so the presence of a package in that area can't be used to determine "local" vs. not-local.)
- I have **_not_** yet added logic to the bundle script to add the `-p no:cacheprovider` qualifier to the `pytest` command when running integtests from Python packages that are not installed in a write-able location on disk.  The reason for this is twofold: there are discussions about how to avoid needing to specify that qualifier, so we will let that discussion proceed.  And in the short term, I expect that it will be rather rare for someone to run integtests from Python packages without having a local software area.

Here are suggested steps for testing these changes:

```
DATE_PREFIX=`date '+%d%b'`
TIME_SUFFIX=`date '+%H%M'`

source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
setup_dbt latest
dbt-create -n NFD_DEV_260701_A9 ${DATE_PREFIX}FDDevBundleScriptPythonPkgs_${TIME_SUFFIX}
cd ${DATE_PREFIX}FDDevBundleScriptPythonPkgs_${TIME_SUFFIX}/sourcecode

git clone https://github.com/DUNE-DAQ/daqsystemtest.git -b kbiery/python_package_integtests
cd ..

. ./env.sh
dbt-build -j 12
dbt-workarea-env

dunedaq_integtest_bundle.sh -r all --list

echo ""
echo -e "\U1F535 \U2705 Note that the drunc integtest is included in the list of *all* tests which would be run. \U2705 \U1F535"
echo ""
echo ""
sleep 3

dunedaq_integtest_bundle.sh -r local --list

echo ""
echo -e "\U1F535 \U2705 Note that the drunc integtest is *not* included in the list of *local* tests which would be run. \U2705 \U1F535"
echo ""
echo ""
sleep 3

cd pythoncode
git clone https://github.com/DUNE-DAQ/drunc.git -b develop
cd ..

dunedaq_integtest_bundle.sh -r local --list

echo ""
echo -e "\U1F535 \U2705 Note that the drunc integtest *is now included* in the list of *local* tests which would be run. \U2705 \U1F535"
echo ""
echo ""
sleep 3

dunedaq_integtest_bundle.sh -r drunc

echo ""
echo -e "\U1F535 \U2705 Note that the drunc process_manager_test ran successfully using the bundle script. \U2705 \U1F535"
echo ""
echo ""
```

## Type of change

- [x] Optimization (non-breaking change that improves code/performance)

## Testing checklist

- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
