### PR TITLE
Removed the --trigger-full-rc-output option in the dunedaq_integtest_bundle.sh …

### DIFF
--- a/scripts/dunedaq_integtest_bundle.sh
+++ b/scripts/dunedaq_integtest_bundle.sh
@@ -26,8 +26,6 @@ Options:
     --verbosity <level> : requested level of console messages, in range 1-6, where 1 is least, 6 is DRUNC debug
     --stop-on-failure : causes the script to stop when one of the integtests reports a failure
     --tmpdir <dir> : specifies a root directory to use for test output, e.g. a directory instead of '/tmp'
-    --trigger-full-rc-output <phrase that will trigger the full printout of run control messages>
-       - the phrase can be a Python regex, which can be useful in handling colorized text
     --concise-output : suppresses run control and DAQApp messages in order to focus on test results
        - this is equivalent to \"--verbosity 1\", and this option may be removed at some point in time
     -n <number of times to run each individual test, default=1>
@@ -58,7 +56,7 @@ CaptureOutput() {
     tee -a $1
 }
 
-GETOPT_TEMP=`getopt -o hr:R:k:x:n:N: --long help,stop-on-failure,concise-output,include:,exclude:,tmpdir:,verbosity:,trigger-full-rc-output:,random-subset:,list-only,pytest-options: -- "$@"`
+GETOPT_TEMP=`getopt -o hr:R:k:x:n:N: --long help,stop-on-failure,concise-output,include:,exclude:,tmpdir:,verbosity:,random-subset:,list-only,pytest-options: -- "$@"`
 if [ $? -ne 0 ]; then
     usage
     exit 1
@@ -140,11 +138,6 @@ while true; do
             if [[ $level -ge 6 ]]; then
                 PYTEST_OPTIONS="$PYTEST_OPTIONS --dunerc-option log-level debug"
             fi
-            shift 2
-            ;;
-        --trigger-full-rc-output)
-            watch_string=`echo "$2" | sed 's/ /_SPC_/g'`
-            PYTEST_OPTIONS="$PYTEST_OPTIONS --dunerc-fullprint-watch-string $watch_string"
             shift 2
             ;;
         --random-subset)


### PR DESCRIPTION
…script now that we have run control output stored in log files.

# Description

The title pretty much says it all.  It seems a little silly to maintain code to support functionality that probably won't be used much and, for which, there is an equivalent alternative.

This change was made as part of the work to add user-specified control applications to the `integrationtest` infrastructure (DUNE-DAQ/integrationtest#168), but it is fully independent of those changes.

## Type of change

- [x] Optimization (non-breaking change that improves code/performance)

## Testing checklist

- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
