### PR TITLE
Modified the 3ru_3df_multirun_test to make use of the 'start-run' command...

### DIFF
--- a/integtest/3ru_3df_multirun_test.py
+++ b/integtest/3ru_3df_multirun_test.py
@@ -176,7 +176,7 @@ dunerc_command_list += (
     + "disable-triggers wait 1 drain-dataflow wait 2 stop-trigger-sources wait 1 stop wait 2".split()
 )
 dunerc_command_list += (
-    "start --run-number 103 wait 1 enable-triggers wait ".split()
+    "start-run --run-number 103 wait ".split()
     + [str(run_duration)]
     + "disable-triggers wait 1 drain-dataflow wait 2 stop-trigger-sources wait 1 stop wait 2".split()
 )


### PR DESCRIPTION
…for one of its three runs. This will validate the use of that command going forward.

# Description

At today's SWI&T meeting, Michal mentioned that he noticed that the `start-run` command in run control was running `boot` and `conf` when those transitions had already been run in the current DAQ session.

Surprisingly, we don't seem to have an integration test that uses `start-run`, but we certainly should.

This PR makes use of that command in one of the three data-taking runs that are part of the `3ru_3df_multirun_test`.

The modified version of this integtest will (and **_should_**) fail until the bug is found and fixed in run control.

## Type of change

- [x] Optimization (non-breaking change that improves code/performance)

## Testing checklist

- [ ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
    - NB, this test will fail initially and that is a good thing. The failure demonstrates a problem in run control.
