### PR TITLE
Provided different minimum sizes for the TP fragment by trigger type …

### DIFF
--- a/integtest/readout_type_scan_test.py
+++ b/integtest/readout_type_scan_test.py
@@ -145,8 +145,10 @@ daphne_triggerprimitive_frag_params = {
     "fragment_type_description": "Trigger Primitive",
     "fragment_type": "Trigger_Primitive",
     "expected_fragment_count": 1,  # number of readout apps
-    "min_size_bytes": 96,
+    "min_size_bytes": 72,
     "max_size_bytes": 4392,
+    "frag_sizes_by_TC_type": {"kPrescale": {"min_size_bytes":  96, "max_size_bytes": 4392},
+                                "default": {"min_size_bytes":  72, "max_size_bytes": 4392} }
 }
 tdeeth_triggerprimitive_frag_params = {
     "fragment_type_description": "Trigger Primitive",


### PR DESCRIPTION
…in the DAPHNE_TPG part of the readout_type_scan_test.

# Description

I have occasionally seen the DAPHNE TPG part of the `readout_type_scan_test` fail because the size of a TriggePrimitive fragment is too small (72 bytes, which means that the fragment is empty).  On investigation, I found that these empty TP fragments were part of kRandom triggers.  It is not unreasonable to believe that there may not be TPs in a random time window, so I've updated the expected TP fragment sizes in the `readout_type_scan_test` to allow for empty fragments in triggers that are **_not_** TP-based.

Here are suggested instructions for testing these changes:

```
DATE_PREFIX=`date '+%d%b'`
TIME_SUFFIX=`date '+%H%M'`

source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
setup_dbt latest
dbt-create -n NFD_DEV_260804_A9 ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}
cd ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}/sourcecode

git clone https://github.com/DUNE-DAQ/daqsystemtest.git -b develop

cd ..

. ./env.sh
dbt-build -j 12
dbt-workarea-env

dunedaq_integtest_bundle.sh -k type_scan --verb 1 --stop --pytest-options "-k DAPHNE_TPG" -N 20

echo ""
echo -e "\U1F535 \U2705 Note that, with the existing code, one of the 20 requested tests failed (probably). \U2705 \U1F535"
echo ""
echo ""
sleep 3

cd sourcecode/daqsystemtest
git checkout kbiery/rtst_frag_size_tweak
cd ../../
dbt-build -j 12
dbt-workarea-env

dunedaq_integtest_bundle.sh -k type_scan --verb 1 --stop --pytest-options "-k DAPHNE_TPG" -N 30

echo ""
echo -e "\U1F535 \U2705 Note that, with the new code, 30 tests succeeded (probably). \U2705 \U1F535"
echo ""
echo ""
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing checklist

- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
