### PR TITLE
Added the printout of the pytest.skip reason with verbosity level 6

### DIFF
--- a/scripts/dunedaq_integtest_bundle.sh
+++ b/scripts/dunedaq_integtest_bundle.sh
@@ -138,7 +138,8 @@ while true; do
             PYTEST_OPTIONS="$PYTEST_OPTIONS --integtest-verbosity $2"
             let level=$2
             if [[ $level -ge 6 ]]; then
-                PYTEST_OPTIONS="$PYTEST_OPTIONS --dunerc-option log-level debug"
+                # turn on drunc debugging, and enable printout of Pytest 'skip' reasons
+                PYTEST_OPTIONS="$PYTEST_OPTIONS -rs --dunerc-option log-level debug"
             fi
             shift 2
             ;;

--- a/scripts/dunedaq_integtest_bundle.sh
+++ b/scripts/dunedaq_integtest_bundle.sh
@@ -138,7 +138,7 @@ while true; do
             PYTEST_OPTIONS="$PYTEST_OPTIONS --integtest-verbosity $2"
             let level=$2
             if [[ $level -ge 6 ]]; then
-                # turn on drunc debugging, and enable printout of Pytest 'skip' reasons
+                # enable printout of Pytest 'skip' reasons and turn on drunc debugging
                 PYTEST_OPTIONS="$PYTEST_OPTIONS -rs --dunerc-option log-level debug"
             fi
             shift 2


### PR DESCRIPTION
# Description

I recently ran some integration tests that skipped their tests because my linux shell environment had not yet been fully prepared (an extra location on disk needed to be added to the DB_PATH), and it was not obvious what was causing the tests to be skipped.  I finally figured out the reason by adding the "-rs" option to the `pytest` command.  This option prints out the contents of the `pytest.skip` statements that are executed in the code.

My sense is that it would be useful to have the addition of the "-rs" option available from the global integtest bundle script, so I have added it for verbosity level 6 (which previously just enabled `drunc` debug mode).

To test this change, one can create a local software area from a recently nightly build, include the branch from this PR, build the software area, and run one of the `drunc` integtests.

For example, the following command should show a skipped test without information of why the test was skipped:

```
dunedaq_integtest_bundle.sh -r drunc -k failure_mode_death_post_boot_nest_app_test
```

While the following command *will* show some information on why the test was skipped.

```
dunedaq_integtest_bundle.sh -r drunc -k failure_mode_death_post_boot_nest_app_test --verb 6
```

So far, I have preferred to provide print statements in the integration test code that describe why a test was skipped, rather than using the pytest.skip(<text>) messages, because that choice produces less cluttered output on the user console.  But, other developers may make different choices, and that is why I think that an option to print out the contents of the pytest.skip messages will be useful.

## Type of change

- [x] Optimization (non-breaking change that improves code/performance)

## Testing checklist

- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
