### PR TITLE
Changed a couple of AVXThresholdProcessor configuration declarations …

### DIFF
--- a/config/daqsystemtest/df-segment.data.xml
+++ b/config/daqsystemtest/df-segment.data.xml
@@ -72,6 +72,7 @@
  <file path="config/daqsystemtest/moduleconfs.data.xml"/>
  <file path="config/daqsystemtest/hosts.data.xml"/>
  <file path="config/daqsystemtest/ccm.data.xml"/>
+ <file path="config/daqsystemtest/fsm.data.xml"/>
 </include>
 
 

--- a/config/daqsystemtest/hsi-dts-segment.data.xml
+++ b/config/daqsystemtest/hsi-dts-segment.data.xml
@@ -74,6 +74,7 @@
  <file path="config/daqsystemtest/hosts.data.xml"/>
  <file path="config/daqsystemtest/ccm.data.xml"/>
  <file path="schema/hsilibs/hsi.schema.xml"/>
+ <file path="config/daqsystemtest/fsm.data.xml"/>
 </include>
 
 <comments>

--- a/config/daqsystemtest/hsi-fake-segment.data.xml
+++ b/config/daqsystemtest/hsi-fake-segment.data.xml
@@ -73,6 +73,7 @@
  <file path="config/daqsystemtest/moduleconfs.data.xml"/>
  <file path="config/daqsystemtest/hosts.data.xml"/>
  <file path="config/daqsystemtest/ccm.data.xml"/>
+ <file path="config/daqsystemtest/fsm.data.xml"/>
 </include>
 
 <comments>

--- a/config/daqsystemtest/moduleconfs.data.xml
+++ b/config/daqsystemtest/moduleconfs.data.xml
@@ -129,9 +129,9 @@
 
 <obj class="AVXThresholdProcessor" id="tpg-threshold-proc">
  <attr name="metric_collect_time_sample_period" type="u64" val="256"/>
- <attr name="plane0" type="u16" val="100"/>
- <attr name="plane1" type="u16" val="100"/>
- <attr name="plane2" type="u16" val="100"/>
+ <attr name="plane0" type="s16" val="100"/>
+ <attr name="plane1" type="s16" val="100"/>
+ <attr name="plane2" type="s16" val="100"/>
 </obj>
 
 <obj class="ActionPlan" id="crt-readout-start">

--- a/config/daqsystemtest/ru-segment.data.xml
+++ b/config/daqsystemtest/ru-segment.data.xml
@@ -69,12 +69,14 @@
  <file path="schema/confmodel/dunedaq.schema.xml"/>
  <file path="schema/appmodel/application.schema.xml"/>
  <file path="schema/appmodel/fdmodules.schema.xml"/>
+ <file path="schema/appmodel/hermes.schema.xml"/>
  <file path="schema/appmodel/wiec.schema.xml"/>
  <file path="schema/appmodel/socket.schema.xml"/>
  <file path="config/daqsystemtest/connections.data.xml"/>
  <file path="config/daqsystemtest/moduleconfs.data.xml"/>
  <file path="config/daqsystemtest/hosts.data.xml"/>
  <file path="config/daqsystemtest/ccm.data.xml"/>
+ <file path="config/daqsystemtest/fsm.data.xml"/>
 </include>
 
 <comments>

--- a/integtest/readout_type_scan_test.py
+++ b/integtest/readout_type_scan_test.py
@@ -232,7 +232,7 @@ tde_tpg_conf.config_substitutions.append(
     data_classes.attribute_substitution(
         obj_class="AVXThresholdProcessor",
         obj_id="tpg-threshold-proc",
-        updates={"plane0": 500, "plane1": 500, "plane2": 500},
+        updates={"plane0": "500", "plane1": "500", "plane2": "500"},
     )
 )
 tde_tpg_conf.config_substitutions.append(


### PR DESCRIPTION
…to try to get the data type and syntax correct.

# Description

Marco noticed that some of our configuration settings for AVXThresholdProcessor were not correct.  This PR includes the fixes in this repo.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing checklist

- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
