### PR TITLE
Fix integration test, no longer producing ADC patterns for CRT

### DIFF
--- a/integtest/readout_type_scan_test.py
+++ b/integtest/readout_type_scan_test.py
@@ -308,6 +308,17 @@ grenoble_crt_conf.frame_file = "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd7
 utility_functions.set_rtcm_trigger_params(grenoble_crt_conf, readout_window_before_ticks=8000,
                                           readout_window_after_ticks=10)
 
+# CRT frames carry 32 channels, but the emulator pattern generator draws channel
+# numbers in 0-63. Disable the pattern generator for CRT readout.
+for crt_conf in (bern_crt_conf, grenoble_crt_conf):
+    crt_conf.config_substitutions.append(
+        data_classes.attribute_substitution(
+            obj_class="StreamEmulationParameters",
+            obj_id="stream-emu",
+            updates={"generate_periodic_adc_pattern": 0},
+        )
+    )
+
 confgen_arguments = {
     "WIBEth_System": wibeth_conf,
     "WIBEth_TPG_System": wib_tpg_conf,


### PR DESCRIPTION
# Description

See https://github.com/DUNE-DAQ/datahandlinglibs/issues/145 . `datahandlinglibs` function `generate_periodic_adc_pattern` is currently trying to distribute ADC pattern over 64 frames over CRT which has only 32 frames. Only thing preventing an runtime error is a blind try-catch statement. The correct behaviour should be that ADC pattern generation for CRTs should not be there in the first place. This PR changes it at integration test config substitution level to disable ADC pattern generation on CRT.


## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.

