### PR TITLE
Added logic to the dunedaq_integtest_bundle.sh script to provide hints…

### DIFF
--- a/scripts/dunedaq_integtest_bundle.sh
+++ b/scripts/dunedaq_integtest_bundle.sh
@@ -251,6 +251,44 @@ if [[ $random_subset_count -gt 0 ]]; then
     filtered_integtest_list=($(shuf -n "$random_subset_count" -e "${filtered_integtest_list[@]}"))
 fi
 
+# check if any tests remain; provide hints to the user if not
+if [[ ${#filtered_integtest_list[@]} -eq 0 ]]; then
+    matching_integtest_list=()
+    if  [[ "${requested_test_names}" != "" ]]; then
+        echo "...Looking for integtests..."
+        full_integtest_list=(`list_available_integtests.sh 2>/dev/null`)
+        for repo_test in "${full_integtest_list[@]}"; do
+            test_name=`basename ${repo_test}`
+            match_string=`echo ${test_name} | egrep ${requested_test_names}`
+            if [[ "${match_string}" != "" ]]; then
+                matching_integtest_list+=(${repo_test})
+            fi
+        done
+    fi
+    echo ""
+    echo "*** No integtests were found that matched the specified command-line options."
+    if [[ ${#matching_integtest_list[@]} -gt 0 ]]; then
+        sleep 1
+        repo_name=`dirname ${matching_integtest_list[0]}`
+        test_name=`basename ${matching_integtest_list[0]}`
+        echo ""
+        echo "*** Consider adding '-r ${repo_name}' to the option list to pick up the '${test_name}' test."
+        if [[ ${#matching_integtest_list[@]} -gt 1 ]]; then
+            for match in "${matching_integtest_list[@]:1}"; do
+                repo_name=`dirname ${match}`
+                test_name=`basename ${match}`
+                echo "*** And/or '-r ${repo_name}' to pick up the '${test_name}' test."
+            done
+            echo "*** Or '-r all' to pick up all of these tests."
+        fi
+    fi
+    sleep 1
+    echo ""
+    echo "*** 'list_available_integtests.sh' will list all available tests."
+    echo ""
+    exit 5
+fi
+
 if [[ "$only_list_tests" != "" ]]; then
     let idx=0
     echo ""

--- a/scripts/dunedaq_integtest_bundle.sh
+++ b/scripts/dunedaq_integtest_bundle.sh
@@ -43,6 +43,7 @@ Options:
              for example, --dunerc-option log-level debug
        - example: --pytest-options \"--skip-resource-checks --process-manager-type ssh-standalone --dunerc-option no-override-logs\"
 """
+}
 
 # 29-Dec-2025, KAB: Determine if a non-standard pytest tmpdir has been specified
 # in the linux shell environment in which this script is being run. We need to know

--- a/scripts/dunedaq_integtest_bundle.sh
+++ b/scripts/dunedaq_integtest_bundle.sh
@@ -37,11 +37,12 @@ Options:
          --dunerc-path <path> : Path to DUNE run control. Default is to search in \$PATH
          --skip-resource-checks : Whether to skip the node resource (CPU/Memory) checks for this test
          --process-manager-type <type> : The run control process manager type to use for this test, e.g. ssh-standalone
+         --no-integtest-connsvc : Whether to disable the Connectivity Service for this test
+         --remove-hdf5-files <choice> : 'always' forces files to be removed, 'never' forces files to be kept
          --dunerc-option <option-name> <option-value> : Repeatable, run control arguments without leading dashes
              for example, --dunerc-option log-level debug
        - example: --pytest-options \"--skip-resource-checks --process-manager-type ssh-standalone --dunerc-option no-override-logs\"
 """
-}
 
 # 29-Dec-2025, KAB: Determine if a non-standard pytest tmpdir has been specified
 # in the linux shell environment in which this script is being run. We need to know


### PR DESCRIPTION
…to the user when no tests are left after filtering based on the command-line options.

# Description

In recent discussions, it was mentioned that there are times that the `daqsystemtest/dunedaq_integtest_bundle.sh` script finds no integtests that match what the user requested based on the command-line options provided to the script, and it is not obvious why the bundle script doesn't run any tests.

In subsequent discussions of how to deal with this issue, one suggestion was to provide more information to the user about what had happened and suggest alternatives (as compared with adding logic to the script to guess what the user wanted).

This PR attempts to do that.  It now provides suggested command-line options.

For example:

```
$ dunedaq_integtest_bundle.sh -k process

Integtests from the _daqsystemtest_ repo will be run...
...Looking for integtests...

*** No integtests were found that matched the specified command-line options.

*** Consider adding '-r drunc' to the option list to pick up the 'process_manager_test.py' test.

*** 'list_available_integtests.sh' will list all available tests.
```

Here are suggested instructions for testing this change:

```
DATE_PREFIX=`date '+%d%b'`
TIME_SUFFIX=`date '+%H%M'`

source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
setup_dbt latest
dbt-create -n NFD_DEV_260729_A9 ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}
cd ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}/sourcecode

git clone https://github.com/DUNE-DAQ/daqsystemtest.git -b kbiery/bundle_script_option_hints

cd ..

. ./env.sh
dbt-build -j 12
dbt-workarea-env

echo ""
echo -e "\U1F535 \U2705 Various bundle script argument combinations that now provide hints... \U2705 \U1F535"
echo ""
echo ""

dunedaq_integtest_bundle.sh -k process

sleep 3

dunedaq_integtest_bundle.sh -r trigger -k dis

sleep 3

dunedaq_integtest_bundle.sh -r trigger -k b
```

## Type of change

- [x] Optimization (non-breaking change that improves code/performance)

## Testing checklist

- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
