### PR TITLE
Increased the max expected TC fragment size in the disabled_tpg_test …

### DIFF
--- a/integtest/disabled_tpg_test.py
+++ b/integtest/disabled_tpg_test.py
@@ -41,14 +41,13 @@ wibeth_frag_params = {
     "max_size_bytes": 28872,
 }
 # sizes: 128 is for one TC with zero TAs inside it (72+56)
-#        208 is for one TC with one TA inside it (72+56+80)
-#        264 is for two TCs with one TA in one of them (72+56+80+56)
+#        184 is for two TCs with zero TAs inside them (72+56+56)
 triggercandidate_frag_params = {
     "fragment_type_description": "Trigger Candidate",
     "fragment_type": "Trigger_Candidate",
     "expected_fragment_count": 1,
     "min_size_bytes": 128,
-    "max_size_bytes": 128,
+    "max_size_bytes": 184,
     "debug_mask": 0x0,
 }
 triggerprimitive_frag_params = {


### PR DESCRIPTION
…to take into account overlapping kTiming and kRandom TCs.

# Description

In the running of today's over-night regression tests, there was a failure reported by the `disabled_tpg_test` (e.g. see [here](https://github.com/DUNE-DAQ/daq-release/actions/runs/29227759732/job/86745378913)).

The problem was that occasionally `kTiming` (`FakeHSI`) and `kRandom` (`RandomTriggerCandidateMaker`) triggers overlap, and there are TriggerCandidate objects in the TriggerRecord for both of them.  This caused the TriggerCandidate fragment to be larger than expected.

The solution is to simply increase the max allowed size of TC fragments, since there is nothing inherently wrong with triggers happening at the same time.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing checklist

- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
